### PR TITLE
Fix potential undefined index on request submission

### DIFF
--- a/includes/request.php
+++ b/includes/request.php
@@ -631,7 +631,10 @@ class accRequest {
 		$xffheader = getenv("HTTP_X_FORWARDED_FOR");
 		if($xffheader != "") $proxystring = "'" . $tsSQL->escape($xffheader) . "'";
 		
-		$useragent = $tsSQL->escape(htmlentities($_SERVER["HTTP_USER_AGENT"],ENT_COMPAT,'UTF-8'));
+		$useragent = 'NULL';
+		$uaheader = getenv("HTTP_USER_AGENT");
+		if ($uaheader != "")
+			$useragent = $tsSQL->escape(htmlentities($uaheader,ENT_COMPAT,'UTF-8'));
 		
 		// Gets the current date and time.
 		$dnow = date("Y-m-d H-i-s");


### PR DESCRIPTION
When submitting a request for an account without a `HTTP_USER_AGENT`, a
`NOTICE` is emitted:

```
Notice: Undefined index: HTTP_USER_AGENT in /var/www/includes/request.php on line 634
```

This patch changes the submit function to check for existence of the
`HTTP_USER_AGENT` header before adding it to the database.
