### PR TITLE
Ignore tests subdirectory from inspections

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -11,4 +11,6 @@ tools:
     sensiolabs_security_checker: true
 
 filter:
-    excluded_paths: ["lib/*"]
+    excluded_paths:
+        - lib/*
+        - tests/*


### PR DESCRIPTION
This is a fix for #237, however please note that no code inspections are run of the tests directory at all.  