### PR TITLE
Look up default action for close reason for created check

### DIFF
--- a/acc.php
+++ b/acc.php
@@ -1189,9 +1189,13 @@ elseif ($action == "done" && $_GET['id'] != "") {
 	else {
 		$exists = false;
 	}
-	
-	// check if a request being created does not already exist. 
-	if ($gem == 1 && !$exists && !isset($_GET['createoverride'])) {
+
+	/** @var EmailTemplate $emailTemplate */
+	$emailTemplate = EmailTemplate::getById($gem, gGetDb());
+	$isForCreated = $emailTemplate->getDefaultAction() === EmailTemplate::CREATED;
+
+	// check if a request being created does not already exist.
+	if ($isForCreated && !$exists && !isset($_GET['createoverride'])) {
 		$alertContent = "<p>You have chosen to mark this request as \"created\", but the account does not exist on the English Wikipedia, proceed?</p><br />";
 		$alertContent .= "<div class=\"row-fluid\">";
 		$alertContent .= "<a class=\"btn btn-success offset3 span3\"  href=\"$baseurl/acc.php?" . $_SERVER["QUERY_STRING"] . "&amp;createoverride=yes\">Yes</a>";


### PR DESCRIPTION
This should partially fix #250 for the legacy code. This will not fix the issue for custom closes, that's going to be a lot more challenging, but this should fix the initially reported problem.