### PR TITLE
Adjust account create URL for AuthManager? changes

### DIFF
--- a/templates/zoom-parts/request-actions.tpl
+++ b/templates/zoom-parts/request-actions.tpl
@@ -1,7 +1,7 @@
 <!-- tpl:zoom-parts/request-actions.tpl -->
 {if $showinfo == true && $isprotected == false && $request->getReserved() != 0}
 <div class="row-fluid">
-  <a class="btn btn-primary span12" target="_blank" href="https://en.wikipedia.org/w/index.php?title=Special:UserLogin/signup&amp;wpName={$usernamerawunicode|escape:'url'}&amp;wpEmail={$request->getEmail()|escape:'url'}&amp;wpReason=Requested%20account%20at%20%5B%5BWP%3AACC%5D%5D%2C%20request%20%23{$request->getId()}&amp;wpCreateaccountMail=true"{if !$currentUser->getAbortPref() && $createdEmailTemplate->getJsquestion() != ''} onclick="return confirm('{$createdEmailTemplate->getJsquestion()}')"{/if}>Create account</a>
+  <a class="btn btn-primary span12" target="_blank" href="https://en.wikipedia.org/w/index.php?title=Special:UserLogin/signup&amp;wpName={$usernamerawunicode|escape:'url'}&amp;email={$request->getEmail()|escape:'url'}&amp;reason=Requested%20account%20at%20%5B%5BWP%3AACC%5D%5D%2C%20request%20%23{$request->getId()}&amp;wpCreateaccountMail=true"{if !$currentUser->getAbortPref() && $createdEmailTemplate->getJsquestion() != ''} onclick="return confirm('{$createdEmailTemplate->getJsquestion()}')"{/if}>Create account</a>
 </div>
 <hr />
 {/if}


### PR DESCRIPTION
Adjust the generated URL to create accounts on Wikipedia to match the presumed
changes made by AuthManager.  This will allow the email and reason fields on the
account creation form to be prefilled by the tool again.

Problem with the ACC tool no longer pre-populating the email and reason fields on Wikipedia's create account form reported originally on IRC by JJMC89.  This fix tested to work as expected on my local vagrant instance of ACC with the actual Wikipedia.

This pull is based off master, not newinternal, and I plan to create rel6.8.11 on merge of this pull request, with a corresponding deploy to production.

Sorry in advance @stwalkerster for giving you another code review, and for another thing to foreport into newinternal.  :P