### PR TITLE
Add audit functionality

### DIFF
--- a/ClearOldData.php
+++ b/ClearOldData.php
@@ -19,7 +19,21 @@ $db->transactionally(function() use ($db)
 		":ip" => $cDataClearIp,
 		":mail" => $cDataClearEmail
 	));
-	
+
+	if (!$success) {
+		throw new TransactionException("Error in transaction: Could not clear data.");
+	}
+
+	$query = $db->prepare("DELETE FROM audit WHERE `timestamp` < DATE_SUB(curdate(), INTERVAL $dataclear_interval);");
+	$success = $query->execute();
+
+	if (!$success) {
+		throw new TransactionException("Error in transaction: Could not clear data.");
+	}
+
+	$query = $db->prepare("DELETE FROM ratelimit WHERE `timestamp` < DATE_SUB(curdate(), INTERVAL 1 DAY);");
+	$success = $query->execute();
+
 	if (!$success) {
 		throw new TransactionException("Error in transaction: Could not clear data.");
 	}

--- a/acc.php
+++ b/acc.php
@@ -287,6 +287,9 @@ elseif ($action == "forgotpw") {
 		$user = User::getByUsername($_POST['username'], gGetDb());
 
 		if ($user == false) {
+
+			auditForgottenPassword($_POST['username'], $_POST['email'], false);
+
 			BootstrapSkin::displayAlertBox(
 				"Could not find user with that username and email address!", 
 				"alert-error", 
@@ -298,16 +301,22 @@ elseif ($action == "forgotpw") {
 			die();
 		}
 		elseif (strtolower($_POST['email']) != strtolower($user->getEmail())) {
-			BootstrapSkin::displayAlertBox("Could not find user with that username and email address!", 
-				"alert-error", 
-				"Error", 
-				true, 
+			// Fake it.
+			auditForgottenPassword($_POST['username'], $_POST['email'], false);
+
+			BootstrapSkin::displayAlertBox(
+				"<strong>Your password reset request has been completed.</strong> Please check your e-mail.",
+				"alert-success",
+				"",
+				false,
 				false);
             
 			BootstrapSkin::displayInternalFooter();
 			die();
 		}
 		else {
+			auditForgottenPassword($_POST['username'], $_POST['email'], true);
+
 			$hash = $user->getForgottenPasswordHash();
                        
 			$smarty->assign("user", $user);
@@ -351,6 +360,7 @@ elseif ($action == "login") {
 	$user = User::getByUsername($_POST['username'], gGetDb());
     
 	if ($user == false || !$user->authenticate($_POST['password'])) {
+		auditLoginFailure($_POST['username']);
 		header("Location: $baseurl/acc.php?error=authfail&tplUsername=" . urlencode($_POST['username']));
 		die();
 	}

--- a/functions.php
+++ b/functions.php
@@ -414,3 +414,29 @@ $('.username-typeahead').typeahead({
 JS;
 	return $tailscript;
 }
+
+function auditLoginFailure($username) {
+    $database = gGetDb();
+    $s = $database->prepare('INSERT INTO audit (type, email, username, ip, xff) VALUES (:type, :email, :username, :ip, :xff);');
+    $s->execute(array(
+        ':type' => 'loginfailure',
+        ':email' => null,
+        ':username' => $username,
+        ':ip' => $_SERVER['REMOTE_ADDR'],
+        ':xff' => isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : null
+    ));
+}
+
+function auditForgottenPassword($username, $email, $successful) {
+	$database = gGetDb();
+	$type = $successful ? "forgotpwrequest" : "forgotpwrequest-failure";
+
+	$s = $database->prepare('INSERT INTO audit (type, email, username, ip, xff) VALUES (:type, :email, :username, :ip, :xff);');
+    $s->execute(array(
+        ':type' => $type,
+        ':email' => $email,
+        ':username' => $username,
+        ':ip' => $_SERVER['REMOTE_ADDR'],
+        ':xff' => isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : null
+    ));
+}

--- a/sql/grants.sql
+++ b/sql/grants.sql
@@ -1,0 +1,18 @@
+revoke all privileges on production.* from production;
+grant select,update,insert,delete on `antispoofcache` to production;
+grant select,insert on `applicationlog` to production;
+grant insert on `audit` to production;
+grant select,update,insert on `ban` to production;
+grant select,update,insert on `comment` to production;
+grant select,update,insert on `emailtemplate` to production;
+grant select,update,insert,delete on `geolocation` to production;
+grant select,update,insert on `interfacemessage` to production;
+grant select,insert on `log` to production;
+grant select,insert on `ratelimit` to production;
+grant select,update,insert,delete on `rdnscache` to production;
+grant select,update,insert,delete on `request` to production;
+grant select,update on `schemaversion` to production;
+grant select,update,insert on `user` to production;
+grant select,update,insert on `welcometemplate` to production;
+grant select,update,insert,delete on `xfftrustcache` to production;
+

--- a/sql/patches/patch17-auditratelimit.sql
+++ b/sql/patches/patch17-auditratelimit.sql
@@ -1,0 +1,82 @@
+-- -----------------------------------------------------------------------------
+-- Hey!
+-- 
+-- This is a new patch-creation script which SHOULD stop double-patching and
+-- running patches out-of-order.
+--
+-- If you're running patches, please close this file, and run this from the 
+-- command line:
+--   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
+-- where:
+--      USERNAME = a user with CREATE/ALTER access to the schema
+--      SCHEMA = the schema to run the changes against
+--      patch-XX-this-file.sql = this file
+--
+-- If you are writing patches, you need to copy this template to a numbered 
+-- patch file, update the patchversion variable, and add the SQL code to upgrade
+-- the database where indicated below.
+
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
+DELIMITER ';;'
+CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
+    -- -------------------------------------------------------------------------
+    -- Developers - set the number of the schema patch here!
+    -- -------------------------------------------------------------------------
+    DECLARE patchversion INT DEFAULT 17;
+    -- -------------------------------------------------------------------------
+    -- working variables
+	DECLARE currentschemaversion INT DEFAULT 0;
+    DECLARE lastversion INT;
+
+    -- check the schema has a version table
+    IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'schemaversion' AND table_schema = DATABASE()) THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please ensure patches are run in order! This database does not have a schemaversion table.';
+    END IF;
+
+    -- get the current version
+    SELECT version INTO currentschemaversion FROM schemaversion;
+
+    -- check schema is not ahead of this patch
+    IF currentschemaversion >= patchversion THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'This patch has already been applied!';
+    END IF;
+
+    -- check schema is up-to-date
+    SET lastversion = patchversion - 1;
+    IF currentschemaversion != lastversion THEN
+		SET @message_text = CONCAT('Please ensure patches are run in order! This patch upgrades to version ', patchversion, ', but the database is not version ', lastversion);
+        SIGNAL SQLSTATE '45000' SET message_text = @message_text;
+    END IF;
+
+    -- -------------------------------------------------------------------------
+    -- Developers - put your upgrade statements here!
+    -- -------------------------------------------------------------------------
+
+    CREATE TABLE audit
+    (
+        id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+        type VARCHAR(45) NOT NULL,
+        timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        email VARCHAR(255),
+        username VARCHAR(45),
+        ip VARCHAR(45),
+        xff VARCHAR(255)
+    ) ENGINE=MyISAM;
+
+    CREATE TABLE ratelimit
+    (
+        id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+        type VARCHAR(45) NOT NULL,
+        timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        username VARCHAR(45),
+        ip VARCHAR(45),
+        xff VARCHAR(255)
+    ) ENGINE=InnoDB;
+
+    -- -------------------------------------------------------------------------
+    -- finally, update the schema version to indicate success
+    UPDATE schemaversion SET version = patchversion;
+END;;
+DELIMITER ';'
+CALL SCHEMA_UPGRADE_SCRIPT();
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;


### PR DESCRIPTION
Adds auditing for failed logins, and both failed and successful password
resets. My testing shows that this seems to work as expected, though I can't test XFF functionality:
![image](https://cloud.githubusercontent.com/assets/722710/18065915/e3b991c0-6e2d-11e6-8160-4d7c89642810.png)

As per earlier emails, we could do with this change being approved from a privacy policy perspective. I don't expect it to have any issues since the data clear script is also changed to account for this, and this information is not visible.

We also *must* get this tested properly on the sandbox with the new grants, as they are a best-guess and not actually tested. We should test this by attempting any operation which I have revoked through the Web UI and seeing if that capability is exposed, as well as forcing the tool to use each privilege of each grant at least once.

I've added the table for ratelimiting, but I'm not looking at implementing that yet, I think it's more high-prio that we get audit functionality established. If this isn't reviewed/approved by the time I've got rate limiting done, then I'll add it, otherwise it can go in a separate PR.

+ Priority: High  - per emails,
+ Needs Discussion  - PrivPol check
+ live config  - grants need fixing on deployment

Targeting enwikipedia-acc/master for deployment *before* newinternal. I'll patch up newinternal to have the same added functionality in a little bit.