### PR TITLE
Add grants script

### DIFF
--- a/sql/grants.sql
+++ b/sql/grants.sql
@@ -16,7 +16,7 @@ CREATE PROCEDURE SCHEMA_GRANTS_REFRESH(
     -- against privmode
     -- --------------------------------------------------------------------------------------------------
     DECLARE cur_select CURSOR FOR
-        SELECT 'antispoofcache' AS tbl UNION
+        SELECT 'antispoofcache' UNION
         SELECT 'ban' UNION
         SELECT 'comment' UNION
         SELECT 'emailtemplate' UNION
@@ -31,7 +31,7 @@ CREATE PROCEDURE SCHEMA_GRANTS_REFRESH(
         SELECT 'xfftrustcache';
 
     DECLARE cur_update CURSOR FOR
-        SELECT 'ban' AS tbl UNION
+        SELECT 'ban' UNION
         SELECT 'comment' UNION
         SELECT 'emailtemplate' UNION
         SELECT 'geolocation' UNION
@@ -43,7 +43,7 @@ CREATE PROCEDURE SCHEMA_GRANTS_REFRESH(
         SELECT 'welcometemplate';
 
     DECLARE cur_insert CURSOR FOR
-        SELECT 'antispoofcache' AS tbl UNION
+        SELECT 'antispoofcache' UNION
         SELECT 'applicationlog' UNION
         SELECT 'ban' UNION
         SELECT 'comment' UNION
@@ -66,13 +66,13 @@ CREATE PROCEDURE SCHEMA_GRANTS_REFRESH(
     -- --------------------------------------------------------------------------------------------------
     -- These two cursors find all existing mysql grants on this schema and systematically revoke them.
     DECLARE cur_revschema CURSOR FOR
-        SELECT CONCAT('REVOKE ALL PRIVILEGES ON ', table_schema, '.* FROM ', grantee) vsql
+        SELECT CONCAT('REVOKE ALL PRIVILEGES ON ', table_schema, '.* FROM ', grantee)
         FROM information_schema.schema_privileges
         WHERE grantee = targetuser
         GROUP BY table_schema, grantee;
 
     DECLARE cur_revtable CURSOR FOR
-        SELECT CONCAT('REVOKE ALL PRIVILEGES ON ', table_schema, '.', table_name, ' FROM ', grantee) vsql
+        SELECT CONCAT('REVOKE ALL PRIVILEGES ON ', table_schema, '.', table_name, ' FROM ', grantee)
         FROM information_schema.table_privileges
         WHERE grantee = targetuser AND table_schema = schemaname
         GROUP BY grantee, table_schema, table_name;

--- a/sql/grants.sql
+++ b/sql/grants.sql
@@ -1,0 +1,181 @@
+DROP PROCEDURE IF EXISTS SCHEMA_GRANTS_REFRESH;
+DELIMITER ';;'
+CREATE PROCEDURE SCHEMA_GRANTS_REFRESH(
+      IN schemaname VARCHAR(64)
+    , IN targetuser VARCHAR(190)
+    , IN privmode   VARCHAR(20)
+) BEGIN
+    -- Declare some quick variables
+    DECLARE cursor_done INT;
+    DECLARE tableName VARCHAR(64);
+    DECLARE vsql VARCHAR(4000);
+
+    -- --------------------------------------------------------------------------------------------------
+    -- PERMISSIONS
+    -- Add tables to these queries to assign grants as needed. Limit the rows by adding where clauses
+    -- against privmode
+    -- --------------------------------------------------------------------------------------------------
+    DECLARE cur_select CURSOR FOR
+        SELECT 'antispoofcache' AS tbl UNION
+        SELECT 'ban' UNION
+        SELECT 'comment' UNION
+        SELECT 'emailtemplate' UNION
+        SELECT 'geolocation' UNION
+        SELECT 'interfacemessage' UNION
+        SELECT 'log' UNION
+        SELECT 'rdnscache' UNION
+        SELECT 'request' UNION
+        SELECT 'schemaversion' UNION
+        SELECT 'user' UNION
+        SELECT 'welcometemplate' UNION
+        SELECT 'xfftrustcache';
+
+    DECLARE cur_update CURSOR FOR
+        SELECT 'ban' AS tbl UNION
+        SELECT 'comment' UNION
+        SELECT 'emailtemplate' UNION
+        SELECT 'geolocation' UNION
+        SELECT 'interfacemessage' UNION
+        SELECT 'rdnscache' UNION
+        SELECT 'request' UNION
+        SELECT 'schemaversion' FROM DUAL WHERE privmode = 'maintenance' UNION
+        SELECT 'user' UNION
+        SELECT 'welcometemplate';
+
+    DECLARE cur_insert CURSOR FOR
+        SELECT 'antispoofcache' AS tbl UNION
+        SELECT 'applicationlog' UNION
+        SELECT 'ban' UNION
+        SELECT 'comment' UNION
+        SELECT 'emailtemplate' UNION
+        SELECT 'geolocation' UNION
+        SELECT 'interfacemessage' UNION
+        SELECT 'log' UNION
+        SELECT 'rdnscache' UNION
+        SELECT 'request' UNION
+        SELECT 'user' UNION
+        SELECT 'welcometemplate' UNION
+        SELECT 'xfftrustcache' FROM DUAL WHERE privmode = 'maintenance';
+
+    DECLARE cur_delete CURSOR FOR
+        SELECT 'antispoofcache' FROM DUAL WHERE privmode = 'maintenance' UNION
+        SELECT 'geolocation' FROM DUAL WHERE privmode = 'maintenance' UNION
+        SELECT 'rdnscache' FROM DUAL WHERE privmode = 'maintenance' UNION
+        SELECT 'xfftrustcache' FROM DUAL WHERE privmode = 'maintenance';
+
+    -- --------------------------------------------------------------------------------------------------
+    -- These two cursors find all existing mysql grants on this schema and systematically revoke them.
+    DECLARE cur_revschema CURSOR FOR
+        SELECT CONCAT('REVOKE ALL PRIVILEGES ON ', table_schema, '.* FROM ', grantee) vsql
+        FROM information_schema.schema_privileges
+        WHERE grantee = targetuser
+        GROUP BY table_schema, grantee;
+
+    DECLARE cur_revtable CURSOR FOR
+        SELECT CONCAT('REVOKE ALL PRIVILEGES ON ', table_schema, '.', table_name, ' FROM ', grantee) vsql
+        FROM information_schema.table_privileges
+        WHERE grantee = targetuser AND table_schema = schemaname
+        GROUP BY grantee, table_schema, table_name;
+
+    -- Continue handler for when a cursor fetch retrieves no data.
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET cursor_done = 1;
+
+    IF privmode NOT IN ('web', 'maintenance') THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'The privmode parameter should be either web or maintenance';
+    END IF;
+
+    IF targetuser NOT LIKE '\'%\'@\'%\'' THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please specify user in the standard MySQL format of \'user\'@\'host\'.';
+    END IF;
+
+    -- Revoke everything to begin with - looping over result sets from the revocation
+    -- cursors and running the dynamic sql; firstly schema-wide, then table-specific.
+    SET cursor_done = 0;
+    OPEN cur_revschema;
+    revschema: REPEAT
+        FETCH cur_revschema INTO vsql;
+        IF cursor_done THEN
+            LEAVE revschema;
+        END IF;
+        SET @sqlText = vsql;
+        PREPARE statement FROM @sqlText;
+        EXECUTE statement;
+        DEALLOCATE PREPARE statement;
+    UNTIL cursor_done END REPEAT revschema;
+    CLOSE cur_revschema;
+
+    SET cursor_done = 0;
+    OPEN cur_revtable;
+    revtable: REPEAT
+        FETCH cur_revtable INTO vsql;
+        IF cursor_done THEN
+            LEAVE revtable;
+        END IF;
+        SET @sqlText = vsql;
+        PREPARE statement FROM @sqlText;
+        EXECUTE statement;
+        DEALLOCATE PREPARE statement;
+    UNTIL cursor_done END REPEAT revtable;
+    CLOSE cur_revtable;
+
+    -- Set up the granular permissions as needed using the table lists in the cursors at the
+    -- top of the file
+    SET cursor_done = 0;
+    OPEN cur_select;
+    lselect: REPEAT
+        FETCH cur_select INTO tableName;
+        IF cursor_done THEN
+            LEAVE lselect;
+        END IF;
+        SET @sqlText = CONCAT('GRANT SELECT ON ', schemaname, '.', tableName, ' TO ', targetuser);
+        PREPARE statement FROM @sqlText;
+        EXECUTE statement;
+        DEALLOCATE PREPARE statement;
+    UNTIL cursor_done END REPEAT lselect;
+    CLOSE cur_select;
+
+    SET cursor_done = 0;
+    OPEN cur_update;
+    lupdate: REPEAT
+        FETCH cur_update INTO tableName;
+        IF cursor_done THEN
+            LEAVE lupdate;
+        END IF;
+        SET @sqlText = CONCAT('GRANT UPDATE ON ', schemaname, '.', tableName, ' TO ', targetuser);
+        PREPARE statement FROM @sqlText;
+        EXECUTE statement;
+        DEALLOCATE PREPARE statement;
+    UNTIL cursor_done END REPEAT lupdate;
+    CLOSE cur_update;
+
+    SET cursor_done = 0;
+    OPEN cur_insert;
+    linsert: REPEAT
+        FETCH cur_insert INTO tableName;
+        IF cursor_done THEN
+            LEAVE linsert;
+        END IF;
+        SET @sqlText = CONCAT('GRANT INSERT ON ', schemaname, '.', tableName, ' TO ', targetuser);
+        PREPARE statement FROM @sqlText;
+        EXECUTE statement;
+        DEALLOCATE PREPARE statement;
+    UNTIL cursor_done END REPEAT linsert;
+    CLOSE cur_insert;
+
+    SET cursor_done = 0;
+    OPEN cur_delete;
+    ldelete: REPEAT
+        FETCH cur_delete INTO tableName;
+        IF cursor_done THEN
+            LEAVE ldelete;
+        END IF;
+        SET @sqlText = CONCAT('GRANT DELETE ON ', schemaname, '.', tableName, ' TO ', targetuser);
+        PREPARE statement FROM @sqlText;
+        EXECUTE statement;
+        DEALLOCATE PREPARE statement;
+    UNTIL cursor_done END REPEAT ldelete;
+    CLOSE cur_delete;
+
+    -- All done!
+END;;
+DELIMITER ';'

--- a/sql/test_db.sh
+++ b/sql/test_db.sh
@@ -71,6 +71,9 @@ for f in `ls patches/patch*.sql`; do
 	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < $f
 done
 
+echo "Adding grants script..."
+mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < grants.sql
+
 if [ $1 -eq 0 ]; then
 	echo "Dumping schema to file..."
 	mysqldump --compact -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME > schema.sql


### PR DESCRIPTION
This script will automatically fix all of the relevant mysql grants on a way
we can be sure that the same grants are applied across different environments.

To run, grab yourself a privileged session on the database server, and run:

CALL SCHEMA_GRANTS_REFRESH("production", "'production'@'%'", "maintenance");

This should give a sane level of permissions which is currently needed by our
architecture. Future work elsewhere will allow us to pass in "web" to get a further
reduced set of permissions for the web UI, and a diferent set of permissions for
maintenance scripts.

As this is entirely in the database, it should be easy enough for us to include in the
standard deployment runbook. This is being added to the main repo so other
developers can use the same grants as in production, and so that it can be a developer
responsibility to think about what grants are actually needed, and not just deferring it
to the DBAs.
