### PR TITLE
Alter dataclear script to only purge closed reqs

### DIFF
--- a/ClearOldData.php
+++ b/ClearOldData.php
@@ -14,7 +14,7 @@ $db->transactionally(function() use ($db)
 {
 	global $cDataClearIp, $cDataClearEmail, $dataclear_interval;
     
-	$query = $db->prepare("UPDATE request SET ip = :ip, forwardedip = null, email = :mail, useragent = '' WHERE date < DATE_SUB(curdate(), INTERVAL $dataclear_interval);");
+	$query = $db->prepare("UPDATE request SET ip = :ip, forwardedip = null, email = :mail, useragent = '' WHERE date < DATE_SUB(curdate(), INTERVAL $dataclear_interval) AND status = 'Closed';");
 	$success = $query->execute(array( 
 		":ip" => $cDataClearIp,
 		":mail" => $cDataClearEmail


### PR DESCRIPTION
This has the effect of ensuring that requests have their data preserved for as
long as they are open.  With this patch, closed requests will have their data
cleared once they become older than 14 days; if a request has been open for
longer than 14 days, that request's private data will be purged "immediately"
upon close - more specifically, on the next run of the dataclear script after
the request is closed.

We may wish to modify this so that requests' private data is purged 14 days
after the request is closed, whenever that is, regardless of how old the
request was when it was closed.  This would be, of course, pending WMF approval,
and I'll also port this patch to newinternal once we've finalized the approach
to take.