### PR TITLE
Performance: cache the checkuser status of a user

### DIFF
--- a/includes/DataObjects/User.php
+++ b/includes/DataObjects/User.php
@@ -30,6 +30,8 @@ class User extends DataObject
 
 	private $identityCache = null;
 
+	private $isCheckuserCache = null;
+
 	/**
 	 * Summary of getCurrent
 	 * @param PdoDatabase $database
@@ -652,7 +654,11 @@ SQL
     
 	public function isCheckuser()
 	{
-		return $this->checkuser == 1 || $this->oauthCanCheckUser();
+	    if($this->isCheckuserCache === null) {
+	        $this->isCheckuserCache = $this->checkuser == 1 || $this->oauthCanCheckUser();
+        }
+
+		return $this->isCheckuserCache;
 	}
     
 	public function isIdentified()


### PR DESCRIPTION
Analysing some XHProf data has revealed that the `User::isCheckuser` function is exceedingly slow.

![image](https://cloud.githubusercontent.com/assets/722710/23828095/5246cb0c-06be-11e7-918d-7b25515e9a54.png)

The old implementation of `return $this->checkuser == 1 || $this->oauthCanCheckUser()` means that the OAuth identity ticket will be checked on every call of this method, which involves an unserialize, date cache check, array search, and a possible remote fetch. 

![image](https://cloud.githubusercontent.com/assets/722710/23828115/326a5726-06bf-11e7-8297-1527b92b462f.png)

Needless to say, this is something which we don't care if it changes within a request, so caching this is appropriate.

This, unfortunately, isn't really possible for me to test locally.