### PR TITLE
Fix encoding issue in redirection tool

### DIFF
--- a/redir.php
+++ b/redir.php
@@ -7,7 +7,7 @@ $toolList = array(
 	'oq-whois' => 'https://whois.domaintools.com/%DATA%',
 	'tl-whois' => 'https://tools.wmflabs.org/whois/gateway.py?lookup=true&ip=%DATA%',
 	'sulutil' => '//tools.wmflabs.org/quentinv57-tools/tools/sulinfo.php?showinactivity=1&showblocks=1&username=%DATA%',
-	'google' => 'https://www.google.com/search?q=%DATA%',
+	'google' => 'https://www.google.com/search?q="%DATA%"',
 );
 
 if(!isset($_GET['tool'])
@@ -20,7 +20,7 @@ if(!isset($_GET['tool'])
 }
 
 if (isset($_GET['round2'])) {
-	echo '<script>window.location.href="' . str_replace("%DATA%", htmlentities($_GET['data'], ENT_COMPAT, 'UTF-8'), $toolList[$_GET['tool']]) . '"</script>';
+	echo '<script>window.location.href=' . json_encode(str_replace("%DATA%", urlencode($_GET['data']), $toolList[$_GET['tool']])) . '</script>';
 }
 else {
 	header("Location: " . $_SERVER["REQUEST_URI"] . "&round2=true");


### PR DESCRIPTION
An issue reported by DatGuy on IRC, where a username request for Foo&Bar
was getting passed to Google as /search?q=Foo&Bar instead of
/search?q=Foo%26Bar - this is caused by us using htmlentities instead of
urlencoding. We're now additionally using json_encode to create the
javascript string instead of manually wrapping the search term in quotes
to prevent escaping the string.