### PR TITLE
Add Link to Project Honeypot

### DIFF
--- a/redir.php
+++ b/redir.php
@@ -6,6 +6,7 @@ $toolList = array(
 	'guc' => '//tools.wmflabs.org/guc/?user=%DATA%',
 	'oq-whois' => 'https://whois.domaintools.com/%DATA%',
 	'tl-whois' => 'https://tools.wmflabs.org/whois/gateway.py?lookup=true&ip=%DATA%',
+	'honeypot' => 'https://www.projecthoneypot.org/ip_%DATA%',
 	'sulutil' => '//tools.wmflabs.org/quentinv57-tools/tools/sulinfo.php?showinactivity=1&showblocks=1&username=%DATA%',
 	'google' => 'https://www.google.com/search?q=%DATA%',
 );

--- a/templates/zoom-parts/ip-links.tpl
+++ b/templates/zoom-parts/ip-links.tpl
@@ -15,7 +15,7 @@
     <a id="IPWhois-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=oq-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois-{$index}').addClass('btn-visited');">Whois</a>
     <a id="IPWhois2-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=tl-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois2-{$index}').addClass('btn-visited');">(alt)</a>
   </div>
-  <a id="Honeypot-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=honeypot&amp;data={$ipaddress}" onMouseUp="$('#Honeypot-{$index}').addClass('btn-visited');">Project Honeypot</a>
+  <a id="IPHoneypot-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=honeypot&amp;data={$ipaddress}" onMouseUp="$('#IPHoneypot-{$index}').addClass('btn-visited');">Project Honeypot</a>
   <a id="IPAbuseLog-{$index}" class="btn btn-small" target="_blank" href="https://en.wikipedia.org/w/index.php?title=Special:AbuseLog&amp;wpSearchUser={$ipaddress}" onMouseUp="$('#IPAbuseLog-{$index}').addClass('btn-visited');">Abuse Filter Log</a>
   {if $currentUser->isCheckUser() == true}
     <a id="IPCU-{$index}" class="btn btn-small" target="_blank" href="https://en.wikipedia.org/w/index.php?title=Special:CheckUser&amp;ip={$ipaddress}&amp;reason=%5B%5BWP:ACC%5D%5D%20request%20%23{$request->getId()}" onMouseUp="$('#IPCU-{$index}').addClass('btn-visited');">CheckUser</a>

--- a/templates/zoom-parts/ip-links.tpl
+++ b/templates/zoom-parts/ip-links.tpl
@@ -14,6 +14,7 @@
   <div class="btn-group">
     <a id="IPWhois-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=oq-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois-{$index}').addClass('btn-visited');">Whois</a>
     <a id="IPWhois2-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=tl-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois2-{$index}').addClass('btn-visited');">(alt)</a>
+    <a id="IPWhois3-{$index}" class="btn btn-small" target="_blank" href="https://www.projecthoneypot.org/ip_{$ipaddress}" onMouseUp="$('#IPWhois3-{$index}').addClass('btn-visited');">IP-Project Honeypot</a>
   </div>
   <a id="IPAbuseLog-{$index}" class="btn btn-small" target="_blank" href="https://en.wikipedia.org/w/index.php?title=Special:AbuseLog&amp;wpSearchUser={$ipaddress}" onMouseUp="$('#IPAbuseLog-{$index}').addClass('btn-visited');">Abuse Filter Log</a>
   {if $currentUser->isCheckUser() == true}

--- a/templates/zoom-parts/ip-links.tpl
+++ b/templates/zoom-parts/ip-links.tpl
@@ -15,9 +15,7 @@
     <a id="IPWhois-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=oq-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois-{$index}').addClass('btn-visited');">Whois</a>
     <a id="IPWhois2-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=tl-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois2-{$index}').addClass('btn-visited');">(alt)</a>
   </div>
-  <div class="btn-group">
-  <a id="IPWhois3-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=honeypot&amp;data={$ipaddress}" onMouseUp="$('#IPWhois3-{$index}').addClass('btn-visited');">Project Honeypot</a>
-  </div>
+  <a id="Honeypot-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=honeypot&amp;data={$ipaddress}" onMouseUp="$('#Honeypot-{$index}').addClass('btn-visited');">Project Honeypot</a>
   <a id="IPAbuseLog-{$index}" class="btn btn-small" target="_blank" href="https://en.wikipedia.org/w/index.php?title=Special:AbuseLog&amp;wpSearchUser={$ipaddress}" onMouseUp="$('#IPAbuseLog-{$index}').addClass('btn-visited');">Abuse Filter Log</a>
   {if $currentUser->isCheckUser() == true}
     <a id="IPCU-{$index}" class="btn btn-small" target="_blank" href="https://en.wikipedia.org/w/index.php?title=Special:CheckUser&amp;ip={$ipaddress}&amp;reason=%5B%5BWP:ACC%5D%5D%20request%20%23{$request->getId()}" onMouseUp="$('#IPCU-{$index}').addClass('btn-visited');">CheckUser</a>

--- a/templates/zoom-parts/ip-links.tpl
+++ b/templates/zoom-parts/ip-links.tpl
@@ -14,7 +14,9 @@
   <div class="btn-group">
     <a id="IPWhois-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=oq-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois-{$index}').addClass('btn-visited');">Whois</a>
     <a id="IPWhois2-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=tl-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois2-{$index}').addClass('btn-visited');">(alt)</a>
-    <a id="IPWhois3-{$index}" class="btn btn-small" target="_blank" href="https://www.projecthoneypot.org/ip_{$ipaddress}" onMouseUp="$('#IPWhois3-{$index}').addClass('btn-visited');">IP-Project Honeypot</a>
+  </div>
+  <div class="btn-group">
+  <a id="IPWhois3-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=honeypot&amp;data={$ipaddress}" onMouseUp="$('#IPWhois3-{$index}').addClass('btn-visited');">Project Honeypot</a>
   </div>
   <a id="IPAbuseLog-{$index}" class="btn btn-small" target="_blank" href="https://en.wikipedia.org/w/index.php?title=Special:AbuseLog&amp;wpSearchUser={$ipaddress}" onMouseUp="$('#IPAbuseLog-{$index}').addClass('btn-visited');">Abuse Filter Log</a>
   {if $currentUser->isCheckUser() == true}


### PR DESCRIPTION
<img width="1220" alt="screen shot 2017-06-04 at 10 28 07 pm" src="https://cloud.githubusercontent.com/assets/26441280/26769542/65e39b3c-4975-11e7-97f2-6fec8d8fde92.png">
Adds a link to project honeypot to the IP links section; useful for determining patterns of abusive IPs and when requests may need more scrutiny.