### PR TITLE
Remove surrounding quotes in Google Search

### DIFF
--- a/redir.php
+++ b/redir.php
@@ -8,7 +8,7 @@ $toolList = array(
 	'tl-whois' => 'https://tools.wmflabs.org/whois/gateway.py?lookup=true&ip=%DATA%',
 	'honeypot' => 'https://www.projecthoneypot.org/ip_%DATA%',
 	'sulutil' => '//tools.wmflabs.org/quentinv57-tools/tools/sulinfo.php?showinactivity=1&showblocks=1&username=%DATA%',
-	'google' => 'https://www.google.com/search?q="%DATA%"',
+	'google' => 'https://www.google.com/search?q=%DATA%',
 );
 
 if(!isset($_GET['tool'])


### PR DESCRIPTION
Due to technical difficulties, we can miss some important notabilities based on little things like spaces when searching for an exact string.  Reversing this to ensure we don't miss potential results that are relevant.