### PR TITLE
Wrap session start in new function

### DIFF
--- a/acc.php
+++ b/acc.php
@@ -18,13 +18,11 @@ ob_start();
 // load the configuration
 require_once 'config.inc.php';
 
-// Initialize the session data.
-session_start();
-
 // Get all the classes.
 require_once 'functions.php';
+initialiseSession();
 require_once 'includes/PdoDatabase.php';
-require_once 'includes/SmartyInit.php'; // this needs to be high up, but below config, functions, and database
+require_once 'includes/SmartyInit.php'; // this needs to be high up, but below config, functions, database and session init
 require_once 'includes/session.php';
 
 // Check to see if the database is unavailable.

--- a/functions.php
+++ b/functions.php
@@ -26,6 +26,11 @@ require_once 'includes/session.php';
 // Initialize the class objects.
 $session = new session();
 
+/** Initialises the PHP Session */
+function initialiseSession() {
+    session_start();
+}
+
 /**
  * Send a "close pend ticket" email to the end user. (created, taken, etc...)
  */

--- a/oauth/callback.php
+++ b/oauth/callback.php
@@ -10,11 +10,9 @@ ob_start();
 // load the configuration
 require_once 'config.inc.php';
 
-// Initialize the session data.
-session_start();
-
 // Get all the classes.
 require_once 'functions.php';
+initialiseSession();
 require_once 'includes/PdoDatabase.php';
 require_once 'includes/SmartyInit.php'; // this needs to be high up, but below config, functions, and database
 

--- a/search.php
+++ b/search.php
@@ -17,11 +17,9 @@ global $session;
 // load the configuration
 require_once 'config.inc.php';
 
-// Initialize the session data.
-session_start();
-
 // Get all the classes.
 require_once 'functions.php';
+initialiseSession();
 require_once 'includes/PdoDatabase.php';
 require_once 'includes/SmartyInit.php';
 

--- a/statistics.php
+++ b/statistics.php
@@ -15,11 +15,9 @@
 // load the configuration
 require_once 'config.inc.php';
 
-// Initialize the session data.
-session_start();
-
 // Get all the classes.
 require_once 'functions.php';
+initialiseSession();
 require_once 'includes/PdoDatabase.php';
 require_once 'includes/SmartyInit.php';
 require_once 'includes/StatisticsPage.php';

--- a/team.php
+++ b/team.php
@@ -15,11 +15,9 @@
 // load the configuration
 require_once 'config.inc.php';
 
-// Initialize the session data.
-session_start();
-
 // Get all the classes.
 require_once 'functions.php';
+initialiseSession();
 require_once 'includes/PdoDatabase.php';
 require_once 'includes/SmartyInit.php';
 

--- a/users.php
+++ b/users.php
@@ -15,11 +15,9 @@
 // load the configuration
 require_once 'config.inc.php';
 
-// Initialize the session data.
-session_start();
-
 // Get all the classes.
 require_once 'functions.php';
+initialiseSession();
 require_once 'includes/PdoDatabase.php';
 require_once 'includes/SmartyInit.php';
 require_once 'includes/session.php';


### PR DESCRIPTION
Makes profiler output more clear as to which opcode-cached things are caused by the session.

![image](https://user-images.githubusercontent.com/722710/27333824-1e0d500e-55bf-11e7-9d3f-5ede550d4813.png)

Related to #421 