### PR TITLE
Swap WHOIS tools, add button to check IP with Stop Forum Spam

### DIFF
--- a/redir.php
+++ b/redir.php
@@ -7,6 +7,7 @@ $toolList = array(
 	'oq-whois' => 'https://whois.domaintools.com/%DATA%',
 	'tl-whois' => 'https://tools.wmflabs.org/whois/gateway.py?lookup=true&ip=%DATA%',
 	'honeypot' => 'https://www.projecthoneypot.org/ip_%DATA%',
+	'stopforumspam' => 'https://www.stopforumspam.com/ipcheck/%DATA%',
 	'sulutil' => '//tools.wmflabs.org/quentinv57-tools/tools/sulinfo.php?showinactivity=1&showblocks=1&username=%DATA%',
 	'google' => 'https://www.google.com/search?q=%DATA%',
 );

--- a/templates/zoom-parts/ip-links.tpl
+++ b/templates/zoom-parts/ip-links.tpl
@@ -12,10 +12,11 @@
   <a id="IPGlobalBlockLog-{$index}" class="btn btn-small" target="_blank" href="https://meta.wikimedia.org/w/index.php?title=Special:Log&amp;type=gblblock&amp;page={$ipaddress}" onMouseUp="$('#IPGlobalBlockLog-{$index}').addClass('btn-visited');">Global Block Log</a>
   <a id="IPActiveGlobalBlock-{$index}" class="btn btn-small" target="_blank" href="https://en.wikipedia.org/wiki/Special:GlobalBlockList/{$ipaddress}" onMouseUp="$('#IPActiveGlobalBlock-{$index}').addClass('btn-visited');">Active Global Blocks</a>
   <div class="btn-group">
-    <a id="IPWhois-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=oq-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois-{$index}').addClass('btn-visited');">Whois</a>
-    <a id="IPWhois2-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=tl-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois2-{$index}').addClass('btn-visited');">(alt)</a>
+    <a id="IPWhois-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=tl-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois-{$index}').addClass('btn-visited');">Whois</a>
+    <a id="IPWhois2-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=oq-whois&amp;data={$ipaddress}" onMouseUp="$('#IPWhois2-{$index}').addClass('btn-visited');">(alt)</a>
   </div>
   <a id="IPHoneypot-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=honeypot&amp;data={$ipaddress}" onMouseUp="$('#IPHoneypot-{$index}').addClass('btn-visited');">Project Honeypot</a>
+  <a id="IPStopForumSpam-{$index}" class="btn btn-small" target="_blank" href="{$baseurl}/redir.php?tool=stopforumspam&amp;data={$ipaddress}" onMouseUp="$('#IPStopForumSpam-{$index}').addClass('btn-visited');">StopForumSpam</a>
   <a id="IPAbuseLog-{$index}" class="btn btn-small" target="_blank" href="https://en.wikipedia.org/w/index.php?title=Special:AbuseLog&amp;wpSearchUser={$ipaddress}" onMouseUp="$('#IPAbuseLog-{$index}').addClass('btn-visited');">Abuse Filter Log</a>
   {if $currentUser->isCheckUser() == true}
     <a id="IPCU-{$index}" class="btn btn-small" target="_blank" href="https://en.wikipedia.org/w/index.php?title=Special:CheckUser&amp;ip={$ipaddress}&amp;reason=%5B%5BWP:ACC%5D%5D%20request%20%23{$request->getId()}" onMouseUp="$('#IPCU-{$index}').addClass('btn-visited');">CheckUser</a>


### PR DESCRIPTION
This commit swaps the WHOIS tools presented in the IP address information section, such that the primary WHOIS tool is now the WMF ToolForge WHOIS tool, and DomainTools is now the alternate tool because CAPTCHAs are annoying.  Resolves #456.

In addition, this commit adds another IP check tool in addition to the exiting Project Honeypot button, the Storm Forum Spam website.  Resolves #457.

Tested to work as expected on the ACC sandbox.