### PR TITLE
Inactivity changes to hide recently-approved users

### DIFF
--- a/includes/DataObjects/User.php
+++ b/includes/DataObjects/User.php
@@ -223,7 +223,7 @@ class User extends DataObject
 	public static function getAllInactive(PdoDatabase $database)
 	{
 		$date = new DateTime();
-		$date->modify("-45 days");
+		$date->modify("-90 days");
 
 		$statement = $database->prepare(<<<SQL
 			SELECT * 

--- a/includes/statistics/StatsInactiveUsers.php
+++ b/includes/statistics/StatsInactiveUsers.php
@@ -19,17 +19,17 @@ class StatsInactiveUsers extends StatisticsPage
 		global $smarty;
 
 		// this is horrible.
-        // yes, there is business logic in the templates
-        // yes, there was some there before
-        // yes, I have just added to it.
-        //
-        // I'm sorry.
-        //
-        // newinternal will fix this.
-        $date = new DateTime();
-        $date->modify("-90 days");
+		// yes, there is business logic in the templates
+		// yes, there was some there before
+		// yes, I have just added to it.
+		//
+		// I'm sorry.
+		//
+		// newinternal will fix this.
+		$date = new DateTime();
+		$date->modify("-90 days");
 
-        $smarty->assign('datelimit', $date);
+		$smarty->assign('datelimit', $date);
 
 		$showImmune = false;
 		if (isset($_GET['showimmune'])) {

--- a/includes/statistics/StatsInactiveUsers.php
+++ b/includes/statistics/StatsInactiveUsers.php
@@ -18,6 +18,19 @@ class StatsInactiveUsers extends StatisticsPage
 	{
 		global $smarty;
 
+		// this is horrible.
+        // yes, there is business logic in the templates
+        // yes, there was some there before
+        // yes, I have just added to it.
+        //
+        // I'm sorry.
+        //
+        // newinternal will fix this.
+        $date = new DateTime();
+        $date->modify("-90 days");
+
+        $smarty->assign('datelimit', $date);
+
 		$showImmune = false;
 		if (isset($_GET['showimmune'])) {
 			$showImmune = true;

--- a/templates/statistics/inactiveusers.tpl
+++ b/templates/statistics/inactiveusers.tpl
@@ -1,4 +1,4 @@
-﻿<p>This list contains the usernames of all accounts that have not logged in in the past 45 days.</p>
+﻿<p>This list contains the usernames of all accounts that have not logged in in the past 90 days.</p>
 
 {if ! $showImmune}<p>Tool root and checkuser-flagged accounts are hidden from this list.</p>{/if}
 
@@ -10,8 +10,8 @@
       <th>User access level</th>
       <th>Checkuser?</th>
       <th>enwiki username</th>
-      <th>Last activity</th>
-      <th>Approval</th>
+      <th><abbr title="Last login or logged-in page load">Last seen</abbr></th>
+      <th><abbr title="Date user was approved for tool access">Approval</abbr></th>
       {if $currentUser->isAdmin()}<th>Suspend</th>{/if}
     </tr>
   </thead>
@@ -29,8 +29,8 @@
           <td>{if $user->getApprovalDate() != false}{$user->getApprovalDate()->format("Y-m-d H:i:s")}{/if}</td>
           {if $currentUser->isAdmin()}
             <td>
-              {if ! $user->isCheckuser()}
-              <a class="btn btn-danger btn-small" href="{$baseurl}/users.php?suspend={$user->getId()}&amp;preload=Inactive%20for%2045%20or%20more%20days.%20Please%20contact%20a%20tool%20admin%20if%20you%20wish%20to%20come%20back.">
+              {if (! $user->isCheckuser()) && ($user->getApprovalDate() < $datelimit)}
+              <a class="btn btn-danger btn-small" href="{$baseurl}/users.php?suspend={$user->getId()}&amp;preload=Inactive%20for%2090%20or%20more%20days.%20Please%20contact%20a%20tool%20admin%20if%20you%20wish%20to%20come%20back.">
                 <i class="icon-ban-circle icon-white"></i> Suspend!
               </a>
               {/if}


### PR DESCRIPTION
Also bump time to 90d.

I'm openly admitting that this is a horrible patch.

The way I'd like to do this would be to do all the checking in the database, and pull out approval date, last active, username, etc in one query that did everything necessary. However, the code at present relies on PHP logic to get the current on-wiki username, which can't be done in the database, and requires user objects be pulled back from the database, thus we can't add extra fields to it. As such, we're stuck with either rewriting the oauth code (which is what I did in newinternal), or doing horrible hacks like pulling the approval date for every returned user separately, in individual queries. This is how the existing code works.

My change admits that this is bad, and does nothing to fix it.

Instead, I add to the logic in the display template to simply hide the suspend button from recently approved users, in the same way that it's currently hidden for inactive checkusers.

Using my data-sanitised production clone, and using James as a test user:

![image](https://user-images.githubusercontent.com/722710/29272532-5e5ef09a-80f8-11e7-83b4-c3afcf37a801.png)