### PR TITLE
Fix CC-to-mailing-list option for checkusers

### DIFF
--- a/acc.php
+++ b/acc.php
@@ -1246,9 +1246,17 @@ elseif ($action == "done" && $_GET['id'] != "") {
 		}
 
 		$headers = 'From: accounts-enwiki-l@lists.wikimedia.org' . "\r\n";
-		if (!User::getCurrent()->isAdmin() || isset($_POST['ccmailist']) && $_POST['ccmailist'] == "on") {
-			$headers .= 'Cc: accounts-enwiki-l@lists.wikimedia.org' . "\r\n";
-		}
+
+		// CC mailing list option
+        if (User::getCurrent()->isAdmin() || User::getCurrent()->isCheckuser()) {
+            // these people get the choice
+            if (isset($_POST['ccmailist']) && $_POST['ccmailist'] == "on") {
+                $headers .= 'Cc: accounts-enwiki-l@lists.wikimedia.org' . "\r\n";
+            }
+        } else {
+            // these people do not.
+            $headers .= 'Cc: accounts-enwiki-l@lists.wikimedia.org' . "\r\n";
+        }
 
 		$headers .= 'X-ACC-Request: ' . $request->getId() . "\r\n";
 		$headers .= 'X-ACC-UserID: ' . User::getCurrent()->getId() . "\r\n";

--- a/acc.php
+++ b/acc.php
@@ -1248,15 +1248,15 @@ elseif ($action == "done" && $_GET['id'] != "") {
 		$headers = 'From: accounts-enwiki-l@lists.wikimedia.org' . "\r\n";
 
 		// CC mailing list option
-        if (User::getCurrent()->isAdmin() || User::getCurrent()->isCheckuser()) {
-            // these people get the choice
-            if (isset($_POST['ccmailist']) && $_POST['ccmailist'] == "on") {
-                $headers .= 'Cc: accounts-enwiki-l@lists.wikimedia.org' . "\r\n";
-            }
-        } else {
-            // these people do not.
-            $headers .= 'Cc: accounts-enwiki-l@lists.wikimedia.org' . "\r\n";
-        }
+		if (User::getCurrent()->isAdmin() || User::getCurrent()->isCheckuser()) {
+			// these people get the choice
+			if (isset($_POST['ccmailist']) && $_POST['ccmailist'] == "on") {
+				$headers .= 'Cc: accounts-enwiki-l@lists.wikimedia.org' . "\r\n";
+			}
+		} else {
+			// these people do not.
+			$headers .= 'Cc: accounts-enwiki-l@lists.wikimedia.org' . "\r\n";
+		}
 
 		$headers .= 'X-ACC-Request: ' . $request->getId() . "\r\n";
 		$headers .= 'X-ACC-UserID: ' . User::getCurrent()->getId() . "\r\n";

--- a/config.inc.php
+++ b/config.inc.php
@@ -308,7 +308,7 @@ foreach (array(
 	"pdo", "pdo_mysql", // new database module
 	"session", "date", "pcre", // core stuff
 	"curl", // mediawiki api access etc
-	"mcrypt", "openssl", // password encryption etc
+	"openssl", // email confirmation hash gen, oauth stuff
 	) as $x) {if (!extension_loaded($x)) {die("extension $x is required."); }}
 
 require_once($filepath . "includes/AutoLoader.php");

--- a/users.php
+++ b/users.php
@@ -411,7 +411,7 @@ if (isset ($_GET['rename'])) {
 
 #region edit user
 
-if (isset ($_GET['edituser']) && $enableRenames == 1) {
+if (isset ($_GET['edituser'])) {
 	$user = User::getById($_GET['edituser'], gGetDb());
 
 	if ($user == false) {


### PR DESCRIPTION
Currently, if a checkuser clears the "CC to mailing list" option (which the UI allows them to do), the message to the mailing list is still sent as the underlying check only checks the user is a tool admin.

This fixes that, and cleans up a couple of other things spotted too.