### PR TITLE
Remove LIMIT clauses from write queries

### DIFF
--- a/acc.php
+++ b/acc.php
@@ -1844,7 +1844,7 @@ elseif ($action == "sendtouser") {
     
 	$database->transactionally(function() use ($database, $user, $requestObject, $curuser)
 	{
-		$updateStatement = $database->prepare("UPDATE request SET reserved = :userid WHERE id = :request LIMIT 1;");
+		$updateStatement = $database->prepare("UPDATE request SET reserved = :userid WHERE id = :request;");
 		$updateStatement->bindValue(":userid", $user->getId());
 		$updateStatement->bindValue(":request", $requestObject->getId());
 		if (!$updateStatement->execute()) {

--- a/includes/DataObject.php
+++ b/includes/DataObject.php
@@ -87,7 +87,7 @@ abstract class DataObject
 		$statement = $this->dbObject->prepare(
 			"DELETE FROM `"
 			. strtolower(get_called_class())
-			. "` WHERE id = :id LIMIT 1;");
+			. "` WHERE id = :id;");
 
 		$statement->bindValue(":id", $this->id);
 		$statement->execute();

--- a/includes/DataObjects/Ban.php
+++ b/includes/DataObjects/Ban.php
@@ -167,7 +167,7 @@ SQL
 		}
 		else {
 // update
-			$statement = $this->dbObject->prepare("UPDATE `ban` SET duration = :duration, active = :active, user = :user WHERE id = :id LIMIT 1;");
+			$statement = $this->dbObject->prepare("UPDATE `ban` SET duration = :duration, active = :active, user = :user WHERE id = :id;");
 			$statement->bindValue(":id", $this->id);
 			$statement->bindValue(":duration", $this->duration);
 			$statement->bindValue(":active", $this->active);

--- a/includes/DataObjects/Comment.php
+++ b/includes/DataObjects/Comment.php
@@ -80,7 +80,7 @@ SQL
 			$statement = $this->dbObject->prepare(<<<SQL
 UPDATE comment
 SET comment = :comment, visibility = :visibility
-WHERE id = :id LIMIT 1;
+WHERE id = :id;
 SQL
 			);
 			$statement->bindValue(":id", $this->id);

--- a/includes/DataObjects/EmailTemplate.php
+++ b/includes/DataObjects/EmailTemplate.php
@@ -138,7 +138,7 @@ SET name = :name,
 	defaultaction = :defaultaction,
 	active = :active,
 	preloadonly = :preloadonly
-WHERE id = :id LIMIT 1;
+WHERE id = :id;
 SQL
 			);
 			$statement->bindValue(":id", $this->id);

--- a/includes/DataObjects/GeoLocation.php
+++ b/includes/DataObjects/GeoLocation.php
@@ -54,7 +54,7 @@ class GeoLocation extends DataObject
 		}
 		else {
 // update
-			$statement = $this->dbObject->prepare("UPDATE `geolocation` SET address = :address, data = :data WHERE id = :id LIMIT 1;");
+			$statement = $this->dbObject->prepare("UPDATE `geolocation` SET address = :address, data = :data WHERE id = :id;");
 			$statement->bindValue(":address", $this->address);
 			$statement->bindValue(":id", $this->id);
 			$statement->bindValue(":data", $this->data);

--- a/includes/DataObjects/InterfaceMessage.php
+++ b/includes/DataObjects/InterfaceMessage.php
@@ -55,7 +55,7 @@ class InterfaceMessage extends DataObject
 		}
 		else {
 // update
-			$statement = $this->dbObject->prepare("UPDATE interfacemessage SET type = :type, description = :desc, content = :content, updatecounter = updatecounter + 1 WHERE id = :id LIMIT 1;");
+			$statement = $this->dbObject->prepare("UPDATE interfacemessage SET type = :type, description = :desc, content = :content, updatecounter = updatecounter + 1 WHERE id = :id;");
 			$statement->bindValue(":id", $this->id);
 			$statement->bindValue(":type", $this->type);
 			$statement->bindValue(":desc", $this->description);

--- a/includes/DataObjects/RDnsCache.php
+++ b/includes/DataObjects/RDnsCache.php
@@ -48,7 +48,7 @@ class RDnsCache extends DataObject
 		}
 		else {
 // update
-			$statement = $this->dbObject->prepare("UPDATE `rdnscache` SET address = :address, data = :data WHERE id = :id LIMIT 1;");
+			$statement = $this->dbObject->prepare("UPDATE `rdnscache` SET address = :address, data = :data WHERE id = :id;");
 			$statement->bindValue(":address", $this->address);
 			$statement->bindValue(":id", $this->id);
 			$statement->bindValue(":data", $this->data);

--- a/includes/DataObjects/Request.php
+++ b/includes/DataObjects/Request.php
@@ -93,7 +93,7 @@ SQL
 			$statement = $this->dbObject->prepare("UPDATE `request` SET " .
 				"status = :status, checksum = :checksum, emailsent = :emailsent, emailconfirm = :emailconfirm, " .
 				"reserved = :reserved " .
-				"WHERE id = :id LIMIT 1;");
+				"WHERE id = :id;");
 			$statement->bindValue(":id", $this->id);
 			$statement->bindValue(":status", $this->status);
 			$statement->bindValue(":checksum", $this->checksum);

--- a/includes/DataObjects/User.php
+++ b/includes/DataObjects/User.php
@@ -332,8 +332,7 @@ SQL
 					confirmationdiff = :confirmationdiff, emailsig = :emailsig, 
 					oauthrequesttoken = :ort, oauthrequestsecret = :ors, 
 					oauthaccesstoken = :oat, oauthaccesssecret = :oas 
-				WHERE id = :id 
-				LIMIT 1;
+				WHERE id = :id;
 SQL
 			);
 			$statement->bindValue(":id", $this->id);

--- a/includes/DataObjects/WelcomeTemplate.php
+++ b/includes/DataObjects/WelcomeTemplate.php
@@ -54,7 +54,7 @@ class WelcomeTemplate extends DataObject
 		}
 		else {
 // update
-			$statement = $this->dbObject->prepare("UPDATE `welcometemplate` SET usercode = :usercode, botcode = :botcode WHERE id = :id LIMIT 1;");
+			$statement = $this->dbObject->prepare("UPDATE `welcometemplate` SET usercode = :usercode, botcode = :botcode WHERE id = :id;");
 			$statement->bindValue(":id", $this->id);
 			$statement->bindValue(":usercode", $this->usercode);
 			$statement->bindValue(":botcode", $this->botcode);


### PR DESCRIPTION
Using LIMIT is unsafe in a replication environment due to the nature of
how MySQL retrieves rows to process the update might mean it retrieves a
different set of rows on the master and the slave, causing them to drift
out of sync.

This change removes this clause from all update and delete statements,
and by a happy coincidence all of these are already using the table's
primary key in the WHERE clause, so this is functionally a no-op, and
operationally hides a whole bunch of warnings in the log.