### PR TITLE
First Bumper Bugfix Bonanza 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "ext-openssl": "*",
         "ext-dom": "*",
         "ext-pdo": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-curl": "*"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.7",

--- a/includes/DataObjects/User.php
+++ b/includes/DataObjects/User.php
@@ -589,17 +589,6 @@ SQL
     #endregion 
 
     /**
-     * Gets a hash of data for the user to reset their password with.
-     * @category Security-Critical
-     * @return string
-     */
-    public function getForgottenPasswordHash()
-    {
-        // FIXME
-        return md5($this->username . $this->email . $this->welcome_template . $this->id);
-    }
-
-    /**
      * Gets the approval date of the user
      * @return DateTime|false
      */

--- a/includes/ExceptionHandler.php
+++ b/includes/ExceptionHandler.php
@@ -34,13 +34,13 @@ class ExceptionHandler
 <meta charset="utf-8">
 <title>Oops! Something went wrong!</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link href="{$siteConfiguration->getBaseUrl()}/vendor/twbs/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
+<link href="{$siteConfiguration->getBaseUrl()}/resources/generated/bootstrap-main.css" rel="stylesheet">
 <style>
   body {
     padding-top: 60px;
   }
 </style>
-</head><body><div class="container-fluid">
+</head><body><div class="container">
 <h1>Oops! Something went wrong!</h1>
 <p>We'll work on fixing this for you, so why not come back later?</p>
 <p class="muted">If our trained monkeys ask, tell them this error ID: <code>$1$</code></p>

--- a/includes/Pages/PageLog.php
+++ b/includes/Pages/PageLog.php
@@ -40,19 +40,29 @@ class PageLog extends PagedInternalPageBase
 
         $logSearch = LogSearchHelper::get($database);
 
+        if ($filterUser !== null) {
+            $userObj = User::getByUsername($filterUser, $database);
+            if ($userObj !== false) {
+                $logSearch->byUser($userObj->getId());
+            } else {
+                $logSearch->byUser(-1);
+            }
+        }
+        if ($filterAction !== null) {
+            $logSearch->byAction($filterAction);
+        }
+        if ($filterObjectType !== null) {
+            $logSearch->byObjectType($filterObjectType);
+        }
+        if ($filterObjectId !== null) {
+            $logSearch->byObjectId($filterObjectId);
+        }
+
         $this->setSearchHelper($logSearch);
         $this->setupLimits();
 
-
         /** @var Log[] $logs */
         $logs = $logSearch->getRecordCount($count)->fetch();
-
-        if ($count === 0) {
-            $this->assign('logs', array());
-            $this->setTemplate('logs/main.tpl');
-
-            return;
-        }
 
         list($users, $logData) = LogHelper::prepareLogsForTemplate($logs, $database, $this->getSiteConfiguration());
 

--- a/includes/Pages/PageUserManagement.php
+++ b/includes/Pages/PageUserManagement.php
@@ -37,6 +37,15 @@ class PageUserManagement extends InternalPageBase
         $database = $this->getDatabase();
         $currentUser = User::getCurrent($database);
 
+        $userSearchRequest = WebRequest::getString('usersearch');
+        if ($userSearchRequest !== null) {
+            $searchedUser = User::getByUsername($userSearchRequest, $database);
+            if($searchedUser !== false) {
+                $this->redirect('statistics/users', 'detail', ['user' => $searchedUser->getId()]);
+                return;
+            }
+        }
+
         // A bit hacky, but it's better than my last solution of creating an object for each user and passing that to
         // the template. I still don't have a particularly good way of handling this.
         OAuthUserHelper::prepareTokenCountStatement($database);

--- a/includes/Pages/PageXffDemo.php
+++ b/includes/Pages/PageXffDemo.php
@@ -1,0 +1,148 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\Pages;
+
+use Waca\Fragments\RequestData;
+use Waca\Tasks\InternalPageBase;
+
+class PageXffDemo extends InternalPageBase
+{
+    use RequestData;
+
+    /**
+     * @inheritDoc
+     */
+    protected function main()
+    {
+        $this->setTemplate('xffdemo.tpl');
+
+        // requestHasForwardedIp == false
+        // requestProxyData
+        // requestRealIp == proxy
+        // requestForwardedIp == xff header
+        // forwardedOrigin  == top of the chain, assuming xff is trusted
+
+
+        $this->assign('demo2', [
+            [
+                'trust' => true,
+                'trustedlink' => true,
+                'ip' => '172.16.0.164',
+                'routable' => false,
+
+            ],[
+                'trust' => true,
+                'ip' => '198.51.100.123',
+                'routable' => true,
+                'rdns' => 'trustedproxy.example.com',
+
+            ],[
+                'trust' => true,
+                'ip' => '192.0.2.1',
+                'routable' => true,
+                'rdns' => 'client.users.example.org',
+                'location' => [
+                    'cityName' => 'San Francisco',
+                    'regionName' => 'California',
+                    'countryName' => 'United States'
+                ],
+                'showlinks' => true
+            ]
+        ]);
+
+        $this->assign('demo3', [
+            [
+                'trust' => true,
+                'trustedlink' => true,
+                'ip' => '172.16.0.164',
+                'routable' => false,
+
+            ],[
+                'trust' => false,
+                'ip' => '198.51.100.234',
+                'routable' => true,
+                'rdns' => 'sketchyproxy.example.com',
+                'showlinks' => true
+
+            ],[
+                'trust' => false,
+                'ip' => '192.0.2.1',
+                'routable' => true,
+                'rdns' => 'client.users.example.org',
+                'location' => [
+                    'cityName' => 'San Francisco',
+                    'regionName' => 'California',
+                    'countryName' => 'United States'
+                ],
+                'showlinks' => true
+            ]
+        ]);
+
+        $this->assign('demo4', [
+            [
+                'trust' => true,
+                'trustedlink' => true,
+                'ip' => '172.16.0.164',
+                'routable' => false,
+
+            ],[
+                'trust' => true,
+                'ip' => '198.51.100.123',
+                'routable' => true,
+                'rdns' => 'trustedproxy.example.com',
+            ],[
+                'trust' => false,
+                'ip' => '198.51.100.234',
+                'routable' => true,
+                'rdns' => 'sketchyproxy.example.com',
+                'showlinks' => true
+            ], [
+                'trust' => false,
+                'trustedlink' => true,
+                'ip' => '198.51.100.124',
+                'routable' => true,
+                'rdns' => 'trustedproxy2.example.com',
+                'showlinks' => true
+            ],[
+                'trust' => false,
+                'ip' => '192.0.2.1',
+                'routable' => true,
+                'rdns' => 'client.users.example.org',
+                'location' => [
+                    'cityName' => 'San Francisco',
+                    'regionName' => 'California',
+                    'countryName' => 'United States'
+                ],
+                'showlinks' => true
+            ]
+        ]);
+
+        $this->assign('demo1', [
+            [
+                'trust' => true,
+                'trustedlink' => true,
+                'ip' => '172.16.0.164',
+                'routable' => false,
+
+            ], [
+                'trust' => true,
+                'trustedlink' => true,
+                'ip' => '192.0.2.1',
+                'routable' => true,
+                'rdns' => 'client.users.example.org',
+                'location' => [
+                    'cityName' => 'San Francisco',
+                    'regionName' => 'California',
+                    'countryName' => 'United States'
+                ],
+                'showlinks' => true
+            ]
+        ]);
+    }
+}

--- a/includes/Pages/UserAuth/PageForgotPassword.php
+++ b/includes/Pages/UserAuth/PageForgotPassword.php
@@ -73,7 +73,7 @@ class PageForgotPassword extends InternalPageBase
 
             $emailContent = $this->fetchTemplate('forgot-password/reset-mail.tpl');
 
-            $this->getEmailHelper()->sendMail($user->getEmail(), "", $emailContent);
+            $this->getEmailHelper()->sendMail($user->getEmail(), "WP:ACC password reset", $emailContent);
         }
     }
 

--- a/includes/Router/RequestRouter.php
+++ b/includes/Router/RequestRouter.php
@@ -15,6 +15,7 @@ use Waca\Pages\PageEditComment;
 use Waca\Pages\PageEmailManagement;
 use Waca\Pages\PageExpandedRequestList;
 use Waca\Pages\PageJobQueue;
+use Waca\Pages\PageXffDemo;
 use Waca\Pages\RequestAction\PageCreateRequest;
 use Waca\Pages\UserAuth\Login\PageOtpLogin;
 use Waca\Pages\UserAuth\Login\PagePasswordLogin;
@@ -350,6 +351,11 @@ class RequestRouter implements IRequestRouter
         'requestList'                 =>
             array(
                 'class'   => PageExpandedRequestList::class,
+                'actions' => array(),
+            ),
+        'xffdemo'                     =>
+            array(
+                'class'   => PageXffDemo::class,
                 'actions' => array(),
             ),
     );

--- a/includes/Security/CredentialProviders/ScratchTokenCredentialProvider.php
+++ b/includes/Security/CredentialProviders/ScratchTokenCredentialProvider.php
@@ -14,7 +14,9 @@ use Waca\Exceptions\ApplicationLogicException;
 use Waca\Exceptions\OptimisticLockFailedException;
 use Waca\PdoDatabase;
 use Waca\Security\EncryptionHelper;
+use Waca\SessionAlert;
 use Waca\SiteConfiguration;
+use Waca\WebRequest;
 
 class ScratchTokenCredentialProvider extends CredentialProviderBase
 {
@@ -62,6 +64,8 @@ class ScratchTokenCredentialProvider extends CredentialProviderBase
         foreach ($scratchTokens as $scratchToken) {
             if (password_verify($data, $scratchToken)){
                 $usedToken = $scratchToken;
+                SessionAlert::quick("Hey, it looks like you used a scratch token to log in. Would you like to change your multi-factor authentication configuration?", 'alert-warning');
+                WebRequest::setPostLoginRedirect($this->getConfiguration()->getBaseUrl() . "/internal.php/multiFactor");
                 break;
             }
         }

--- a/includes/Security/RoleConfiguration.php
+++ b/includes/Security/RoleConfiguration.php
@@ -16,6 +16,7 @@ use Waca\Pages\PageExpandedRequestList;
 use Waca\Pages\PageJobQueue;
 use Waca\Pages\PageLog;
 use Waca\Pages\PageMain;
+use Waca\Pages\PageXffDemo;
 use Waca\Pages\RequestAction\PageCreateRequest;
 use Waca\Pages\UserAuth\PageChangePassword;
 use Waca\Pages\UserAuth\MultiFactor\PageMultiFactor;
@@ -93,6 +94,9 @@ class RoleConfiguration
             PageTeam::class => array(
                 self::MAIN => self::ACCESS_ALLOW,
             ),
+            PageXffDemo::class        => array(
+                self::MAIN  => self::ACCESS_ALLOW,
+            )
         ),
         'loggedIn'          => array(
             /*

--- a/includes/Tasks/JsonApiPageBase.php
+++ b/includes/Tasks/JsonApiPageBase.php
@@ -26,8 +26,6 @@ abstract class JsonApiPageBase extends ApiPageBase implements IJsonApiAction
             throw new ApiException('Headers have already been sent - this indicates a bug in the application!');
         }
 
-        header("Content-Type: application/json");
-
         // javascript access control
         $httpOrigin = WebRequest::origin();
 
@@ -73,6 +71,9 @@ abstract class JsonApiPageBase extends ApiPageBase implements IJsonApiAction
         $targetVar = WebRequest::getString('targetVariable');
         if ($targetVar !== null && preg_match('/^[a-z]+$/', $targetVar)) {
             $data = $targetVar . ' = ' . $data . ';';
+            header("Content-Type: text/javascript");
+        } else {
+            header("Content-Type: application/json");
         }
 
         return $data;

--- a/includes/Tasks/PagedInternalPageBase.php
+++ b/includes/Tasks/PagedInternalPageBase.php
@@ -38,7 +38,7 @@ abstract class PagedInternalPageBase extends InternalPageBase
             // Can the user go to the next page?
             'cannext'   => ($page * $limit) < $count,
             // Maximum page number
-            'maxpage'   => ceil($count / $limit),
+            'maxpage'   => max(1, ceil($count / $limit)),
             // Limit to the number of pages to display
             'pagelimit' => $pageLimit,
         );

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -333,11 +333,18 @@ class WebRequest
 
     /**
      * Sets the post-login redirect
+     *
+     * @param string|null $uri The URI to redirect to
      */
-    public static function setPostLoginRedirect()
+    public static function setPostLoginRedirect($uri = null)
     {
         $session = &self::$globalStateProvider->getSessionSuperGlobal();
-        $session['returnTo'] = self::requestUri();
+
+        if ($uri === null) {
+            $uri = self::requestUri();
+        }
+
+        $session['returnTo'] = $uri;
     }
 
     /**

--- a/resources/scss/_common.scss
+++ b/resources/scss/_common.scss
@@ -44,3 +44,12 @@ span.twitter-typeahead {
         margin-bottom: 0.4rem;
     }
 }
+
+input[type=number] {
+    -moz-appearance: textfield;
+
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+        display: none;
+    }
+}

--- a/templates/navigation-menu.tpl
+++ b/templates/navigation-menu.tpl
@@ -51,7 +51,7 @@
         {if $nav__canViewRequest}
             <li class="nav-item">
                 <form class="navbar-form form-search" action="{$baseurl}/internal.php/viewRequest">
-                    <input class="form-control text-white bg-dark border-0" type="text" placeholder="Jump to request ID" name="id" class="search-query">
+                    <input class="form-control text-white bg-dark border-0" type="number" placeholder="Jump to request ID" name="id" class="search-query">
                 </form>
             </li>
         {/if}

--- a/templates/view-request/ip-links.tpl
+++ b/templates/view-request/ip-links.tpl
@@ -78,7 +78,7 @@
         </div>
         <div class="btn-group">
             <a id="IPLWCU-{$index}" class="btn btn-sm btn-outline-secondary visit-tracking" target="_blank"
-               href="https://login.wikimedia.org/w/index.php?title=Special:CheckUser&amp;ip={$ipaddress}&amp;reason=%5B%5BWP:ACC%5D%5D%20request%20%23{$requestId}">
+               href="https://login.wikimedia.org/w/index.php?title=Special:CheckUser&amp;ip={$ipaddress}&amp;reason=%5B%5B:en:WP:ACC%5D%5D%20request%20%23{$requestId}">
                 LW CU
             </a>
             <a id="IPLWCULog-{$index}" class="btn btn-sm btn-outline-secondary visit-tracking" target="_blank"

--- a/templates/view-request/ip-section.tpl
+++ b/templates/view-request/ip-section.tpl
@@ -5,7 +5,7 @@
         X-Forwarded-For HTTP header. The IP address which Wikipedia will see is the first "untrusted" IP address in
         the list below. Links are shown for all addresses starting from where the chain becomes untrusted. IPs past
         the first untrusted address are not trusted to be correct. Please see the
-        <a href="https://accounts-dev.wmflabs.org/other/xff.html">XFF demo</a> for more details.
+        <a href="{$baseurl}/internal.php/xffdemo">XFF demo</a> for more details.
     </p>
     <h5>Forwarded IP addresses:</h5>
     <table class="table table-sm table-striped">
@@ -65,4 +65,3 @@
     <h3>IP Address links:</h3>
     {include file="view-request/ip-links.tpl" ipaddress="{$requestTrustedIp}" index="0"}
 {/if}
-<hr/>

--- a/templates/view-request/main-with-data.tpl
+++ b/templates/view-request/main-with-data.tpl
@@ -31,7 +31,7 @@
                 </a>
             </div>
             <div class="col-md-4">
-                <a class="btn btn-danger btn-block" href="{$baseurl}/internal.php/bans/set?type=IP&amp;request{$requestId}">
+                <a class="btn btn-danger btn-block" href="{$baseurl}/internal.php/bans/set?type=IP&amp;request={$requestId}">
                     Ban IP
                 </a>
             </div>

--- a/templates/view-request/main-with-data.tpl
+++ b/templates/view-request/main-with-data.tpl
@@ -42,6 +42,8 @@
 
 {block name="ipSection"}
     {include file="view-request/ip-section.tpl"}
+
+    <hr/>
 {/block}
 
 {block name="emailSection"}

--- a/templates/view-request/request-log.tpl
+++ b/templates/view-request/request-log.tpl
@@ -11,7 +11,7 @@
             <tbody>
             {if $requestLogs}
                 {foreach from=$requestLogs item=zoomrow name=logloop}
-                    <tr {if $zoomrow.security == "admin"}class="bg-danger-light"{/if}>
+                    <tr {if $zoomrow.security == "admin"}class="table-danger"{/if}>
                         <td class="text-nowrap">
                             {if $zoomrow.userid != null}
                                 <a href='{$baseurl}/internal.php/statistics/users/detail?user={$zoomrow.userid}'>{$zoomrow.user|escape}</a>

--- a/templates/view-request/request-private-data.tpl
+++ b/templates/view-request/request-private-data.tpl
@@ -2,30 +2,28 @@
     <div class="row">
         <div class="col-md-4">
             <strong>Email address:</strong>
+            <span class="float-right ml-1 badge{if $requestRelatedEmailRequestsCount > 0} badge-danger{else} badge-secondary{/if} badge-pill">{$requestRelatedEmailRequestsCount}</span>
         </div>
-        <div class="col-md-7">
+        <div class="col-md-8">
             <a href="mailto:{$requestEmail|escape:'url'}">{$requestEmail|escape}</a>
-        </div>
-        <div class="col-md-1">
-            <span class="badge{if $requestRelatedEmailRequestsCount > 0} badge-danger{else} badge-secondary{/if}">{$requestRelatedEmailRequestsCount}</span>
         </div>
     </div>
     <div class="row">
-        <div class="col-md-4"><strong>IP address:</strong></div>
-        <div class="col-md-7">
+        <div class="col-md-4">
+            <strong>IP address:</strong>
+            <span class="float-right ml-1 badge{if $requestRelatedIpRequestsCount > 0} badge-danger{else} badge-secondary{/if} badge-pill">{$requestRelatedIpRequestsCount}</span>
+            <span class="float-right ml-1 badge badge-info badge-pill">XFF</span>
+        </div>
+        <div class="col-md-8">
             {$requestTrustedIp|escape}
             <br/>
-        <span class="text-muted">
-          {if $requestTrustedIpLocation != null}
-              Location: {$requestTrustedIpLocation.cityName|escape}, {$requestTrustedIpLocation.regionName|escape}, {$requestTrustedIpLocation.countryName|escape}
-          {else}
-              <em>Location unavailable</em>
-          {/if}
-        </span>
-        </div>
-        <div class="col-md-1">
-            <span class="badge badge-info">XFF</span>
-            <span class="badge{if $requestRelatedIpRequestsCount > 0} badge-danger{else} badge-secondary{/if}">{$requestRelatedIpRequestsCount}</span>
+            <span class="text-muted">
+              {if $requestTrustedIpLocation != null}
+                  Location: {$requestTrustedIpLocation.cityName|escape}, {$requestTrustedIpLocation.regionName|escape}, {$requestTrustedIpLocation.countryName|escape}
+              {else}
+                  <em>Location unavailable</em>
+              {/if}
+            </span>
         </div>
     </div>
 {/block}

--- a/templates/xffdemo.tpl
+++ b/templates/xffdemo.tpl
@@ -1,0 +1,188 @@
+{extends file="pagebase.tpl"}
+{block name="content"}
+    <div id="pageRequestLog">
+        <div class="row">
+            <div class="col-md-12" >
+                <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                    <h1 class="h2">X-Forwarded-For demo <small class="text-muted">Help on interpreting the XFF data</small></h1>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="offset-lg-2 offset-xl-3 col-lg-8 col-xl-6">
+                <p class="lead">
+                    When handling requests, you are likely to come across several different possible scenarios when looking
+                    at the IP address section. This page aims to guide you through what the tool is trying to tell you.
+                </p>
+                <p>
+                    When the tool receives a request from a newbie, the tool records the newbie's IP address as seen by the
+                    server on which ACC runs. However, there is sometimes a proxy between the tool and the newbie - when
+                    that is the case, the IP address seen by the server is that of the proxy, not the newbie. Some proxy
+                    servers include a special header, known as <code>X-Forwarded-For</code>, in which they append the IP
+                    address of the end user to this header before passing the request on. If there are multiple proxy
+                    servers, multiple IP addresses get added to this header.
+                </p>
+                <p>
+                    If there is no proxy server, this is what you would see:
+                </p>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12 px-3 mb-3">
+                <div class="bg-light border border-dark rounded p-3">
+                    {include file="view-request/ip-section.tpl" requestHasForwardedIp=false requestTrustedIp="1.2.3.4"}
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="offset-lg-2 offset-xl-3 col-lg-8 col-xl-6">
+                <p>
+                    This scenario, however, is not likely to ever appear for the simple reason that Wikimedia Cloud Services
+                    have placed their own proxy server in front of the tool. Thus, there will always be at least one proxy
+                    server.
+                </p>
+                <h3>97% of requests: Wikimedia proxy only</h3>
+                <p>
+                    When there is only the WMCS proxy in place, this is what you are likely to see something more like this:
+                </p>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12 px-3 mb-3">
+                <div class="bg-light border border-dark rounded p-3">
+                    {include file="view-request/ip-section.tpl" requestHasForwardedIp=true requestForwardedIp="192.0.2.1" requestRealIp="172.16.0.164" forwardedOrigin="192.0.2.1" requestProxyData=$demo1}
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="offset-lg-2 offset-xl-3 col-lg-8 col-xl-6">
+                <p>
+                    The above scenario has passed through one server we trust (<code>172.16.0.164</code>), and that
+                    server
+                    has indicated it received a request from <code>190.0.2.1</code>. At this point, the XFF chain stops,
+                    and we assume that <code>192.0.2.1</code> is the client's IP address.
+                </p>
+                <p>
+                    We also augment each IP address with some extra information, including the estimated location of the
+                    IP address, and the reverse DNS name of the IP address. These can help give some indication of the
+                    type of IP address - whether it's a residential ISP, a hosting provider, or otherwise.
+                </p>
+                <h3>2% of requests - another trusted proxy</h3>
+                <p>
+                    Occasionally, we will get a request from a user who is using a proxy service which we trust to provide
+                    accurate XFF headers. It's worth noting here that Wikimedia takes the XFF headers as truth where the
+                    provider of the XFF header is trusted. We use the same trust list here, but we display all the data
+                    anyway. The essence of it is that the last "trusted" IP address in the list will be the one that
+                    Wikimedia uses.
+                </p>
+                <p>
+                    In this example, the user has passed through a trusted proxy provider before hitting the WMCS proxy.
+                    Both proxy servers are listed and marked as trusted, and we don't show the IP links for those trusted
+                    proxy servers.
+                </p>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12 px-3 mb-3">
+                <div class="bg-light border border-dark rounded p-3">
+                    {include file="view-request/ip-section.tpl" requestHasForwardedIp=true requestForwardedIp="192.0.2.1, 198.51.100.123" requestRealIp="172.16.0.164" forwardedOrigin="192.0.2.1" requestProxyData=$demo2}
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="offset-lg-2 offset-xl-3 col-lg-8 col-xl-6">
+                <h3>0.5% of requests - untrusted proxies</h3>
+                <p>
+                    Conversely to the above, sometimes people will request an account from a proxy server which publishes
+                    the client IP address, but not one that we trust to be accurate.
+                </p>
+                <p>
+                    As each server on the chain of proxies has the option to rewrite the entire XFF header, we should not
+                    use any entries from servers we don't trust. If we trust a server to not forge the XFF header, we can
+                    trust the next item in the chain is accurate, but no further. It is at this point that the trust chain
+                    breaks, and we start seeing lots of red flags.
+                </p>
+            </div>
+        </div>
+
+
+        <div class="row">
+            <div class="col-12 px-3 mb-3">
+                <div class="bg-light border border-dark rounded p-3">
+                    {include file="view-request/ip-section.tpl" requestHasForwardedIp=true requestForwardedIp="192.0.2.1, 198.51.100.234" requestRealIp="172.16.0.164" forwardedOrigin="192.0.2.1" requestProxyData=$demo3}
+                </div>
+            </div>
+        </div>
+
+
+        <div class="row">
+            <div class="offset-lg-2 offset-xl-3 col-lg-8 col-xl-6">
+                <p>
+                    In this scenario, because we trust the first IP address, we can believe that it's correct in telling
+                    us that <code>198.51.100.234</code> is indeed where the request has come from. However, we cannot
+                    trust that server is telling the truth.
+                </p>
+                <p>
+                    The second server is reporting that the third server exists, but Wikimedia will only believe that the
+                    client is on the second IP address, and so this is the IP address we should check. It is worth checking
+                    the third too, because it's possible that the trust lists between ACC and Wikimedia have drifted.
+                </p>
+                <h3>0% of requests - an insane possibility</h3>
+                <p>
+                    If someone really wants to play with the XFF headers, they are welcome to do so as they send in the
+                    request. If they're putting crazy things in the header, it's not outside the realm of possibility that
+                    something like this will occur:
+                </p>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12 px-3 mb-3">
+                <div class="bg-light border border-dark rounded p-3">
+                    {include file="view-request/ip-section.tpl" requestHasForwardedIp=true requestForwardedIp="192.0.2.1, 198.51.100.234" requestRealIp="172.16.0.164" forwardedOrigin="192.0.2.1" requestProxyData=$demo4}
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="offset-lg-2 offset-xl-3 col-lg-8 col-xl-6">
+                <p>
+                    This example has three trusted servers - <code>172.16.0.164</code>, <code>198.51.100.123</code>, and
+                    <code>198.51.100.124</code>. However, this indicates the breaking of the trust chain - because the
+                    request passed through an untrusted server, we can't tell if the untrusted server is forging the information
+                    leading to the trusted server. As such, we indicate that the <code>198.51.100.124</code> would be
+                    trusted, had the trust chain not already been broken.
+                </p>
+                <p>
+                    In this case, the IP address that Wikipedia will see is <code>198.51.100.234</code> - the first untrusted
+                    IP address in the list.
+                </p>
+            </div>
+        </div>
+
+    </div>
+    <div class="row">
+        <div class="offset-lg-2 offset-xl-3 col-lg-8 col-xl-6 text-muted">
+            <h5><small>Notes on percentage estimates</small></h5>
+            <p><small>
+                    The estimates of request volumes in this documentation is a vague guess only based on intuition of a
+                    long-term ACC user, and is quite likely to be inaccurate.
+                </small></p>
+            <h5><small>Notes on privacy</small></h5>
+            <p><small>
+                This documentation uses IP addresses in the <a href="https://tools.ietf.org/html/rfc1918">RFC 1918</a>
+                range 172.16.0.0/12 to represent internal Wikimedia IP addresses, and IP address in the
+                <a href="https://tools.ietf.org/html/rfc5737">RFC 5737</a> ranges 192.0.2.0/24 and 198.51.100.0/24 to represent external IP
+                addresses. Both of these address blocks are not routable on the public internet, and thus do not have
+                any privacy implications by being part of this documentation.
+                </small></p>
+        </div>
+    </div>
+{/block}


### PR DESCRIPTION
The first of several bumper bugfix bonanzas.

This is done commit-by-commit, so you can see the commit history for a change log.

There is one bit of new functionality, and it's the move of the XFF demo page into the tool itself. Essentially, it's replacing [this page](https://accounts-dev.wmflabs.org/other/xff.html) with [this one](https://accounts-dev.wmflabs.org/rc/internal.php/xffdemo). I've left it at public access, but there's no inbound links to it from public areas, which matches the existing page. I'm happy to reduce the access scope, but I see little point as it's all demo data. The most someone malicious could do would be to see what tools we use, which they could from GitHub anyway.
