### PR TITLE
Fix travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 before_script:
   - pecl install runkit7-3.0.0
   - phpenv config-add .travis.php.ini
-  - msyql -u root -e "ALTER USER root@localhost IDENTIFIED VIA mysql_native_password USING PASSWORD("password")"
+  - mysql -u root -e "ALTER USER root@localhost IDENTIFIED VIA mysql_native_password USING PASSWORD("password")"
   - cd sql
   - bash test_db.sh 1
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   - MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_SCHEMA=testdb
 
 before_script:
-  - pecl install runkit7
+  - pecl install runkit7-3.0.0
   - phpenv config-add .travis.php.ini
   - cd sql
   - bash test_db.sh 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 7.3
 
 addons:
-  mariadb: '10.1'
+  mariadb: '10.5'
 
 os: linux
 dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,12 @@ git:
   submodules: true
 
 env:
-  - MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_SCHEMA=testdb
+  - MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_SCHEMA=testdb MYSQL_PASSWORD=password
 
 before_script:
   - pecl install runkit7-3.0.0
   - phpenv config-add .travis.php.ini
+  - msyql -u root -e "ALTER USER root@localhost IDENTIFIED VIA mysql_native_password USING PASSWORD("password")"
   - cd sql
   - bash test_db.sh 1
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 before_script:
   - pecl install runkit7-3.0.0
   - phpenv config-add .travis.php.ini
-  - mysql -u root -e "ALTER USER root@localhost IDENTIFIED VIA mysql_native_password USING PASSWORD("password")"
+  - sudo mysql -u root -e "ALTER USER root@localhost IDENTIFIED VIA mysql_native_password USING PASSWORD("password")"
   - cd sql
   - bash test_db.sh 1
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   - MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_SCHEMA=testdb
 
 before_script:
-  - pecl install runkit
+  - pecl install runkit7
   - phpenv config-add .travis.php.ini
   - cd sql
   - bash test_db.sh 1
@@ -38,7 +38,7 @@ after_script:
 notifications:
   irc:
     channels:
-      - "chat.freenode.net#wikipedia-en-accounts-devs"
+      #- "chat.freenode.net#wikipedia-en-accounts-devs"
     on_success: change
     on_failure: always
     template:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 7.3
 
 addons:
-  mariadb: '10.5'
+  mariadb: '10.2'
 
 os: linux
 dist: bionic
@@ -17,12 +17,11 @@ git:
   submodules: true
 
 env:
-  - MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_SCHEMA=testdb MYSQL_PASSWORD=password
+  - MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_SCHEMA=testdb
 
 before_script:
   - pecl install runkit7-3.0.0
   - phpenv config-add .travis.php.ini
-  - sudo mysql -u root -e "ALTER USER root@localhost IDENTIFIED VIA mysql_native_password USING PASSWORD("password")"
   - cd sql
   - bash test_db.sh 1
   - cd ..

--- a/sql/test_db.sh
+++ b/sql/test_db.sh
@@ -23,53 +23,53 @@ fi
 if [ $# -ge 2 ]; then
 	SQL_SERVER=$2
 else
-	SQL_SERVER=$MYSQL_HOST
+	SQL_SERVER=$sudo mysql_HOST
 fi
 
 if [ $# -ge 3 ]; then
 	SQL_DBNAME=$3
 else
-	SQL_DBNAME=$MYSQL_SCHEMA
+	SQL_DBNAME=$sudo mysql_SCHEMA
 fi
 
 if [ $# -ge 4 ]; then
 	SQL_USERNAME=$4
 else
-	SQL_USERNAME=$MYSQL_USER
+	SQL_USERNAME=$sudo mysql_USER
 fi
 
 if [ $# -ge 5 ]; then
 	SQL_PASSWORD=-p$5
-elif [ -n "$MYSQL_PASSWORD" ]; then
-	SQL_PASSWORD=-p$MYSQL_PASSWORD
+elif [ -n "$sudo mysql_PASSWORD" ]; then
+	SQL_PASSWORD=-p$sudo mysql_PASSWORD
 else
 	SQL_PASSWORD=
 fi
 
 echo "Check a few configuration flags"
-mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@sql_mode;"
-mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@version;"
+sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@sql_mode;"
+sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@version;"
 
 if [[ $SQL_USERNAME == "root" ]]; then
 	echo "Forcing SQL mode"
-	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SET GLOBAL sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES,ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO';"
+	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SET GLOBAL sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES,ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO';"
 
-	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@sql_mode;"
+	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@sql_mode;"
 fi
 
 echo "Dropping old database..."
-mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "DROP DATABASE IF EXISTS $SQL_DBNAME;"
+sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "DROP DATABASE IF EXISTS $SQL_DBNAME;"
 
 echo "Creating database..."
-mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "CREATE DATABASE $SQL_DBNAME;"
+sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "CREATE DATABASE $SQL_DBNAME;"
 
 echo "Loading initial schema..."
-mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < db-structure.sql
+sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < db-structure.sql
 
 echo "Loading initial seed data..."
 for f in `ls seed/*_data.sql`; do
 	echo "  * $f"
-	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < $f
+	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < $f
 done
 
 echo "Applying patches..."
@@ -79,24 +79,24 @@ for f in `ls patches/patch*.sql`; do
 	fi
 
 	echo "  * $f"
-	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < $f
+	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < $f
 done
 
 if [ $1 -eq 0 ]; then
 	echo "Dumping schema to file..."
-	mysqldump --compact -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME > schema.sql
+	sudo mysqldump --compact -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME > schema.sql
 
 	echo "Dropping database from server..."
-	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "DROP DATABASE IF EXISTS $SQL_DBNAME;"
+	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "DROP DATABASE IF EXISTS $SQL_DBNAME;"
 
 	echo "Creating database..."
-	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "CREATE DATABASE $SQL_DBNAME;"
+	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "CREATE DATABASE $SQL_DBNAME;"
 
 	echo "Reloading database from file..."
-	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < schema.sql
+	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < schema.sql
 
 	echo "Dumping schema to file..."
-	mysqldump --compact -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME > schema2.sql
+	sudo mysqldump --compact -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME > schema2.sql
 
 	echo "Comparing dumps..."
 	diff -q schema.sql schema2.sql

--- a/sql/test_db.sh
+++ b/sql/test_db.sh
@@ -47,29 +47,29 @@ else
 fi
 
 echo "Check a few configuration flags"
-sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@sql_mode;"
-sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@version;"
+mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@sql_mode;"
+mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@version;"
 
 if [[ $SQL_USERNAME == "root" ]]; then
 	echo "Forcing SQL mode"
-	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SET GLOBAL sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES,ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO';"
+	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SET GLOBAL sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES,ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO';"
 
-	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@sql_mode;"
+	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "SELECT @@sql_mode;"
 fi
 
 echo "Dropping old database..."
-sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "DROP DATABASE IF EXISTS $SQL_DBNAME;"
+mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "DROP DATABASE IF EXISTS $SQL_DBNAME;"
 
 echo "Creating database..."
-sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "CREATE DATABASE $SQL_DBNAME;"
+mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "CREATE DATABASE $SQL_DBNAME;"
 
 echo "Loading initial schema..."
-sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < db-structure.sql
+mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < db-structure.sql
 
 echo "Loading initial seed data..."
 for f in `ls seed/*_data.sql`; do
 	echo "  * $f"
-	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < $f
+	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < $f
 done
 
 echo "Applying patches..."
@@ -79,24 +79,24 @@ for f in `ls patches/patch*.sql`; do
 	fi
 
 	echo "  * $f"
-	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < $f
+	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < $f
 done
 
 if [ $1 -eq 0 ]; then
 	echo "Dumping schema to file..."
-	sudo mysqldump --compact -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME > schema.sql
+	mysqldump --compact -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME > schema.sql
 
 	echo "Dropping database from server..."
-	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "DROP DATABASE IF EXISTS $SQL_DBNAME;"
+	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "DROP DATABASE IF EXISTS $SQL_DBNAME;"
 
 	echo "Creating database..."
-	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "CREATE DATABASE $SQL_DBNAME;"
+	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD -e "CREATE DATABASE $SQL_DBNAME;"
 
 	echo "Reloading database from file..."
-	sudo mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < schema.sql
+	mysql -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME < schema.sql
 
 	echo "Dumping schema to file..."
-	sudo mysqldump --compact -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME > schema2.sql
+	mysqldump --compact -h $SQL_SERVER -u $SQL_USERNAME $SQL_PASSWORD $SQL_DBNAME > schema2.sql
 
 	echo "Comparing dumps..."
 	diff -q schema.sql schema2.sql

--- a/sql/test_db.sh
+++ b/sql/test_db.sh
@@ -23,25 +23,25 @@ fi
 if [ $# -ge 2 ]; then
 	SQL_SERVER=$2
 else
-	SQL_SERVER=$sudo mysql_HOST
+	SQL_SERVER=$MYSQL_HOST
 fi
 
 if [ $# -ge 3 ]; then
 	SQL_DBNAME=$3
 else
-	SQL_DBNAME=$sudo mysql_SCHEMA
+	SQL_DBNAME=$MYSQL_SCHEMA
 fi
 
 if [ $# -ge 4 ]; then
 	SQL_USERNAME=$4
 else
-	SQL_USERNAME=$sudo mysql_USER
+	SQL_USERNAME=$MYSQL_USER
 fi
 
 if [ $# -ge 5 ]; then
 	SQL_PASSWORD=-p$5
-elif [ -n "$sudo mysql_PASSWORD" ]; then
-	SQL_PASSWORD=-p$sudo mysql_PASSWORD
+elif [ -n "$MYSQL_PASSWORD" ]; then
+	SQL_PASSWORD=-p$MYSQL_PASSWORD
 else
 	SQL_PASSWORD=
 fi


### PR DESCRIPTION
This commit fixes the Travis configuration by making the following changes:
- Upgrade the MariaDB version to 10.2
- Upgrades Runkit to use Runkit7.  Runkit7 is a fork of Runkit that adds support for PHP 7.  The package is labelled as "alpha" in pecl, so I have manually configured to use v.3.0.0 right now.  Once a stable version is published, we can drop the 3.0.0 designator.

A couple of notes:
- I commented out the IRC notifications.  They need to be re-enabled.  I only did this to not flood the -dev channel with extraneous notifications.
- We... also probably want to squash this commit.  You can see by my log why I recommend that.  

Looking forward, MariaDB v.10.4 changes mysql authentication.  One of the tasks we need to consider is upgrading our Travis config to use this new authentication.  [Details](https://mariadb.com/kb/en/authentication-from-mariadb-104/)