### PR TITLE
Fix OTP Field Behavior and Browser Title Handling

### DIFF
--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -26,7 +26,7 @@ use Waca\WebRequest;
 class PageViewRequest extends InternalPageBase
 {
     use RequestData;
-    const STATUS_SYMBOL_OPEN = '&#x2610';
+    const STATUS_SYMBOL_OPEN = '&#927';
     const STATUS_SYMBOL_ACCEPTED = '&#x2611';
     const STATUS_SYMBOL_REJECTED = '&#x2612';
 

--- a/templates/login/otp.tpl
+++ b/templates/login/otp.tpl
@@ -3,7 +3,7 @@
     <div class="form-group row">
         <div class="col">
             <label for="otp" class="sr-only">OTP</label>
-            <input type="password" id="otp" name="otp" placeholder="Enter your one-time code" class="form-control" required tabindex="2" autocomplete="one-time-code">
+            <input type="text" id="otp" name="otp" placeholder="Enter your one-time code" class="form-control" required tabindex="2" autocomplete="one-time-code">
         </div>
     </div>
 {/block}

--- a/templates/mfa/enableYubikey.tpl
+++ b/templates/mfa/enableYubikey.tpl
@@ -31,7 +31,7 @@
                         <div class="form-group row">
                             <div class="col">
                                 <label class="sr-only" for="otp">YubiKey OTP</label>
-                                <input type="password" id="otp" name="otp" placeholder="YubiKey OTP" class="form-control"
+                                <input type="text" id="otp" name="otp" placeholder="YubiKey OTP" class="form-control"
                                        required tabindex="2" autocomplete="one-time-code">
                             </div>
                             <input type="hidden" name="stage" value="auth">


### PR DESCRIPTION
Change Open Symbol to an Omicron to prevent confusion (changed from empty box)