### PR TITLE
Fix usage of deprecated database field `emailtemplate.oncreated`

### DIFF
--- a/includes/DataObjects/Request.php
+++ b/includes/DataObjects/Request.php
@@ -334,7 +334,7 @@ SQL
         }
 
         $statement = $this->dbObject->prepare(<<<SQL
-SELECT emailtemplate.oncreated, log.action
+SELECT emailtemplate.defaultaction, log.action
 FROM log
 LEFT JOIN emailtemplate ON CONCAT('Closed ', emailtemplate.id) = log.action
 WHERE log.objecttype = 'Request'
@@ -347,15 +347,15 @@ SQL
 
         $statement->bindValue(":requestId", $this->id);
         $statement->execute();
-        $onCreated = $statement->fetchColumn(0);
+        $defaultAction = $statement->fetchColumn(0);
         $logAction = $statement->fetchColumn(1);
         $statement->closeCursor();
 
-        if ($onCreated === null) {
+        if ($defaultAction === null) {
             return $logAction === "Closed custom-y";
         }
 
-        return (bool)$onCreated;
+        return $defaultAction === EmailTemplate::CREATED;
     }
 
     /**

--- a/includes/Pages/Statistics/StatsUsers.php
+++ b/includes/Pages/Statistics/StatsUsers.php
@@ -9,6 +9,7 @@
 namespace Waca\Pages\Statistics;
 
 use PDO;
+use Waca\DataObjects\EmailTemplate;
 use Waca\DataObjects\Log;
 use Waca\DataObjects\User;
 use Waca\Exceptions\ApplicationLogicException;
@@ -94,11 +95,11 @@ INNER JOIN user ON log.user = user.id
 LEFT JOIN emailtemplate ON concat('Closed ', emailtemplate.id) = log.action
 WHERE user.username = :username
     AND log.action LIKE 'Closed %'
-    AND (emailtemplate.oncreated = '1' OR log.action = 'Closed custom-y')
+    AND (emailtemplate.defaultaction = :created OR log.action = 'Closed custom-y')
 ORDER BY log.timestamp;
 SQL
         );
-        $usersCreatedQuery->execute(array(":username" => $user->getUsername()));
+        $usersCreatedQuery->execute(array(":username" => $user->getUsername(), ':created' => EmailTemplate::CREATED));
         $usersCreated = $usersCreatedQuery->fetchAll(PDO::FETCH_ASSOC);
         $this->assign("created", $usersCreated);
 
@@ -110,11 +111,11 @@ JOIN user ON log.user = user.id
 LEFT JOIN emailtemplate ON concat('Closed ', emailtemplate.id) = log.action
 WHERE user.username = :username
     AND log.action LIKE 'Closed %'
-    AND (emailtemplate.oncreated = '0' OR log.action = 'Closed custom-n' OR log.action = 'Closed 0')
+    AND (emailtemplate.defaultaction = :created OR log.action = 'Closed custom-n' OR log.action = 'Closed 0')
 ORDER BY log.timestamp;
 SQL
         );
-        $usersNotCreatedQuery->execute(array(":username" => $user->getUsername()));
+        $usersNotCreatedQuery->execute(array(":username" => $user->getUsername(), ':created' => EmailTemplate::CREATED));
         $usersNotCreated = $usersNotCreatedQuery->fetchAll(PDO::FETCH_ASSOC);
         $this->assign("notcreated", $usersNotCreated);
 


### PR DESCRIPTION
This field hasn't been populated [since 2015](https://github.com/enwikipedia-acc/waca/commit/ef3a35df06033845e7287d5dd53bfe12c9236f33), but was still being read from. Any "created"-type close reasons created since then will have been reporting incorrectly - thankfully that list is zero in production.
