### PR TITLE
Fix database migration scripts for development installations.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM php:7.3-apache-buster
+
+# VOLUME /var/www/html
+RUN apt-get update \
+    && apt-get install git unzip -q -y --no-install-recommends \
+    && apt-get clean
+
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+RUN chmod ug+x /usr/local/bin/install-php-extensions && sync && \
+    install-php-extensions pdo_mysql xdebug
+
+WORKDIR /opt
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php \
+    && rm composer-setup.php
+
+VOLUME /var/www/html/templates_c
+VOLUME /var/www/html/errorlog
+
+WORKDIR /var/www/html
+COPY . /var/www/html
+
+ENTRYPOINT /var/www/html/docker/entrypoint.sh

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -13,14 +13,14 @@ You must also have a database which you can use with the tool.
 ## PHP configuration
 You'll also need some PHP extensions:
 
+* curl
+* date
 * mbstring
+* openssl
+* pcre
 * pdo
 * pdo_mysql
 * session
-* date
-* pcre
-* curl
-* openssl
 
 There's nothing special here, these are all standard PHP extensions that are bundled with PHP - you may
 just need to switch some of them on in the php.ini file.
@@ -59,14 +59,21 @@ This was written using Windows 10.
 4. Clone the ACC repo to C:\xampp\htdocs\waca\
 5. Browse to http://localhost/phpmyadmin/ and create a new database called "waca".
 6. Run `composer install` (https://getcomposer.org)
-7. Update the dependent git repos
-  * `git submodule update --init --recursive`
 8. Generate the stylesheets:
   * `cd maintenance/; php RegenerateStylesheets.php`
 8. run the database setup scripts:
   * `./test_db.sh 1 localhost <dbname> <user> <password>`
-  * `mysql <dbname> -e "update user set status = 'Active' ;"`
 9. Create the configuration file (see below).
+
+# Docker
+There is **experimental** support for Docker. Knowledge of Docker is assumed here if you want to use it - this is not
+a configuration which the team will spend much time to support.
+
+You will still need to create the configuration file as below, but you should be able to just run `docker-compose up -d`
+in this folder, and two containers should start - one for the database listening on port 3306, and one for the web
+application listening on port 8080. The configuration should use "waca" as the username, password, and database name,
+and "database" for the hostname. The `$baseurl` setting should also be set to `http://127.0.0.1:8080`. All other 
+installation steps including dependencies and loading the initial database schema are handled automatically by Docker.
 
 # Configuration File
 Create a new PHP file called config.local.inc.php, and fill it with the following:
@@ -91,7 +98,6 @@ $whichami = "MyName";
 
 // these turn off features which you probably want off for ease of development.
 $enableEmailConfirm = 0;
-$forceIdentification = false;
 $locationProviderClass = "FakeLocationProvider";
 $antispoofProviderClass = "FakeAntiSpoofProvider";
 $rdnsProviderClass = "FakeRDnsLookupProvider";
@@ -107,7 +113,9 @@ Most settings are flags to turn on and off features for development systems whic
 
 # First Login!
 
-Browse to http://localhost/waca/internal.php, and log in! There's a user created by default called "Admin", with the password "Admin".
+Browse to http://localhost/waca/internal.php, and log in! There's a user created by default called "Admin", with the password "enwpaccAdmin1!".
+
+Note that this user account is configured to skip the standard checks that the user has identified to the Wikimedia Foundation. By default, all additional users created will require an "on-wiki" username to match a username on the identification noticeboard, or will require the `forceidentified` flag to be set to `1` in the `user` table in the database. There is no user interface for doing this by design. 
 
 # OAuth setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.0"
+services:
+  application:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/var/www/html/
+    ports:
+      - 8080:80
+    depends_on:
+      - database
+  database:
+    image: mariadb:10.3
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: waca
+      MYSQL_DATABASE: waca
+      MYSQL_USER: waca
+      MYSQL_PASSWORD: waca
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./docker/database.sh:/docker-entrypoint-initdb.d/init.sh
+      - ./sql:/wacadb
+volumes:
+  mysql-data:
+

--- a/docker/database.sh
+++ b/docker/database.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -x
+
+cd /wacadb
+./test_db.sh 1 localhost ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+cd /var/www/html
+
+chown -R www-data templates_c errorlog
+
+php /opt/composer.phar install
+php maintenance/RegenerateStylesheets.php
+
+exec apache2-foreground

--- a/docker/index.php
+++ b/docker/index.php
@@ -1,0 +1,12 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+// Redirect user away from the current directory.
+require_once('../config.inc.php');
+header("Location: $baseurl/");
+die();

--- a/sql/patches/patch25-migrationscript-placeholder.sql
+++ b/sql/patches/patch25-migrationscript-placeholder.sql
@@ -45,6 +45,8 @@ CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
         INSERT INTO userrole (user, role, updateversion)
         VALUES (1, 'admin', 0), (1, 'toolRoot', 0);
 
+        UPDATE user SET status = 'Active' WHERE id = 1;
+
         UPDATE schemaversion SET version = patchversion;
     ELSE
         IF NOT EXISTS (SELECT * FROM user WHERE status = 'Active') THEN

--- a/sql/patches/patch30-force-identification.sql
+++ b/sql/patches/patch30-force-identification.sql
@@ -54,6 +54,10 @@ CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
 
     -- Force all users to be checked again
     UPDATE user SET forceidentified = null WHERE 1=1;
+
+    -- Force identified status for the default admin user for non-production installations
+    -- This has no effect on production, since user 1 doesn't have a username of 'Admin'.
+    UPDATE user SET forceidentified = 1 WHERE id = 1 AND username = 'Admin';
     
     -- -------------------------------------------------------------------------
     -- finally, update the schema version to indicate success

--- a/sql/patches/patch31-darkmode.sql
+++ b/sql/patches/patch31-darkmode.sql
@@ -36,6 +36,10 @@ CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
     
     ALTER TABLE user ADD COLUMN skin VARCHAR(10) DEFAULT 'main' NOT NULL;
 
+    -- Use the new default for the default admin user for non-production installations
+    -- This has no effect on production, since user 1 doesn't have a username of 'Admin'.
+    UPDATE user SET skin = 'auto' WHERE id = 1 AND username = 'Admin';
+
     -- -------------------------------------------------------------------------
     -- finally, update the schema version to indicate success
     UPDATE schemaversion SET version = patchversion;

--- a/sql/seed/user_data.sql
+++ b/sql/seed/user_data.sql
@@ -19,7 +19,7 @@
 -- Dumping data for table `user`
 --
 
-INSERT INTO `user` VALUES (1,'Admin','admin@localhost',':1:salt:c72deb17cc624f7bbe4ad632887b0202','Admin','MediaWiki User', '','0000-00-00 00:00:00',0,0,1,0,0,0,'Admin',NULL,NULL,NULL,NULL,NULL);
+INSERT INTO `user` VALUES (1,'Admin','admin@localhost',':2:x:$2y$10$nDVrjPbb10hDOQrB9WZ/vOragq4sAtm3IsorML5ooESdNA55FfHYO','Admin','MediaWiki User', '','0000-00-00 00:00:00',0,0,1,0,0,0,'Admin',NULL,NULL,NULL,NULL,NULL);
 
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 


### PR DESCRIPTION
These changes have no effect on Production, partly because a) they've
already run, and b) they depend on the use of the default install seed
data.

Roughly speaking, these fixes are as follows:
* Update the default password to one that's actually able to log in
  after the changes to minimum password complexity rules
* Force the default admin user to be marked as identified by default
* Force the default admin user to use an automatic skin, which is the
  default at the moment
* Update the status of the default admin user to 'Active' - the change
  is normally done in the MigrateToRoles.php script, but this is not run
  when the database is installed from the base data.

I've also yanked the instructions from INSTALLING.md to sync git
submodules (we got rid of those), and removed the setting for
`$forceIdentification` as this does nothing now. I've also yanked the
instruction to manually set the user as Active - this is now handled in
the initial installation script.

Finally, I've also added *experimental* Docker support in the form of
a Dockerfile for the main application, and a docker-compose.yml file to
bring up both the application and the database. YMMV, it seems to work
for me, so it'll probably work for others, but you should know Docker
before playing with it.

Fixes #620