### PR TITLE
Add basic database infrastructure for multi-project support

### DIFF
--- a/includes/ConsoleTasks/MigrateToDomains.php
+++ b/includes/ConsoleTasks/MigrateToDomains.php
@@ -1,0 +1,62 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\ConsoleTasks;
+
+use Waca\DataObjects\Domain;
+use Waca\DataObjects\RequestQueue;
+use Waca\Tasks\ConsoleTaskBase;
+
+class MigrateToDomains extends ConsoleTaskBase
+{
+    public function execute()
+    {
+        $requestStates = $this->getSiteConfiguration()->getRequestStates();
+        $database = $this->getDatabase();
+
+        $domain = new Domain();
+        $domain->setEnabled(true);
+        $domain->setShortName('enwiki');
+        $domain->setLongName('English Wikipedia');
+        $domain->setWikiArticlePath($this->getSiteConfiguration()->getMediawikiScriptPath());
+        $domain->setWikiApiPath($this->getSiteConfiguration()->getMediawikiWebServiceEndpoint());
+        $domain->setEnabled(true);
+        $domain->setDefaultClose($this->getSiteConfiguration()->getDefaultCreatedTemplateId());
+        $domain->setDefaultLanguage('en');
+        $domain->setEmailSender('accounts-enwiki-l@lists.wikimedia.org');
+        $domain->setNotificationTarget($this->getSiteConfiguration()->getIrcNotificationType());
+
+        $domain->setDatabase($database);
+        $domain->save();
+
+        $first = true;
+        foreach ($requestStates as $key => $data) {
+            $state = new RequestQueue();
+            $state->setDefault($first);
+            $state->setDomain($domain->getId());
+            $state->setApiName($data['api']);
+            $state->setDisplayName($data['deferto']);
+            $state->setHeader($data['header']);
+            $state->setLogName($data['defertolog']);
+            $state->setLegacyStatus($key);
+            $state->setEnabled(true);
+
+            if (isset($data['help'])) {
+                $state->setHelp($data['help']);
+            }
+
+            $state->setDatabase($database);
+            $state->save();
+
+            $first = false;
+        }
+
+        /** @noinspection SqlWithoutWhere */
+        $database->exec("UPDATE schemaversion SET version = 37;");
+    }
+}

--- a/includes/DataObjects/Domain.php
+++ b/includes/DataObjects/Domain.php
@@ -1,0 +1,254 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\DataObjects;
+
+use Exception;
+use Waca\DataObject;
+use Waca\Exceptions\OptimisticLockFailedException;
+
+class Domain extends DataObject
+{
+    /** @var string */
+    private $shortname;
+    /** @var string */
+    private $longname;
+    /** @var string */
+    private $wikiarticlepath;
+    /** @var string */
+    private $wikiapipath;
+    /** @var int */
+    private $enabled = 0;
+    /** @var int|null */
+    private $defaultclose;
+    /** @var string */
+    private $defaultlanguage = 'en';
+    /** @var string */
+    private $emailsender;
+    /** @var string|null */
+    private $notificationtarget;
+
+    public function save()
+    {
+        if ($this->isNew()) {
+            // insert
+            $statement = $this->dbObject->prepare(<<<SQL
+                INSERT INTO domain (
+                    shortname, longname, wikiarticlepath, wikiapipath, enabled, defaultclose, defaultlanguage, 
+                    emailsender, notificationtarget
+                ) VALUES (
+                    :shortname, :longname, :wikiarticlepath, :wikiapipath, :enabled, :defaultclose, :defaultlanguage,
+                    :emailsender, :notificationtarget
+                );
+SQL
+            );
+
+            $statement->bindValue(":shortname", $this->shortname);
+            $statement->bindValue(":longname", $this->longname);
+            $statement->bindValue(":wikiarticlepath", $this->wikiarticlepath);
+            $statement->bindValue(":wikiapipath", $this->wikiapipath);
+            $statement->bindValue(":enabled", $this->enabled);
+            $statement->bindValue(":defaultclose", $this->defaultclose);
+            $statement->bindValue(":defaultlanguage", $this->defaultlanguage);
+            $statement->bindValue(":emailsender", $this->emailsender);
+            $statement->bindValue(":notificationtarget", $this->notificationtarget);
+
+            if ($statement->execute()) {
+                $this->id = (int)$this->dbObject->lastInsertId();
+            }
+            else {
+                throw new Exception($statement->errorInfo());
+            }
+        }
+        else {
+            $statement = $this->dbObject->prepare(<<<SQL
+                UPDATE domain SET
+                    longname = :longname,
+                    wikiarticlepath = :wikiarticlepath,
+                    wikiapipath = :wikiapipath,
+                    enabled = :enabled,
+                    defaultclose = :defaultclose,
+                    defaultlanguage = :defaultlanguage,
+                    emailsender = :emailsender,
+                    notificationtarget = :notificationtarget,
+                
+                    updateversion = updateversion + 1
+				WHERE id = :id AND updateversion = :updateversion;
+SQL
+            );
+
+            $statement->bindValue(":longname", $this->longname);
+            $statement->bindValue(":wikiarticlepath", $this->wikiarticlepath);
+            $statement->bindValue(":wikiapipath", $this->wikiapipath);
+            $statement->bindValue(":enabled", $this->enabled);
+            $statement->bindValue(":defaultclose", $this->defaultclose);
+            $statement->bindValue(":defaultlanguage", $this->defaultlanguage);
+            $statement->bindValue(":emailsender", $this->emailsender);
+            $statement->bindValue(":notificationtarget", $this->notificationtarget);
+
+            $statement->bindValue(':id', $this->id);
+            $statement->bindValue(':updateversion', $this->updateversion);
+
+            if (!$statement->execute()) {
+                throw new Exception($statement->errorInfo());
+            }
+
+            if ($statement->rowCount() !== 1) {
+                throw new OptimisticLockFailedException();
+            }
+
+            $this->updateversion++;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getShortName(): string
+    {
+        return $this->shortname;
+    }
+
+    /**
+     * @param string $shortName
+     */
+    public function setShortName(string $shortName): void
+    {
+        $this->shortname = $shortName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLongName(): string
+    {
+        return $this->longname;
+    }
+
+    /**
+     * @param string $longName
+     */
+    public function setLongName(string $longName): void
+    {
+        $this->longname = $longName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWikiArticlePath(): string
+    {
+        return $this->wikiarticlepath;
+    }
+
+    /**
+     * @param string $wikiArticlePath
+     */
+    public function setWikiArticlePath(string $wikiArticlePath): void
+    {
+        $this->wikiarticlepath = $wikiArticlePath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWikiApiPath(): string
+    {
+        return $this->wikiapipath;
+    }
+
+    /**
+     * @param string $wikiApiPath
+     */
+    public function setWikiApiPath(string $wikiApiPath): void
+    {
+        $this->wikiapipath = $wikiApiPath;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled == 1;
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public function setEnabled(bool $enabled): void
+    {
+        $this->enabled = $enabled ? 1 : 0;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDefaultClose(): ?int
+    {
+        return $this->defaultclose;
+    }
+
+    /**
+     * @param int $defaultClose
+     */
+    public function setDefaultClose(?int $defaultClose): void
+    {
+        $this->defaultclose = $defaultClose;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultLanguage(): string
+    {
+        return $this->defaultlanguage;
+    }
+
+    /**
+     * @param string $defaultLanguage
+     */
+    public function setDefaultLanguage(string $defaultLanguage): void
+    {
+        $this->defaultlanguage = $defaultLanguage;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmailSender(): string
+    {
+        return $this->emailsender;
+    }
+
+    /**
+     * @param string $emailSender
+     */
+    public function setEmailSender(string $emailSender): void
+    {
+        $this->emailsender = $emailSender;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNotificationTarget(): ?string
+    {
+        return $this->notificationtarget;
+    }
+
+    /**
+     * @param string|null $notificationTarget
+     */
+    public function setNotificationTarget(?string $notificationTarget): void
+    {
+        $this->notificationtarget = $notificationTarget;
+    }
+
+
+}

--- a/includes/DataObjects/RequestForm.php
+++ b/includes/DataObjects/RequestForm.php
@@ -1,0 +1,191 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\DataObjects;
+
+use Exception;
+use Waca\DataObject;
+use Waca\Exceptions\OptimisticLockFailedException;
+
+class RequestForm extends DataObject
+{
+    /** @var int */
+    private $enabled = 0;
+    /** @var int */
+    private $domain;
+    /** @var string */
+    private $name;
+    /** @var string */
+    private $publicendpoint;
+    /** @var string */
+    private $formcontent;
+    /** @var int|null */
+    private $overridequeue;
+
+    public function save()
+    {
+        if ($this->isNew()) {
+            // insert
+            $statement = $this->dbObject->prepare(<<<SQL
+                INSERT INTO requestform (
+                    enabled, domain, name, publicendpoint, formcontent, overridequeue
+                ) VALUES (
+                    :enabled, :domain, :name, :publicendpoint, :formcontent, :overridequeue
+                );
+SQL
+            );
+
+            $statement->bindValue(":enabled", $this->enabled);
+            $statement->bindValue(":domain", $this->domain);
+            $statement->bindValue(":name", $this->name);
+            $statement->bindValue(":publicendpoint", $this->publicendpoint);
+            $statement->bindValue(":formcontent", $this->formcontent);
+            $statement->bindValue(":overridequeue", $this->overridequeue);
+
+            if ($statement->execute()) {
+                $this->id = (int)$this->dbObject->lastInsertId();
+            }
+            else {
+                throw new Exception($statement->errorInfo());
+            }
+        }
+        else {
+            $statement = $this->dbObject->prepare(<<<SQL
+                UPDATE requestform SET
+                    enabled = :enabled,
+                    domain = :domain,
+                    name = :name,
+                    publicendpoint = :publicendpoint,
+                    formcontent = :formcontent,
+                    overridequeue = :overridequeue,
+                
+                    updateversion = updateversion + 1
+				WHERE id = :id AND updateversion = :updateversion;
+SQL
+            );
+
+            $statement->bindValue(":enabled", $this->enabled);
+            $statement->bindValue(":domain", $this->domain);
+            $statement->bindValue(":name", $this->name);
+            $statement->bindValue(":publicendpoint", $this->publicendpoint);
+            $statement->bindValue(":formcontent", $this->formcontent);
+            $statement->bindValue(":overridequeue", $this->overridequeue);
+
+            $statement->bindValue(':id', $this->id);
+            $statement->bindValue(':updateversion', $this->updateversion);
+
+            if (!$statement->execute()) {
+                throw new Exception($statement->errorInfo());
+            }
+
+            if ($statement->rowCount() !== 1) {
+                throw new OptimisticLockFailedException();
+            }
+
+            $this->updateversion++;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled == 1;
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public function setEnabled(bool $enabled): void
+    {
+        $this->enabled = $enabled ? 1 : 0;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDomain(): int
+    {
+        return $this->domain;
+    }
+
+    /**
+     * @param int $domain
+     */
+    public function setDomain(int $domain): void
+    {
+        $this->domain = $domain;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPublicEndpoint(): string
+    {
+        return $this->publicendpoint;
+    }
+
+    /**
+     * @param string $publicEndpoint
+     */
+    public function setPublicEndpoint(string $publicEndpoint): void
+    {
+        $this->publicendpoint = $publicEndpoint;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFormContent(): string
+    {
+        return $this->formcontent;
+    }
+
+    /**
+     * @param string $formContent
+     */
+    public function setFormContent(string $formContent): void
+    {
+        $this->formcontent = $formContent;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getOverrideQueue(): ?int
+    {
+        return $this->overridequeue;
+    }
+
+    /**
+     * @param int|null $overrideQueue
+     */
+    public function setOverrideQueue(?int $overrideQueue): void
+    {
+        $this->overridequeue = $overrideQueue;
+    }
+
+
+}

--- a/includes/DataObjects/RequestQueue.php
+++ b/includes/DataObjects/RequestQueue.php
@@ -1,0 +1,265 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\DataObjects;
+
+use Exception;
+use Waca\DataObject;
+use Waca\Exceptions\OptimisticLockFailedException;
+
+class RequestQueue extends DataObject
+{
+    /** @var int */
+    private $enabled = 0;
+    /** @var int */
+    private $isdefault = 0;
+    /** @var int */
+    private $domain;
+    /** @var string */
+    private $apiname;
+    /** @var string */
+    private $displayname;
+    /** @var string */
+    private $header;
+    /** @var string|null */
+    private $help;
+    /**
+     * @var string
+     * @deprecated Removal due as part of #607
+     */
+    private $logname;
+    /**
+     * @var string
+     * @deprecated Removal due as part of #602
+     */
+    private $legacystatus;
+
+
+    public function save()
+    {
+        if ($this->isNew()) {
+            // insert
+            $statement = $this->dbObject->prepare(<<<SQL
+                INSERT INTO requestqueue (
+                    enabled, isdefault, domain, apiname, displayname, header, help, logname, legacystatus
+                ) VALUES (
+                    :enabled, :isdefault, :domain, :apiname, :displayname, :header, :help, :logname, :legacystatus
+                );
+SQL
+            );
+
+            $statement->bindValue(":enabled", $this->enabled);
+            $statement->bindValue(":isdefault", $this->isdefault);
+            $statement->bindValue(":domain", $this->domain);
+            $statement->bindValue(":apiname", $this->apiname);
+            $statement->bindValue(":displayname", $this->displayname);
+            $statement->bindValue(":header", $this->header);
+            $statement->bindValue(":help", $this->help);
+            $statement->bindValue(":logname", $this->logname);
+            $statement->bindValue(":legacystatus", $this->legacystatus);
+
+            if ($statement->execute()) {
+                $this->id = (int)$this->dbObject->lastInsertId();
+            }
+            else {
+                throw new Exception($statement->errorInfo());
+            }
+        }
+        else {
+            $statement = $this->dbObject->prepare(<<<SQL
+                UPDATE requestqueue SET
+                    enabled = :enabled,
+                    isdefault = :isdefault,
+                    domain = :domain,
+                    apiname = :apiname,
+                    displayname = :displayname,
+                    header = :header,
+                    help = :help,
+                    logname = :logname,
+                    legacystatus = :legacystatus,
+                
+                    updateversion = updateversion + 1
+				WHERE id = :id AND updateversion = :updateversion;
+SQL
+            );
+
+            $statement->bindValue(":enabled", $this->enabled);
+            $statement->bindValue(":isdefault", $this->isdefault);
+            $statement->bindValue(":domain", $this->domain);
+            $statement->bindValue(":apiname", $this->apiname);
+            $statement->bindValue(":displayname", $this->displayname);
+            $statement->bindValue(":header", $this->header);
+            $statement->bindValue(":help", $this->help);
+            $statement->bindValue(":logname", $this->logname);
+            $statement->bindValue(":legacystatus", $this->legacystatus);
+
+            $statement->bindValue(':id', $this->id);
+            $statement->bindValue(':updateversion', $this->updateversion);
+
+            if (!$statement->execute()) {
+                throw new Exception($statement->errorInfo());
+            }
+
+            if ($statement->rowCount() !== 1) {
+                throw new OptimisticLockFailedException();
+            }
+
+            $this->updateversion++;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled == 1;
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public function setEnabled(bool $enabled): void
+    {
+        $this->enabled = $enabled ? 1 : 0;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDefault(): bool
+    {
+        return $this->isdefault == 1;
+    }
+
+    /**
+     * @param bool $isDefault
+     */
+    public function setDefault(bool $isDefault): void
+    {
+        $this->isdefault = $isDefault ? 1 : 0;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDomain(): int
+    {
+        return $this->domain;
+    }
+
+    /**
+     * @param int $domain
+     */
+    public function setDomain(int $domain): void
+    {
+        $this->domain = $domain;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApiName(): string
+    {
+        return $this->apiname;
+    }
+
+    /**
+     * @param string $apiName
+     */
+    public function setApiName(string $apiName): void
+    {
+        $this->apiname = $apiName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayName(): string
+    {
+        return $this->displayname;
+    }
+
+    /**
+     * @param string $displayName
+     */
+    public function setDisplayName(string $displayName): void
+    {
+        $this->displayname = $displayName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHeader(): string
+    {
+        return $this->header;
+    }
+
+    /**
+     * @param string $header
+     */
+    public function setHeader(string $header): void
+    {
+        $this->header = $header;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getHelp(): ?string
+    {
+        return $this->help;
+    }
+
+    /**
+     * @param string|null $help
+     */
+    public function setHelp(?string $help): void
+    {
+        $this->help = $help;
+    }
+
+    /**
+     * @return string
+     * @deprecated
+     */
+    public function getLogName(): string
+    {
+        return $this->logname;
+    }
+
+    /**
+     * @param string $logName
+     *
+     * @deprecated
+     */
+    public function setLogName(string $logName): void
+    {
+        $this->logname = $logName;
+    }
+
+    /**
+     * @return string
+     * @deprecated
+     */
+    public function getLegacyStatus(): string
+    {
+        return $this->legacystatus;
+    }
+
+    /**
+     * @param string $legacyStatus
+     *
+     * @deprecated
+     */
+    public function setLegacyStatus(string $legacyStatus): void
+    {
+        $this->legacystatus = $legacyStatus;
+    }
+}

--- a/includes/DataObjects/UserDomain.php
+++ b/includes/DataObjects/UserDomain.php
@@ -1,0 +1,84 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\DataObjects;
+
+use Exception;
+use Waca\DataObject;
+
+class UserDomain extends DataObject
+{
+    /** @var int */
+    private $user;
+
+    /** @var int */
+    private $domain;
+
+    public function save()
+    {
+        if ($this->isNew()) {
+            // insert
+            $statement = $this->dbObject->prepare(<<<SQL
+                INSERT INTO userdomain (
+                    user, domain
+                ) VALUES (
+                    :user, :domain
+                );
+SQL
+            );
+
+            $statement->bindValue(":user", $this->user);
+            $statement->bindValue(":domain", $this->domain);
+
+            if ($statement->execute()) {
+                $this->id = (int)$this->dbObject->lastInsertId();
+            }
+            else {
+                throw new Exception($statement->errorInfo());
+            }
+        }
+        else {
+            // insert / delete only, no updates please.
+            throw new Exception('Updating domain membership is not available');
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getUser(): int
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param int $user
+     */
+    public function setUser(int $user): void
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDomain(): int
+    {
+        return $this->domain;
+    }
+
+    /**
+     * @param int $domain
+     */
+    public function setDomain(int $domain): void
+    {
+        $this->domain = $domain;
+    }
+
+
+}

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -19,7 +19,7 @@ class SiteConfiguration
 {
     private $baseUrl;
     private $filePath;
-    private $schemaVersion = 35;
+    private $schemaVersion = 37;
     private $debuggingTraceEnabled;
     private $dataClearIp = '127.0.0.1';
     private $dataClearEmail = 'acc@toolserver.org';
@@ -379,6 +379,7 @@ class SiteConfiguration
 
     /**
      * @return array
+     * @deprecated
      */
     public function getRequestStates()
     {

--- a/maintenance/MigrateToDomains.php
+++ b/maintenance/MigrateToDomains.php
@@ -1,0 +1,25 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca;
+
+use Waca\ConsoleTasks\MigrateToDomains;
+
+chdir(__DIR__);
+chdir('..');
+
+require_once('config.inc.php');
+
+global $siteConfiguration;
+
+// Override required schema version for this script
+$siteConfiguration->setSchemaVersion(36);
+
+$application = new ConsoleStart($siteConfiguration, new MigrateToDomains());
+
+$application->run();

--- a/sql/patches/patch36-multisite-base.sql
+++ b/sql/patches/patch36-multisite-base.sql
@@ -1,0 +1,381 @@
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
+DELIMITER ';;'
+CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
+    -- -------------------------------------------------------------------------
+    -- Developers - set the number of the schema patch here!
+    -- -------------------------------------------------------------------------
+    DECLARE patchversion INT DEFAULT 36;
+    -- -------------------------------------------------------------------------
+    -- working variables
+    DECLARE currentschemaversion INT DEFAULT 0;
+    DECLARE lastversion INT;
+	
+    -- check the schema has a version table
+    IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'schemaversion' AND table_schema = DATABASE()) THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please ensure patches are run in order! This database does not have a schemaversion table.';
+    END IF;
+    
+    -- get the current version
+    SELECT version INTO currentschemaversion FROM schemaversion;
+    
+    -- check schema is not ahead of this patch
+    IF currentschemaversion >= patchversion THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'This patch has already been applied!';
+    END IF;
+    
+    -- check schema is up-to-date
+    SET lastversion = patchversion - 1;
+    IF currentschemaversion != lastversion THEN
+		SET @message_text = CONCAT('Please ensure patches are run in order! This patch upgrades to version ', patchversion, ', but the database is not version ', lastversion);
+        SIGNAL SQLSTATE '45000' SET message_text = @message_text;
+    END IF;
+
+    -- -------------------------------------------------------------------------
+    -- Developers - put your upgrade statements here!
+    -- -------------------------------------------------------------------------
+
+    -- ------------------------------------------------------------
+    -- temporarily drop foreign key constraints
+
+    alter table ban
+        drop constraint ban_user_id_fk;
+
+    alter table comment
+        drop constraint comment_request_id_fk,
+        drop constraint comment_user_id_fk;
+
+    alter table credential
+        drop constraint credential_user_id_fk;
+
+    alter table jobqueue
+        drop constraint jobqueue_emailtemplate_id_fk,
+        drop constraint jobqueue_parent_id_fk,
+        drop constraint jobqueue_request_id_fk,
+        drop constraint jobqueue_user_id_fk;
+
+    alter table oauthidentity
+        drop constraint oauthidentity_user_id_fk;
+
+    alter table oauthtoken
+        drop constraint oauthtoken_user_id_fk;
+
+    alter table user
+        drop constraint user_welcometemplate_id_fk;
+
+    alter table userrole
+        drop constraint userrole_user_id_fk;
+
+    -- ------------------------------------------------------------
+    -- modify column specifications to use unsigned integers / tinyints where appropriate
+
+    alter table antispoofcache
+        modify id int(11) unsigned auto_increment,
+        modify updateversion int(11) unsigned default 0 not null
+    ;
+
+    alter table applicationlog
+        modify id int(11) unsigned auto_increment
+    ;
+
+    alter table ban
+        modify id int(11) unsigned auto_increment,
+        modify active tinyint(1) unsigned default 1 not null,
+        modify updateversion int(11) unsigned default 0 not null,
+        modify user int(11) unsigned not null,
+        modify duration int(11) unsigned null
+    ;
+
+    alter table comment
+        modify id int(11) unsigned auto_increment,
+        modify user int(11) unsigned default 0 null,
+        modify request int(11) unsigned not null,
+        modify updateversion int(11) unsigned default 0 not null
+    ;
+
+    alter table credential
+        modify id int(11) unsigned auto_increment,
+        modify updateversion int(11) unsigned default 0 not null,
+        modify user int(11) unsigned not null,
+        modify factor int(11) unsigned default 1 not null,
+        modify version int(11) unsigned default 1 not null comment 'Version of the credential, used to determine if the storage method needs to be updated',
+        modify disabled tinyint(1) unsigned default 0 not null comment 'Flag determining whether this credential is in use. Used during 2FA setup, operationally useful for disabling 2FA for a user.',
+        modify priority int(1) unsigned default 5 null comment 'the order in which these credentials should be tested'
+    ;
+
+    alter table emailtemplate
+        modify id int(11) unsigned auto_increment comment 'Table key',
+        modify active tinyint(1) unsigned default 1 not null comment '1 if the template should be an available option to users. Default 1',
+        modify preloadonly tinyint(1) unsigned default 0 not null comment '1 if the template is only available as a custom close preload',
+        modify updateversion int(11) unsigned default 0 not null
+    ;
+
+    alter table geolocation
+        modify id int(11) unsigned auto_increment,
+        modify updateversion int(11) unsigned default 0 not null
+    ;
+
+    alter table jobqueue
+        modify id int(11) unsigned auto_increment,
+        modify updateversion int(11) unsigned default 0 not null,
+        modify user int(11) unsigned null,
+        modify request int(11) unsigned null,
+        modify emailtemplate int(11) unsigned null,
+        modify acknowledged tinyint(1) unsigned null comment 'flag indicating if a job error has been acknowledged',
+        modify parent int(11) unsigned null
+    ;
+
+    alter table log
+        modify id int(11) unsigned auto_increment,
+        modify objectid int(11) unsigned not null,
+        modify updateversion int(11) unsigned default 0 not null
+        -- the user column here is stupid, as it uses -1 for the community user. We should fix this, but not now. #607
+    ;
+
+    alter table oauthidentity
+        modify id int(11) unsigned auto_increment,
+        modify updateversion int(11) unsigned default 0 not null,
+        modify user int(11) unsigned not null,
+        modify sub int(11) unsigned not null comment 'centralauth user id',
+        modify editcount int(11) unsigned not null,
+        modify confirmed_email tinyint(1) unsigned not null,
+        modify blocked tinyint(1) unsigned not null,
+        modify checkuser tinyint(1) unsigned not null,
+        modify grantbasic tinyint(1) unsigned not null,
+        modify grantcreateaccount tinyint(1) unsigned not null,
+        modify granthighvolume tinyint(1) unsigned not null,
+        modify grantcreateeditmovepage tinyint(1) unsigned not null
+    ;
+
+    alter table oauthtoken
+        modify id int(11) unsigned auto_increment,
+        modify updateversion int(11) unsigned default 0 not null,
+        modify user int(11) unsigned not null
+    ;
+
+    alter table rdnscache
+        modify id int(11) unsigned auto_increment,
+        modify updateversion int(11) unsigned default 0 not null
+    ;
+
+    alter table request
+        modify id int(11) unsigned auto_increment,
+        modify reserved int(11) unsigned null comment 'User ID of user who has "reserved" this request',
+        modify updateversion int(11) unsigned default 0 not null
+    ;
+
+    alter table schemaversion
+        modify version int(11) unsigned default 10 not null
+    ;
+
+    alter table sitenotice
+        modify id int(11) unsigned auto_increment,
+        modify updateversion int(11) unsigned default 0 not null
+    ;
+
+    alter table tornodecache
+        modify id int(11) unsigned auto_increment,
+        modify updateversion int(11) unsigned default 0 not null,
+        modify exitport int(11) unsigned not null
+    ;
+
+    alter table user
+        modify id int(11) unsigned auto_increment,
+        modify forcelogout tinyint(1) unsigned default 0 not null comment 'flag indicating all user sessions should be invalidated',
+        modify forceidentified tinyint(1) unsigned null comment 'flag forcing the identification status of a user.',
+        modify welcome_template int(11) unsigned null,
+        modify abortpref tinyint(1) unsigned default 0 not null comment 'flag indicating whether JS notifications are used on request closure',
+        modify updateversion int(11) unsigned default 0 not null,
+        modify creationmode int(11) unsigned default 0 not null comment 'flag indicating manual/oauth/bot creation'
+    ;
+
+    alter table userrole
+        modify id int(11) unsigned auto_increment,
+        modify user int(11) unsigned not null,
+        modify updateversion int(11) unsigned default 0 not null
+    ;
+
+    alter table welcometemplate
+        modify id int(11) unsigned auto_increment,
+        modify updateversion int(11) unsigned default 0 not null,
+        modify deleted tinyint(1) unsigned default 0 not null
+    ;
+
+    alter table xfftrustcache
+        modify id int(11) unsigned auto_increment
+    ;
+
+    -- ------------------------------------------------------------
+    -- restore dropped constraints
+
+    alter table ban
+        add constraint ban_user_id_fk FOREIGN KEY (user) REFERENCES user (id)
+    ;
+
+    alter table comment
+        add constraint comment_request_id_fk FOREIGN KEY (request) REFERENCES request (id),
+        add constraint comment_user_id_fk FOREIGN KEY (user) REFERENCES user (id)
+    ;
+
+    alter table credential
+        add constraint credential_user_id_fk FOREIGN KEY (user) REFERENCES user (id)
+    ;
+
+    alter table jobqueue
+        add constraint jobqueue_emailtemplate_id_fk FOREIGN KEY (emailtemplate) REFERENCES emailtemplate (id),
+        add constraint jobqueue_parent_id_fk FOREIGN KEY (parent) REFERENCES jobqueue (id),
+        add constraint jobqueue_request_id_fk FOREIGN KEY (request) REFERENCES request (id),
+        add constraint jobqueue_user_id_fk FOREIGN KEY (user) REFERENCES user (id)
+    ;
+
+    alter table oauthidentity
+        add constraint oauthidentity_user_id_fk FOREIGN KEY (user) REFERENCES user (id)
+    ;
+
+    alter table oauthtoken
+        add constraint oauthtoken_user_id_fk foreign key (user) references user (id)
+    ;
+
+    alter table user
+        add constraint user_welcometemplate_id_fk foreign key (welcome_template) references welcometemplate (id)
+    ;
+
+    alter table userrole
+        add constraint userrole_user_id_fk foreign key (user) references user (id)
+    ;
+
+    -- ------------------------------------------------------------
+    -- drop deprecated/unused columns
+
+    # noinspection SqlResolve @ column/"oncreated"
+    alter table emailtemplate
+        drop column oncreated
+    ;
+
+    -- ------------------------------------------------------------
+    -- add new missing constraints
+
+    alter table ban
+        add constraint ban_active check (active in (0,1))
+    ;
+
+    alter table credential
+        add constraint credential_disabled check (disabled in (0,1))
+    ;
+
+    alter table emailtemplate
+        add constraint emailtemplate_active check (active in (0,1))
+    ;
+
+    alter table jobqueue
+        add constraint jobqueue_acknowledged check (acknowledged in (0,1))
+    ;
+
+    alter table oauthidentity
+        add constraint oauthidentity_confirmed_email check (confirmed_email in (0,1)),
+        add constraint oauthidentity_blocked check (blocked in (0,1)),
+        add constraint oauthidentity_checkuser check (checkuser in (0,1)),
+        add constraint oauthidentity_grantbasic check (grantbasic in (0,1)),
+        add constraint oauthidentity_grantcreateaccount check (grantcreateaccount in (0,1)),
+        add constraint oauthidentity_granthighvolume check (granthighvolume in (0,1)),
+        add constraint oauthidentity_grantcreateeditmovepage check (grantcreateeditmovepage in (0,1))
+    ;
+
+    alter table request
+        add constraint request_user_id_fk foreign key (reserved) references user (id)
+    ;
+
+    alter table user
+        add constraint user_forcelogout check (forcelogout in (0,1)),
+        add constraint user_forceidentified check (forceidentified in (0,1)),
+        add constraint user_abortpref check (abortpref in (0,1)),
+        add constraint user_creationmode check (creationmode in (0,1,2))
+    ;
+
+    alter table welcometemplate
+        add constraint welcometemplate_deleted check (deleted in (0,1))
+    ;
+
+    -- ------------------------------------------------------------
+    -- add tables for multiproject work
+
+    create table domain
+    (
+        id int unsigned auto_increment primary key,
+        updateversion int unsigned default 0 not null,
+        shortname varchar(20) not null comment 'short identifier such as database name, eg enwiki or bnwiki',
+        longname varchar(255) not null comment 'long name of the wiki, such as English Wikipedia',
+        wikiarticlepath varchar(255) not null comment 'https://en.wikipedia.org/wiki/',
+        wikiapipath varchar(255) not null comment 'https://en.wikipedia.org/w/api.php',
+        enabled tinyint unsigned default 0 not null,
+        defaultclose int unsigned null comment 'the default "created" close template to use',
+        defaultlanguage varchar(10) not null default 'en' comment 'the iso language code for users created in this domain',
+        emailsender varchar(255) not null comment 'the from/sender address of the mailing list, for users to reply with',
+        notificationtarget varchar(255) null comment 'the helpmebot target of the notifications from this domain',
+        constraint domain_emailtemplate_id_fk foreign key (defaultclose) references emailtemplate (id),
+        constraint domain_wikiarticlepath_uniq unique (wikiarticlepath),
+        constraint domain_wikiapipath_uniq unique (wikiapipath),
+        constraint domain_enabled check (enabled in (0,1))
+    ) engine=InnoDB;
+
+    create unique index domain_shortname_uindex on domain (shortname);
+
+    create table userdomain
+    (
+        id int unsigned auto_increment primary key,
+        updateversion int unsigned default 0 not null,
+        user int unsigned not null,
+        domain int unsigned not null,
+        constraint userdomain_domain_id_fk foreign key (domain) references domain (id),
+        constraint userdomain_user_id_fk foreign key (user) references user (id)
+    ) engine=InnoDB;
+
+    create unique index userdomain_user_domain_uindex on userdomain (user, domain);
+
+    create table requestqueue
+    (
+        id int unsigned auto_increment primary key,
+        updateversion int unsigned default 0 not null,
+        enabled tinyint unsigned default 0 not null,
+        isdefault tinyint unsigned default 0 not null comment 'whether this is the default queue for the domain. only one set per domain',
+        domain int unsigned not null,
+        apiname varchar(20) not null comment 'the name used in the api and for JS calls',
+        displayname varchar(100) not null comment 'the display name in the GUI',
+        header varchar(100) not null comment 'accordion/group name',
+        help text null comment 'help text to be displayed under the queue',
+        logname varchar(50) not null comment 'name used in logs, to be removed in issue #607',
+        legacystatus varchar(40) not null comment 'old status value from legacy request table, to be removed in issue #602',
+        constraint requestqueue_header_uniq unique (domain, header),
+        constraint requestqueue_apiname_uniq unique (domain, apiname),
+        constraint requestqueue_displayname_uniq unique (domain, displayname),
+        constraint requestqueue_domain_id_fk foreign key (domain) references domain (id),
+        constraint requestqueue_isdefault check (isdefault in (0,1)),
+        constraint requestqueue_enabled check (enabled in (0,1)),
+        constraint requestqueue_defaultisenabled check (case when isdefault = 1 and enabled = 0 then false else true end)
+    ) engine=InnoDB;
+
+    create table requestform
+    (
+        id int unsigned auto_increment primary key ,
+        updateversion int unsigned default 0 not null,
+        enabled tinyint unsigned default 0 not null,
+        domain int unsigned not null,
+        name varchar(255) not null comment 'display name of the form for identification in the UI',
+        publicendpoint varchar(64) not null comment 'public URL segment of the form',
+        formcontent longtext not null comment 'text content of the form',
+        overridequeue int unsigned null comment 'override the default queue to send this request to',
+        constraint requestform_domain_id_fk foreign key (domain) references domain (id),
+        constraint requestform_requestqueue_id_fk foreign key (overridequeue) references requestqueue (id),
+        constraint requestform_enabled check (enabled in (0,1)),
+        constraint requestform_name unique (domain, name)
+    ) engine=InnoDB;
+
+    create unique index requestform_publicendpoint_uindex on requestform (publicendpoint);
+
+    -- -------------------------------------------------------------------------
+    -- finally, update the schema version to indicate success
+    # noinspection SqlWithoutWhere
+    UPDATE schemaversion SET version = patchversion;
+END;;
+DELIMITER ';'
+CALL SCHEMA_UPGRADE_SCRIPT();
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;

--- a/sql/patches/patch37-domainmigration.sql
+++ b/sql/patches/patch37-domainmigration.sql
@@ -1,0 +1,82 @@
+-- -----------------------------------------------------------------------------
+-- Hey!
+-- 
+-- This is a new patch-creation script which SHOULD stop double-patching and
+-- running patches out-of-order.
+--
+-- If you're running patches, please close this file, and run this from the 
+-- command line:
+--   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
+-- where:
+--      USERNAME = a user with CREATE/ALTER access to the schema
+--      SCHEMA = the schema to run the changes against
+--      patch-XX-this-file.sql = this file
+--
+-- If you are writing patches, you need to copy this template to a numbered 
+-- patch file, update the patchversion variable, and add the SQL code to upgrade
+-- the database where indicated below.
+
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
+DELIMITER ';;'
+CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
+    -- -------------------------------------------------------------------------
+    -- Developers - set the number of the schema patch here!
+    -- -------------------------------------------------------------------------
+    DECLARE patchversion INT DEFAULT 37;
+    DECLARE userCount INT;
+    DECLARE initialUser VARCHAR(255);
+    -- -------------------------------------------------------------------------
+    -- working variables
+    DECLARE currentschemaversion INT DEFAULT 0;
+    DECLARE lastversion INT;
+	
+    -- check the schema has a version table
+    IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'schemaversion' AND table_schema = DATABASE()) THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please ensure patches are run in order! This database does not have a schemaversion table.';
+    END IF;
+    
+    -- get the current version
+    SELECT version INTO currentschemaversion FROM schemaversion;
+    
+    -- check schema is not ahead of this patch
+    IF currentschemaversion >= patchversion THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'This patch has already been applied!';
+    END IF;
+    
+    -- check schema is up-to-date
+    SET lastversion = patchversion - 1;
+    IF currentschemaversion != lastversion THEN
+		SET @message_text = CONCAT('Please ensure patches are run in order! This patch upgrades to version ', patchversion, ', but the database is not version ', lastversion);
+        SIGNAL SQLSTATE '45000' SET message_text = @message_text;
+    END IF;
+
+    -- -------------------------------------------------------------------------
+    -- Developers - put your upgrade statements here!
+    -- -------------------------------------------------------------------------
+
+    SELECT username INTO initialUser FROM user WHERE id = 1;
+    SELECT COUNT(*) INTO userCount FROM user;
+
+    IF initialUser = 'Admin' AND userCount = 1 THEN
+        INSERT INTO domain (shortname, longname, wikiarticlepath, wikiapipath, enabled, defaultclose, defaultlanguage, emailsender, notificationtarget)
+        VALUES ('enwiki', 'English Wikipedia', 'https://en.wikipedia.org/wiki/', 'https://en.wikipedia.org/w/api.php', 1, 1, 'en', 'accounts-enwiki-l@lists.wikimedia.org', 1);
+
+        INSERT INTO requestqueue (enabled, isdefault, domain, apiname, displayname, header, help, logname, legacystatus)
+        VALUES (1, 1, 1, 'open', 'users', 'Open requests', null, 'users', 'Open');
+
+        INSERT INTO requestqueue (enabled, isdefault, domain, apiname, displayname, header, help, logname, legacystatus)
+        VALUES (1, 0, 1, 'admin', 'flagged users', 'Flagged user needed', 'This queue lists the requests which require a user with the accountcreator flag to create.\n\nIf creation is determined to be the correct course of action, requests here will require the overriding the AntiSpoof checks or the title blacklist in order to create. It is recommended to try to create the account *without* checking the flags to validate the results of the AntiSpoof and/or title blacklist hits.', 'flagged users', 'Flagged users');
+
+        INSERT INTO requestqueue (enabled, isdefault, domain, apiname, displayname, header, help, logname, legacystatus)
+        VALUES (1, 0, 1, 'checkuser', 'checkusers', 'Checkuser needed', null, 'checkusers', 'Checkuser');
+
+        # noinspection SqlWithoutWhere
+        UPDATE schemaversion SET version = patchversion;
+    ELSE
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please run the MigrateToDomains.php maintenance job to perform the migration!';
+    END IF;
+
+END;;
+DELIMITER ';'
+CALL SCHEMA_UPGRADE_SCRIPT();
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;


### PR DESCRIPTION
* Adds four database tables for domains, request queues, and request
  forms
* Adds migration to populate domains and queue from configuration
* Changes the datatype of a lot of integers to an unsigned int
* Drop an unneeded column from emailtemplate
* Add a couple of missing foreign keys
* Add a lot of missing check constraints (now we're on MariaDB 10.3)

This is a sizable database migration due to the number of tables this is
touching.

Closes #590