### PR TITLE
Flag uncommon email domains from list in config

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -251,6 +251,8 @@ $totpEncryptionKey = "1234";
 // external resource cache epoch value. Bump me to force clients to reload assets
 $resourceCacheEpoch = 1;
 
+$commonEmailDomains = ['gmail.com', 'hotmail.com', 'outlook.com'];
+
 /**************************************************************************
  **********                   IMPORTANT NOTICE                    **********
  ***************************************************************************
@@ -365,4 +367,5 @@ $siteConfiguration->setBaseUrl($baseurl)
     ->setRegistrationAllowed($allowRegistration)
     ->setCspReportUri($cspReportUri)
     ->setResourceCacheEpoch($resourceCacheEpoch)
-    ->setLocationProviderApiKey($locationProviderApiKey);
+    ->setLocationProviderApiKey($locationProviderApiKey)
+    ->setCommonEmailDomains($commonEmailDomains);

--- a/includes/Fragments/RequestData.php
+++ b/includes/Fragments/RequestData.php
@@ -169,15 +169,18 @@ trait RequestData
      * Adds private request data to Smarty. DO NOT USE WITHOUT FIRST CHECKING THAT THE USER IS AUTHORISED!
      *
      * @param Request           $request
+     * @param SiteConfiguration $configuration
      */
     protected function setupPrivateData(
-        $request
+        $request,
+        SiteConfiguration $configuration
     ) {
         $xffProvider = $this->getXffTrustProvider();
 
         $this->assign('requestEmail', $request->getEmail());
         $emailDomain = explode("@", $request->getEmail())[1];
         $this->assign("emailurl", $emailDomain);
+        $this->assign('commonEmailDomain', in_array($emailDomain, $configuration->getCommonEmailDomains()));
 
         $trustedIp = $xffProvider->getTrustedClientIp($request->getIp(), $request->getForwardedIp());
         $this->assign('requestTrustedIp', $trustedIp);

--- a/includes/Fragments/RequestListData.php
+++ b/includes/Fragments/RequestListData.php
@@ -73,6 +73,9 @@ trait RequestListData
             $requestList->requestTrustedIp[$request->getId()] = $trustedIp;
             $requestList->relatedEmailRequests[$request->getId()] = $emailCount;
             $requestList->relatedIpRequests[$request->getId()] = $ipCount;
+
+            $emailDomain = explode("@", $request->getEmail())[1];
+            $requestList->commonEmail[$request->getId()] = in_array($emailDomain, $this->getSiteConfiguration()->getCommonEmailDomains());
         }
 
         $currentUser = User::getCurrent($this->getDatabase());

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -90,7 +90,7 @@ class PageViewRequest extends InternalPageBase
 
         if ($allowedPrivateData) {
             $this->setTemplate('view-request/main-with-data.tpl');
-            $this->setupPrivateData($request);
+            $this->setupPrivateData($request, $config);
 
             $this->assign('canSetBan', $this->barrierTest('set', $currentUser, PageBan::class));
             $this->assign('canSeeCheckuserData', $this->barrierTest('seeUserAgentData', $currentUser, 'RequestData'));

--- a/includes/Pages/RequestAction/PageCustomClose.php
+++ b/includes/Pages/RequestAction/PageCustomClose.php
@@ -132,7 +132,7 @@ class PageCustomClose extends PageCloseRequest
         $this->assign('updateVersion', $request->getUpdateVersion());
         $this->setupBasicData($request, $config);
         $this->setupReservationDetails($request->getReserved(), $database, $currentUser);
-        $this->setupPrivateData($request);
+        $this->setupPrivateData($request, $config);
         $this->setupRelatedRequests($request, $config, $database);
 
         // IP location

--- a/includes/RequestList.php
+++ b/includes/RequestList.php
@@ -26,4 +26,5 @@ class RequestList
     public $canBan;
     public $canBreakReservation;
     public $userList;
+    public $commonEmail;
 }

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -91,6 +91,7 @@ class SiteConfiguration
     private $registrationAllowed = true;
     private $cspReportUri = null;
     private $resourceCacheEpoch = 1;
+    private $commonEmailDomains = [];
 
     /**
      * Gets the base URL of the tool
@@ -1048,6 +1049,26 @@ class SiteConfiguration
     public function setResourceCacheEpoch(int $resourceCacheEpoch): SiteConfiguration
     {
         $this->resourceCacheEpoch = $resourceCacheEpoch;
+
+        return $this;
+}
+
+    /**
+     * @return array
+     */
+    public function getCommonEmailDomains(): array
+    {
+        return $this->commonEmailDomains;
+    }
+
+    /**
+     * @param array $commonEmailDomains
+     *
+     * @return SiteConfiguration
+     */
+    public function setCommonEmailDomains(array $commonEmailDomains): SiteConfiguration
+    {
+        $this->commonEmailDomains = $commonEmailDomains;
 
         return $this;
 }

--- a/resources/scss/_common.scss
+++ b/resources/scss/_common.scss
@@ -85,3 +85,6 @@ td.table-button-cell {
     min-width: 20px;
 }
 
+.badge-pill svg.svg-inline--fa.fa-w-16 {
+    min-width: 1.2em;
+}

--- a/templates/mainpage/requesttable.tpl
+++ b/templates/mainpage/requesttable.tpl
@@ -40,6 +40,7 @@
                         >
                             {$list->relatedEmailRequests[$r->getId()]}
                         </span>
+                        {if !$list->commonEmail[$r->getId()]}<span class="badge badge-warning badge-pill" data-toggle="tooltip" title="Uncommon email domain"><i class="fas fa-gem"></i></span>{/if}
                     {/if}
                 </td>
 

--- a/templates/mainpage/requesttable.tpl
+++ b/templates/mainpage/requesttable.tpl
@@ -35,11 +35,13 @@
                         <span class="text-muted font-italic">Email address purged</span>
                     {else}
                         {$r->getEmail()|escape}
-                        <span class="badge badge-pill {if $list->relatedEmailRequests[$r->getId()] > 0}badge-danger{else}badge-secondary{/if}"
-                            data-toggle="tooltip" data-original-title="{$list->relatedEmailRequests[$r->getId()]} other request(s) from this email address"
-                        >
-                            {$list->relatedEmailRequests[$r->getId()]}
-                        </span>
+                        {if $list->relatedEmailRequests[$r->getId()] > 0}
+                            <span class="badge badge-pill badge-danger"
+                                data-toggle="tooltip" data-original-title="{$list->relatedEmailRequests[$r->getId()]} other request(s) from this email address"
+                            >
+                                <i class="fas fa-clone"></i>&nbsp;{$list->relatedEmailRequests[$r->getId()]}
+                            </span>
+                        {/if}
                         {if !$list->commonEmail[$r->getId()]}<span class="badge badge-warning badge-pill" data-toggle="tooltip" title="Uncommon email domain"><i class="fas fa-gem"></i></span>{/if}
                     {/if}
                 </td>
@@ -50,11 +52,13 @@
                         <span class="text-muted font-italic">IP address purged</span>
                     {else}
                         <a href="https://en.wikipedia.org/wiki/User_talk:{$list->requestTrustedIp[$r->getId()]|escape}" target="_blank">{$list->requestTrustedIp[$r->getId()]|escape}</a>
-                        <span class="badge badge-pill {if $list->relatedIpRequests[$r->getId()] > 0}badge-danger{else}badge-secondary{/if}"
-                              data-toggle="tooltip" data-original-title="{$list->relatedIpRequests[$r->getId()]} other request(s) from this IP address"
-                        >
-                            {$list->relatedIpRequests[$r->getId()]}
-                        </span>
+                        {if $list->relatedIpRequests[$r->getId()] > 0}
+                            <span class="badge badge-pill badge-danger"
+                                  data-toggle="tooltip" data-original-title="{$list->relatedIpRequests[$r->getId()]} other request(s) from this IP address"
+                            >
+                                <i class="fas fa-clone"></i>&nbsp;{$list->relatedIpRequests[$r->getId()]}
+                            </span>
+                        {/if}
                     {/if}
                 </td>
             {/if}

--- a/templates/view-request/request-private-data.tpl
+++ b/templates/view-request/request-private-data.tpl
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col-md-4">
             <strong>Email address:</strong>
-            <span class="float-right ml-1 badge{if $requestRelatedEmailRequestsCount > 0} badge-danger{else} badge-secondary{/if} badge-pill">{$requestRelatedEmailRequestsCount}</span>
+            {if $requestRelatedEmailRequestsCount > 0}<span class="float-right ml-1 badge badge-danger badge-pill" data-toggle="tooltip" title="{$requestRelatedEmailRequestsCount} other request(s) from this email address"><i class="fas fa-clone"></i>&nbsp;{$requestRelatedEmailRequestsCount}</span>{/if}
             {if !$commonEmailDomain}<span class="float-right ml-1 badge badge-warning" data-toggle="tooltip" title="The domain name of this email address is not from a common provider. Look out for potential COI issues."><i class="fas fa-gem"></i>Uncommon</span>{/if}
         </div>
         <div class="col-md-8">
@@ -16,7 +16,7 @@
     <div class="row">
         <div class="col-md-4">
             <strong>IP address:</strong>
-            <span class="float-right ml-1 badge{if $requestRelatedIpRequestsCount > 0} badge-danger{else} badge-secondary{/if} badge-pill">{$requestRelatedIpRequestsCount}</span>
+            {if $requestRelatedIpRequestsCount > 0}<span class="float-right ml-1 badge badge-danger badge-pill" data-toggle="tooltip" title="{$requestRelatedIpRequestsCount} other request(s) from this IP address"><i class="fas fa-clone"></i>&nbsp;{$requestRelatedIpRequestsCount}</span>{/if}
         </div>
         <div class="col-md-8">
             {if !$requestDataCleared}

--- a/templates/view-request/request-private-data.tpl
+++ b/templates/view-request/request-private-data.tpl
@@ -3,6 +3,7 @@
         <div class="col-md-4">
             <strong>Email address:</strong>
             <span class="float-right ml-1 badge{if $requestRelatedEmailRequestsCount > 0} badge-danger{else} badge-secondary{/if} badge-pill">{$requestRelatedEmailRequestsCount}</span>
+            {if !$commonEmailDomain}<span class="float-right ml-1 badge badge-warning" data-toggle="tooltip" title="The domain name of this email address is not from a common provider. Look out for potential COI issues."><i class="fas fa-gem"></i>Uncommon</span>{/if}
         </div>
         <div class="col-md-8">
             {if !$requestDataCleared}


### PR DESCRIPTION
I've added this flag to the summary on the zoom page, and also as a small flag on the request table for when private data is shown on the table.

I've also taken the opportunity to slightly redesign the related requests flag. We no longer show this when the count is zero, and we also now include an icon to let it fit in slightly better.

On the view request page, this now looks like this (where there are no other requests from this IP address, but one from the email address):

![image](https://user-images.githubusercontent.com/722710/97785162-3c457d80-1b9b-11eb-9963-1232f70b5bec.png)

On the request list page (in admin view):

![image](https://user-images.githubusercontent.com/722710/97785245-bd047980-1b9b-11eb-8024-ee06b459b15e.png)

I suspect the design choices here will change again when we look at #425, but I think this is iterates in the right direction.

This fixes #469