### PR TITLE
Fix cleanup of non-email-confirmed requests

### DIFF
--- a/includes/ConsoleTasks/OldRequestCleanupTask.php
+++ b/includes/ConsoleTasks/OldRequestCleanupTask.php
@@ -1,4 +1,5 @@
-<?php
+<?php /** @noinspection SqlConstantCondition */
+
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
  *                                                                            *
@@ -8,24 +9,154 @@
 
 namespace Waca\ConsoleTasks;
 
+use Waca\PdoDatabase;
 use Waca\Tasks\ConsoleTaskBase;
 
 class OldRequestCleanupTask extends ConsoleTaskBase
 {
     public function execute()
     {
-        $statement = $this->getDatabase()->prepare(<<<SQL
+        $database = $this->getDatabase();
+        $expiryTime = [':expiry' => $this->getSiteConfiguration()->getEmailConfirmationExpiryDays()];
+
+        // start by fetching the number of unconfirmed requests which have expired
+        $eligibleRecords = $this->getExpiredCount($database, $expiryTime);
+
+        // fetch the number of unconfirmed requests which have expired and which have no FK constraints which would
+        // otherwise prevent their deletion
+        $eligibleUnconstrainedRecords = $this->getExpiredUnconstrainedCount($database, $expiryTime);
+
+        // Delete any requester comments for expired requests
+        $requesterCommentDelete = <<<SQL
+            DELETE FROM comment
+            WHERE 1 = 1 
+                -- only requester comments
+                AND comment.visibility = 'requester'
+                -- where the following record exists
+                AND exists(
+                    SELECT 1 FROM request r
+                    WHERE 1 = 1
+                        -- a request matching the currently-checked comment
+                        AND comment.request = r.id
+                        -- and the request is expired
+                        AND r.date < DATE_SUB(CURRENT_TIMESTAMP(), INTERVAL :expiry DAY)
+                        -- no confirmed email address
+                        AND r.emailconfirm <> 'Confirmed'
+                        -- not already marked as stale
+                        AND r.emailconfirm <> 'Stale'
+                        -- email confirmation was requested
+                        AND r.emailconfirm <> ''
+                        -- no non-requester comments exist (nobody has commented on the request)
+                        AND NOT exists (SELECT 1 FROM comment c2 WHERE c2.request = r.id AND c2.visibility <> 'requester')
+                        -- no jobqueue entries for this request exist
+                        AND NOT exists (SELECT 1 FROM jobqueue j WHERE j.request = r.id)
+                        -- no log entries for this request exist
+                        AND NOT exists (SELECT 1 FROM log l WHERE l.objectid = r.id and l.objecttype = 'Request')
+                );
+SQL;
+        $statement = $database->prepare($requesterCommentDelete);
+        $statement->execute($expiryTime);
+        $deletedComments = $statement->rowCount();
+
+        // Delete any expired requests with no remaining FK constraints
+        $requestDelete = <<<SQL
             DELETE FROM request
-            WHERE
-                request.date < DATE_SUB(CURRENT_TIMESTAMP(), INTERVAL :expiry DAY)
-                AND request.emailconfirm != 'Confirmed'
-                AND request.emailconfirm != ''
-                AND NOT exists (SELECT 1 FROM comment c WHERE c.request = request.id)
+            WHERE 1 = 1
+              -- request date older than X days ago
+              AND request.date < DATE_SUB(CURRENT_TIMESTAMP(), INTERVAL :expiry DAY)
+              -- no confirmed email address
+              AND request.emailconfirm <> 'Confirmed'
+              -- not already marked as stale
+              AND request.emailconfirm <> 'Stale'
+              -- email confirmation was requested
+              AND request.emailconfirm <> ''
+              -- no comments exist (we just deleted requester comments)
+              AND NOT exists(SELECT 1 FROM comment c WHERE c.request = request.id)
+              -- no jobqueue entries for this request exist
+              AND NOT exists(SELECT 1 FROM jobqueue j WHERE j.request = request.id)
+              -- no log entries for this request exist
+              AND NOT exists(SELECT 1 FROM log l WHERE l.objectid = request.id and l.objecttype = 'Request');
+SQL;
+        $statement = $database->prepare($requestDelete);
+        $statement->execute($expiryTime);
+        $deletedRequests = $statement->rowCount();
+
+        // We've deleted all we can sensibly get away with. Disable the ability to email-confirm requests, and close
+        // them as stale. The purge job will pick up the clearing of any private data.
+        // Note - *very* few requests should get this far; it normally means a tool admin has overridden the
+        // email-confirmation lockout and done something to the non-confirmed request.
+
+        $splatExpired = <<<SQL
+            UPDATE request 
+                SET emailconfirm = 'Stale', status = 'Closed', updateversion = updateversion + 1
+            WHERE 1 = 1
+                AND request.date < DATE_SUB(CURRENT_TIMESTAMP(), INTERVAL :expiry DAY)
+                AND request.emailconfirm <> 'Confirmed'
+                AND request.emailconfirm <> 'Stale'
+                AND request.emailconfirm <> ''
+            ;
+SQL;
+
+        $statement = $database->prepare($splatExpired);
+        $statement->execute($expiryTime);
+        $requestsMarkedStale = $statement->rowCount();
+
+        // All done.
+        $database->commit();
+
+        printf('Cleanup: %d expired; %d unconstrained, %d comments deleted, %d requests deleted, %d marked stale',
+            $eligibleRecords, $eligibleUnconstrainedRecords, $deletedComments, $deletedRequests, $requestsMarkedStale);
+    }
+
+    private function getExpiredCount(PdoDatabase $database, array $expiryTime)
+    {
+        $statement = $database->prepare(<<<SQL
+            SELECT COUNT(*) FROM request r
+            WHERE 1 = 1 
+              -- request date older than X days ago
+              AND r.date < DATE_SUB(CURRENT_TIMESTAMP(), INTERVAL :expiry DAY)
+              -- no confirmed email address
+              AND r.emailconfirm <> 'Confirmed'
+              -- not already marked as stale
+              AND r.emailconfirm <> 'Stale'
+              -- email confirmation was requested
+              AND r.emailconfirm <> '';
 SQL
         );
 
-        $expiryTime = $this->getSiteConfiguration()->getEmailConfirmationExpiryDays();
-        $statement->bindValue(':expiry', $expiryTime);
-        $statement->execute();
+        $statement->execute($expiryTime);
+        $eligibleRecords = $statement->fetchColumn();
+        $statement->closeCursor();
+
+        return $eligibleRecords;
+    }
+
+    private function getExpiredUnconstrainedCount(PdoDatabase $database, array $expiryTime)
+    {
+        $statement = $database->prepare(<<<SQL
+            SELECT COUNT(*) FROM request r
+            WHERE 1 = 1 
+                -- request date older than X days ago
+                AND r.date < DATE_SUB(CURRENT_TIMESTAMP(), INTERVAL :expiry DAY)
+                -- no confirmed email address
+                AND r.emailconfirm <> 'Confirmed'
+                -- not already marked as stale
+                AND r.emailconfirm <> 'Stale'
+                -- email confirmation was requested
+                AND r.emailconfirm <> ''
+                -- no comments for this request exist
+                AND NOT exists(SELECT 1 FROM comment c WHERE c.request = r.id)
+                -- no jobqueue entries for this request exist
+                AND NOT exists(SELECT 1 FROM jobqueue j WHERE j.request = r.id)
+                -- no log entries for this request exist
+                AND NOT exists(SELECT 1 FROM log l WHERE l.objectid = r.id AND l.objecttype = 'Request');
+SQL
+        );
+
+        $statement->execute($expiryTime);
+        $eligibleRecords = $statement->fetchColumn();
+        $statement->closeCursor();
+
+        return $eligibleRecords;
     }
 }


### PR DESCRIPTION
The old version didn't take into account comments being left on requests either by a requester or by tool users.

This meant that these requests would sit and not be deleted by the script which runs every night to clean up non-confirmed requests. In addition, because these requests were marked as "Open", these requests wouldn't have private data cleared from them either.

Now we take the approach of deleting requester comments when there are no other constraints which would prevent a request deletion, and when there are constraints which prevent deletion, we instead mark the request as closed, and "stale" to prevent an email confirmation from succeeding. The number of requests this affects should be close to zero though, because it requires a tool admin to explicitly override the email-confirmation lockout and add a comment or affect a request in such a way which adds a log entry (or a job queue entry).

We don't actually clear private data from "stale" requests immediately either; private data will only be cleared from unconfirmed requests once they are  `MAX(email-confirmation timeout, private data purge timeout)` old, which I think is acceptable.