### PR TITLE
Revoke password reset tokens on login

### DIFF
--- a/templates/forgot-password/reset-mail.tpl
+++ b/templates/forgot-password/reset-mail.tpl
@@ -1,5 +1,5 @@
 ﻿Hello! You, or a user from {$remoteAddress}, has requested a password reset for your account.
 
-Please go to {$baseurl}/internal.php/forgotPassword/reset?si={$hash}&id={$user->getId()} to complete this request.
+Please go to {$baseurl}/internal.php/forgotPassword/reset?si={$hash}&id={$user->getId()} to complete this request. This link will expire in one hour.
 
-If you did not request this reset, please disregard this message.
+If you did not request this reset, you can disregard this message. Logging in to the tool with your current password will cancel this request.


### PR DESCRIPTION
This will revoke when the user logs in with their existing password, thus proving that they know their password and do not require a reset.

Fixes #648