### PR TITLE
Support auto-creation for custom closes

### DIFF
--- a/includes/Pages/PageJobQueue.php
+++ b/includes/Pages/PageJobQueue.php
@@ -8,6 +8,8 @@
 
 namespace Waca\Pages;
 
+use Waca\Background\Task\BotCreationTask;
+use Waca\Background\Task\UserCreationTask;
 use Waca\DataObjects\EmailTemplate;
 use Waca\DataObjects\JobQueue;
 use Waca\DataObjects\Log;
@@ -178,6 +180,16 @@ class PageJobQueue extends PagedInternalPageBase
 
         $this->assign('canAcknowledge', $this->barrierTest('acknowledge', User::getCurrent($database)));
         $this->assign('canRequeue', $this->barrierTest('requeue', User::getCurrent($database)));
+
+        if ($job->getTask() === UserCreationTask::class || $job->getTask() === BotCreationTask::class) {
+            if ($job->getEmailTemplate() === null) {
+                $params = json_decode($job->getParameters());
+
+                if (isset($params->emailText)) {
+                    $this->assign("creationEmailText", $params->emailText);
+                }
+            }
+        }
 
         $this->setHtmlTitle('Job #{$job->getId()|escape}');
         $this->setTemplate('jobqueue/view.tpl');

--- a/includes/Pages/RequestAction/PageCloseRequest.php
+++ b/includes/Pages/RequestAction/PageCloseRequest.php
@@ -65,7 +65,7 @@ class PageCloseRequest extends RequestActionBase
 
         $request->save();
 
-        $this->processWelcome($template->getDefaultAction());
+        $this->processWelcome($template->getDefaultAction(), null);
 
         // Perform the notifications and stuff *after* we've successfully saved, since the save can throw an OLE and
         // be rolled back.
@@ -233,10 +233,11 @@ class PageCloseRequest extends RequestActionBase
 
     /**
      * @param string $action
+     * @param int|null   $parentTaskId
      *
      * @throws ApplicationLogicException
      */
-    final protected function processWelcome(string $action): void
+    final protected function processWelcome(string $action, ?int $parentTaskId): void
     {
         $database = $this->getDatabase();
         $currentUser = User::getCurrent($database);
@@ -258,6 +259,6 @@ class PageCloseRequest extends RequestActionBase
             return;
         }
 
-        $this->enqueueWelcomeTask($this->getRequest($database), null, $currentUser, $database);
+        $this->enqueueWelcomeTask($this->getRequest($database), $parentTaskId, $currentUser, $database);
     }
 }

--- a/includes/Pages/RequestAction/PageCreateRequest.php
+++ b/includes/Pages/RequestAction/PageCreateRequest.php
@@ -63,7 +63,7 @@ class PageCreateRequest extends RequestActionBase
         }
 
         if ($request->getEmailSent()) {
-            throw new ApplicationLogicException('This requester has already had an email sent to them. Please fall back to manual creation');
+            throw new ApplicationLogicException('This requester has already had an email sent to them. Please fall back to manual creation or a custom close');
         }
 
         $request->setStatus(RequestStatus::JOBQUEUE);

--- a/includes/Pages/RequestAction/PageCustomClose.php
+++ b/includes/Pages/RequestAction/PageCustomClose.php
@@ -9,7 +9,10 @@
 namespace Waca\Pages\RequestAction;
 
 use Exception;
+use Waca\Background\Task\BotCreationTask;
+use Waca\Background\Task\UserCreationTask;
 use Waca\DataObjects\EmailTemplate;
+use Waca\DataObjects\JobQueue;
 use Waca\DataObjects\Request;
 use Waca\DataObjects\User;
 use Waca\Exceptions\AccessDeniedException;
@@ -19,12 +22,16 @@ use Waca\Fragments\RequestData;
 use Waca\Helpers\Logger;
 use Waca\Helpers\OAuthUserHelper;
 use Waca\PdoDatabase;
+use Waca\RequestStatus;
 use Waca\SessionAlert;
 use Waca\WebRequest;
 
 class PageCustomClose extends PageCloseRequest
 {
     use RequestData;
+
+    public const CREATE_OAUTH = 'created-oauth';
+    public const CREATE_BOT = 'created-bot';
 
     protected function main()
     {
@@ -149,6 +156,9 @@ class PageCustomClose extends PageCloseRequest
         $this->assign('allowWelcomeSkip', false);
         $this->assign('forceWelcomeSkip', false);
 
+        $canOauthCreate = $this->barrierTest(User::CREATION_OAUTH, $currentUser, 'RequestCreation');
+        $canBotCreate = $this->barrierTest(User::CREATION_BOT, $currentUser, 'RequestCreation');
+
         $oauth = new OAuthUserHelper($currentUser, $this->getDatabase(), $this->getOAuthProtocolHelper(), $config);
 
         if ($currentUser->getWelcomeTemplate() != 0) {
@@ -159,6 +169,12 @@ class PageCustomClose extends PageCloseRequest
             }
         }
 
+        // disable options if there's a misconfiguration.
+        $canOauthCreate &= $oauth->canCreateAccount();
+        $canBotCreate &= $this->getSiteConfiguration()->getCreationBotPassword() !== null;
+
+        $this->assign('canOauthCreate', $canOauthCreate);
+        $this->assign('canBotCreate', $canBotCreate);
 
         // template
         $this->setTemplate('custom-close.tpl');
@@ -199,37 +215,48 @@ class PageCustomClose extends PageCloseRequest
             // Close request
             $this->closeRequest($request, $database, $action, $messageBody);
 
-            $this->processWelcome($action);
+            $this->processWelcome($action, null);
 
             // Send the mail after the save, since save can be rolled back
             $this->sendMail($request, $messageBody, $currentUser, $ccMailingList);
+
+            return;
         }
-        else {
-            if (array_key_exists($action, $availableRequestStates)) {
-                // Defer to other state
-                $this->deferRequest($request, $database, $action, $availableRequestStates, $messageBody);
 
-                // Send the mail after the save, since save can be rolled back
-                $this->sendMail($request, $messageBody, $currentUser, $ccMailingList);
-            }
-            else {
-                $request->setReserved(null);
-                $request->setUpdateVersion(WebRequest::postInt('updateversion'));
-                $request->save();
+        if ($action === self::CREATE_OAUTH || $action === self::CREATE_BOT) {
+            $this->processAutoCreation($currentUser, $action, $request, $messageBody, $ccMailingList);
 
-                // Perform the notifications and stuff *after* we've successfully saved, since the save can throw an OLE
-                // and be rolled back.
-
-                // Send mail
-                $this->sendMail($request, $messageBody, $currentUser, $ccMailingList);
-
-                Logger::sentMail($database, $request, $messageBody);
-                Logger::unreserve($database, $request);
-
-                $this->getNotificationHelper()->sentMail($request);
-                SessionAlert::success("Sent mail to Request {$request->getId()}");
-            }
+            return;
         }
+
+        // If action is a state key, defer to other state
+        if (array_key_exists($action, $availableRequestStates)) {
+            $this->deferRequest($request, $database, $action, $availableRequestStates, $messageBody);
+
+            // Send the mail after the save, since save can be rolled back
+            $this->sendMail($request, $messageBody, $currentUser, $ccMailingList);
+
+            return;
+        }
+
+        // Any other scenario, just send the email.
+
+        $request->setReserved(null);
+        $request->setUpdateVersion(WebRequest::postInt('updateversion'));
+        $request->save();
+
+        // Perform the notifications and stuff *after* we've successfully saved, since the save can throw an OLE
+        // and be rolled back.
+
+        // Send mail
+        $this->sendMail($request, $messageBody, $currentUser, $ccMailingList);
+
+        Logger::sentMail($database, $request, $messageBody);
+        Logger::unreserve($database, $request);
+
+        $this->getNotificationHelper()->sentMail($request);
+        SessionAlert::success("Sent mail to Request {$request->getId()}");
+
     }
 
     /**
@@ -300,5 +327,75 @@ class PageCustomClose extends PageCloseRequest
 
         $deferTo = $availableRequestStates[$action]['deferto'];
         SessionAlert::success("Request {$request->getId()} deferred to $deferTo, sending an email.");
+    }
+
+    /**
+     * @param User    $currentUser
+     * @param string  $action
+     * @param Request $request
+     * @param string  $messageBody
+     * @param bool    $ccMailingList
+     *
+     * @throws AccessDeniedException
+     * @throws ApplicationLogicException
+     * @throws OptimisticLockFailedException
+     */
+    protected function processAutoCreation(User $currentUser, string $action, Request $request, string $messageBody, bool $ccMailingList): void
+    {
+        $db = $this->getDatabase();
+        $oauth = new OAuthUserHelper($currentUser, $db, $this->getOAuthProtocolHelper(), $this->getSiteConfiguration());
+        $canOauthCreate = $this->barrierTest(User::CREATION_OAUTH, $currentUser, 'RequestCreation');
+        $canBotCreate = $this->barrierTest(User::CREATION_BOT, $currentUser, 'RequestCreation');
+        $canOauthCreate &= $oauth->canCreateAccount();
+        $canBotCreate &= $this->getSiteConfiguration()->getCreationBotPassword() !== null;
+
+        $creationTaskClass = null;
+
+        if ($action === self::CREATE_OAUTH) {
+            if(!$canOauthCreate) {
+                throw new AccessDeniedException($this->getSecurityManager());
+            }
+
+            $creationTaskClass = UserCreationTask::class;
+        }
+
+        if ($action === self::CREATE_BOT) {
+            if (!$canBotCreate) {
+                throw new AccessDeniedException($this->getSecurityManager());
+            }
+
+            $creationTaskClass = BotCreationTask::class;
+        }
+
+        if ($creationTaskClass === null) {
+            throw new ApplicationLogicException('Cannot determine creation mode');
+        }
+
+        $request->setStatus(RequestStatus::JOBQUEUE);
+        $request->setReserved(null);
+        $request->save();
+
+        $parameters = [
+            'emailText' => $messageBody,
+            'ccMailingList' => $ccMailingList
+        ];
+
+        $creationTask = new JobQueue();
+        $creationTask->setTask($creationTaskClass);
+        $creationTask->setRequest($request->getId());
+        $creationTask->setTriggerUserId($currentUser->getId());
+        $creationTask->setParameters(json_encode($parameters));
+        $creationTask->setDatabase($db);
+        $creationTask->save();
+
+        $creationTaskId = $creationTask->getId();
+
+        Logger::enqueuedJobQueue($db, $request);
+        $this->getNotificationHelper()->requestCloseQueued($request, 'Custom, Created');
+
+        SessionAlert::success("Request {$request->getId()} has been queued for autocreation");
+
+        // forge this since it is actually a creation.
+        $this->processWelcome(EmailTemplate::CREATED, $creationTaskId);
     }
 }

--- a/templates/custom-close.tpl
+++ b/templates/custom-close.tpl
@@ -36,14 +36,24 @@
             <div class="col-lg-3 col-xl-2">
                 <label for="inputAction">Action to take</label>
             </div>
-            <div class="col-md-5 col-lg-4">
+            <div class="col-md-8 col-lg-6">
                 <select class="form-control" id="inputAction" name="action" required="required">
                     <option value="" {if $defaultAction == ""}selected="selected"{/if}>(please select)</option>
                     <option value="mail">Only send the email</option>
                     <optgroup label="Send email and close request...">
-                        <option value="created" {if $defaultAction == "created"}selected="selected"{/if}>Close
-                            request as created
+                        <option value="created" {if $defaultAction == "created" && $currentUser->getCreationMode() == 0}selected="selected"{/if}>
+                            Close request as created
                         </option>
+                        {if $canOauthCreate}
+                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH}"  {if $defaultAction == "created" && $currentUser->getCreationMode() == 1}selected="selected"{/if}>
+                                Create account (Wikimedia account) & close request as created
+                            </option>
+                        {/if}
+                        {if $canBotCreate}
+                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT}"  {if $defaultAction == "created" && $currentUser->getCreationMode() == 2}selected="selected"{/if}>
+                                Create account (via bot) & close request as created
+                            </option>
+                        {/if}
                         <option value="not created" {if $defaultAction == "not created"}selected="selected"{/if}>
                             Close request as NOT created
                         </option>
@@ -70,10 +80,12 @@
         {if $confirmEmailAlreadySent}
         <div class="form-group row">
             <div class="offset-lg-3 offset-xl-2 col">
-                <p>This request has already had an email sent. Please acknowledge that your message is context-aware of the earlier message.</p>
-                <div class="custom-control custom-checkbox">
-                    <input class="custom-control-input" type="checkbox" id="confirmEmailAlreadySent" name="confirmEmailAlreadySent" required="required"/>
-                    <label class="custom-control-label" for="confirmEmailAlreadySent">Yes, this is an appropriate follow-up email</label>
+                <div class="alert alert-warning alert-block">
+                    <p>This request has already had an email sent. Please acknowledge that your message is context-aware of the earlier message.</p>
+                    <div class="custom-control custom-checkbox">
+                        <input class="custom-control-input" type="checkbox" id="confirmEmailAlreadySent" name="confirmEmailAlreadySent" required="required"/>
+                        <label class="custom-control-label" for="confirmEmailAlreadySent">Yes, this is an appropriate follow-up email</label>
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/email-management/edit.tpl
+++ b/templates/email-management/edit.tpl
@@ -55,24 +55,22 @@
 
                         <select class="form-control" id="inputDefaultAction" aria-describedby="templateDefaultActionHelp"
                                 name="defaultaction" {if $id == $createdid} disabled{/if}>
-                            <option value="" {if $emailTemplate->getDefaultAction() == ""}selected="selected"{/if}>No
-                                default
+                            <option value="" {if $emailTemplate->getDefaultAction() == ""}selected="selected"{/if}>
+                                No default
                             </option>
                             <optgroup label="Close request...">
-                                <option value="created"
-                                        {if $emailTemplate->getDefaultAction() == "created"}selected="selected"{/if}>
-                                    Close request as created
+                                <option value="created" {if $emailTemplate->getDefaultAction() == "created"}selected="selected"{/if}>
+                                    Close request as created (with autocreate if allowed)
                                 </option>
-                                <option value="not created"
-                                        {if $emailTemplate->getDefaultAction() == "not created"}selected="selected"{/if}>
+                                <option value="not created" {if $emailTemplate->getDefaultAction() == "not created"}selected="selected"{/if}>
                                     Close request as NOT created
                                 </option>
                             </optgroup>
                             <optgroup label="Defer to...">
                                 {foreach $requeststates as $state}
-                                    <option value="{$state@key}"
-                                            {if $emailTemplate->getDefaultAction() == $state@key}selected="selected"{/if}>
-                                        Defer to {$state.deferto|capitalize}</option>
+                                    <option value="{$state@key}" {if $emailTemplate->getDefaultAction() == $state@key}selected="selected"{/if}>
+                                        Defer to {$state.deferto|capitalize}
+                                    </option>
                                 {/foreach}
                             </optgroup>
                         </select>

--- a/templates/jobqueue/view.tpl
+++ b/templates/jobqueue/view.tpl
@@ -23,8 +23,8 @@
 
             <div class="padded-data">
                 <div class="row">
-                    <div class="col-md-9 col-lg-7 col-xl-4"><strong>Task</strong></div>
-                    <div class="col-md-9 col-lg-7 col-xl-8">
+                    <div class="col-sm-3 col-lg-5 col-xl-4"><strong>Task</strong></div>
+                    <div class="col-sm-9 col-lg-7 col-xl-8">
                         {if isset($taskNameMap[$job->getTask()])}
                             {$taskNameMap[$job->getTask()]|escape}
                         {else}
@@ -33,24 +33,24 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-3 col-lg-5 col-xl-4"><strong>Trigger user</strong></div>
-                    <div class="col-md-9 col-lg-7 col-xl-8">
+                    <div class="col-sm-3 col-lg-5 col-xl-4"><strong>Trigger user</strong></div>
+                    <div class="col-sm-9 col-lg-7 col-xl-8">
                         <a href="{$baseurl}/internal.php/statistics/users/detail?user={$job->getTriggerUserId()}">
                             {$user->getUsername()|escape}
                         </a>
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-9 col-lg-7 col-xl-4"><strong>Request</strong></div>
-                    <div class="col-md-9 col-lg-7 col-xl-8">
+                    <div class="col-sm-3 col-lg-5 col-xl-4"><strong>Request</strong></div>
+                    <div class="col-sm-9 col-lg-7 col-xl-8">
                         <a href="{$baseurl}/internal.php/viewRequest?id={$job->getRequest()|escape}">
                             #{$job->getRequest()|escape} ({$request->getName()|escape})
                         </a>
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-9 col-lg-7 col-xl-4"><strong>Email Template</strong></div>
-                    <div class="col-md-9 col-lg-7 col-xl-8">
+                    <div class="col-sm-3 col-lg-5 col-xl-4"><strong>Email Template</strong></div>
+                    <div class="col-sm-9 col-lg-7 col-xl-8">
                         {if $emailTemplate !== false}
                         <a href="{$baseurl}/internal.php/emailManagement/view?id={$job->getEmailTemplate()|escape}">
                             {$emailTemplate->getName()|escape}
@@ -61,22 +61,22 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-9 col-lg-7 col-xl-4"><strong>Status</strong></div>
-                    <div class="col-md-9 col-lg-7 col-xl-8">
+                    <div class="col-sm-3 col-lg-5 col-xl-4"><strong>Status</strong></div>
+                    <div class="col-sm-9 col-lg-7 col-xl-8">
                         <span rel="tooltip" title="{$statusDescriptionMap[$job->getStatus()]|escape}"
                               data-toggle="tooltip" id="#status{$job->getId()|escape}">{$job->getStatus()|escape}</span>
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-9 col-lg-7 col-xl-4"><strong>Enqueue time</strong></div>
-                    <div class="col-md-9 col-lg-7 col-xl-8">
+                    <div class="col-sm-3 col-lg-5 col-xl-4"><strong>Enqueue time</strong></div>
+                    <div class="col-sm-9 col-lg-7 col-xl-8">
                         <span rel="tooltip" title="{$job->getEnqueue()|relativedate}"
                               data-toggle="tooltip" id="#enqueue{$job->getId()|escape}">{$job->getEnqueue()|escape}</span>
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-9 col-lg-7 col-xl-4"><strong>Parent task</strong></div>
-                    <div class="col-md-9 col-lg-7 col-xl-8">
+                    <div class="col-sm-3 col-lg-5 col-xl-4"><strong>Parent task</strong></div>
+                    <div class="col-sm-9 col-lg-7 col-xl-8">
                         {if $parent === false}
                             <span class="muted">None.</span>
                         {else}
@@ -85,12 +85,12 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-9 col-lg-7 col-xl-4"><strong>Error message</strong></div>
-                    <div class="col-md-9 col-lg-7 col-xl-8">{$job->getError()|escape}</div>
+                    <div class="col-sm-3 col-lg-5 col-xl-4"><strong>Error message</strong></div>
+                    <div class="col-sm-9 col-lg-7 col-xl-8">{$job->getError()|escape}</div>
                 </div>
                 <div class="row">
-                    <div class="col-md-9 col-lg-7 col-xl-4"><strong>Acknowledged</strong></div>
-                    <div class="col-md-9 col-lg-7 col-xl-8">
+                    <div class="col-sm-3 col-lg-5 col-xl-4"><strong>Acknowledged</strong></div>
+                    <div class="col-sm-9 col-lg-7 col-xl-8">
                         {if $job->getAcknowledged() === null}
                             N/A
                         {elseif $job->getAcknowledged() == 1}
@@ -102,7 +102,7 @@
                 </div>
             </div>
 
-            <div class="row">
+            <div class="row pb-2">
                 {if $job->getStatus() == 'failed'}
                     <div class="col-md-6">
                         {if $canRequeue}
@@ -114,7 +114,7 @@
                             </form>
                         {/if}
                     </div>
-                    <div class="col-md-6">
+                    <div class="col-md-6 pt-2 pt-md-0">
                         {if $job->getAcknowledged() == 0 && $canAcknowledge}
                             <form method="post" action="{$baseurl}/internal.php/jobQueue/acknowledge" class="form-inline">
                                 <input type="hidden" name="updateVersion" value="{$job->getUpdateVersion()|escape}" />
@@ -127,9 +127,16 @@
                 {/if}
             </div>
         </div>
-        <div class="col-lg-8">
+        <div class="col-lg-8 pt-4 pt-lg-0">
             <h3>Job log</h3>
             {include file="logs/datatable.tpl" showComments=true logs=$log showUser=true showObject=false}
+
+            {if isset($creationEmailText)}
+                <h3>Parameters</h3>
+
+                <h5>Email body</h5>
+                <div class="prewrap">{$creationEmailText|escape}</div>
+            {/if}
         </div>
     </div>
 {/block}

--- a/templates/logs/datatable.tpl
+++ b/templates/logs/datatable.tpl
@@ -37,6 +37,10 @@
                 <td>{$entry.comment}</td>
             {/if}
         </tr>
+    {foreachelse}
+    <tr>
+        <td colspan="2"><span class="text-muted font-italic">No log entries</span></td>
+    </tr>
     {/foreach}
     </tbody>
 </table>


### PR DESCRIPTION
* Add new creation-type options to custom close for oauth/bot auto-creations
* Allows creation tasks to bypass email-sent checks if the creation task originates from a custom close
* Allow passing the email body to the creation task as a job parameter instead of passing an email template
* Mark auto-creations as having had an email sent
* Log custom closure text with the request
* Show the email body on the jobqueue entry in case of job failure

Fixes #677