### PR TITLE
More autocreation bugfixes and missed functionality

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -261,6 +261,8 @@ $banMaxIpBlockRange = [4 => 20, 6 => 48];
 // limit for *all* ban actions, including block/drop.
 $banMaxIpRange = [4 => 16, 6 => 32];
 
+$jobQueueBatchSize = 10;
+
 /**************************************************************************
  **********                   IMPORTANT NOTICE                    **********
  ***************************************************************************
@@ -379,4 +381,5 @@ $siteConfiguration->setBaseUrl($baseurl)
     ->setLocationProviderApiKey($locationProviderApiKey)
     ->setCommonEmailDomains($commonEmailDomains)
     ->setBanMaxIpRange($banMaxIpRange)
-    ->setBanMaxIpBlockRange($banMaxIpBlockRange);
+    ->setBanMaxIpBlockRange($banMaxIpBlockRange)
+    ->setJobQueueBatchSize($jobQueueBatchSize);

--- a/includes/Background/BackgroundTaskBase.php
+++ b/includes/Background/BackgroundTaskBase.php
@@ -245,11 +245,11 @@ abstract class BackgroundTaskBase
         Logger::backgroundJobIssue($this->getDatabase(), $this->getJob());
     }
 
-    protected function markFailed($reason = null)
+    protected function markFailed($reason = null, bool $acknowledged = false)
     {
         $this->job->setStatus(JobQueue::STATUS_FAILED);
         $this->job->setError($reason);
-        $this->job->setAcknowledged(0);
+        $this->job->setAcknowledged($acknowledged ? 1 : 0);
         $this->job->save();
 
         Logger::backgroundJobIssue($this->getDatabase(), $this->getJob());

--- a/includes/Background/BackgroundTaskBase.php
+++ b/includes/Background/BackgroundTaskBase.php
@@ -210,6 +210,7 @@ abstract class BackgroundTaskBase
                     return;
                 case JobQueue::STATUS_WAITING:
                 case JobQueue::STATUS_READY:
+                case JobQueue::STATUS_QUEUED:
                 case JobQueue::STATUS_RUNNING:
                 case JobQueue::STATUS_HELD:
                     // Defer to next execution

--- a/includes/Background/Task/WelcomeUserTask.php
+++ b/includes/Background/Task/WelcomeUserTask.php
@@ -20,6 +20,9 @@ use Waca\RequestStatus;
 
 class WelcomeUserTask extends BackgroundTaskBase
 {
+    /** @var Request */
+    private $request;
+
     public static function enqueue(User $triggerUser, Request $request, PdoDatabase $database)
     {
         $job = new JobQueue();
@@ -33,7 +36,7 @@ class WelcomeUserTask extends BackgroundTaskBase
     public function execute()
     {
         $database = $this->getDatabase();
-        $request = $this->getRequest();
+        $this->request = $this->getRequest();
         $user = $this->getTriggerUser();
 
         if ($user->getWelcomeTemplate() === null) {
@@ -55,19 +58,19 @@ class WelcomeUserTask extends BackgroundTaskBase
             $this->getSiteConfiguration());
         $mediaWikiHelper = new MediaWikiHelper($oauth, $this->getSiteConfiguration());
 
-        if ($request->getStatus() !== RequestStatus::CLOSED) {
+        if ($this->request->getStatus() !== RequestStatus::CLOSED) {
             $this->markFailed('Request is currently open');
 
             return;
         }
 
-        if (!$mediaWikiHelper->checkAccountExists($request->getName())) {
+        if (!$mediaWikiHelper->checkAccountExists($this->request->getName())) {
             $this->markFailed('Account does not exist!');
 
             return;
         }
 
-        $this->performWelcome($template, $request, $user, $mediaWikiHelper);
+        $this->performWelcome($template, $this->request, $user, $mediaWikiHelper);
         $this->markComplete();
     }
 
@@ -88,5 +91,12 @@ class WelcomeUserTask extends BackgroundTaskBase
         $templateText = $template->getBotCodeForWikiSave($request->getName(), $user->getOnWikiName());
 
         $mediaWikiHelper->addTalkPageMessage($request->getName(), $template->getSectionHeader(), 'Welcoming user created through [[WP:ACC]]', $templateText);
+    }
+
+    protected function markFailed($reason = null, bool $acknowledged = false)
+    {
+        $this->getNotificationHelper()->requestWelcomeFailed($this->request, $this->getTriggerUser());
+
+        parent::markFailed($reason, $acknowledged);
     }
 }

--- a/includes/ConsoleTasks/RunJobQueueTask.php
+++ b/includes/ConsoleTasks/RunJobQueueTask.php
@@ -40,7 +40,11 @@ class RunJobQueueTask extends ConsoleTaskBase
 
         $sql = 'SELECT * FROM jobqueue WHERE status = :status ORDER BY enqueue LIMIT :lim';
         $statement = $database->prepare($sql);
-        $statement->execute(array(':status' => JobQueue::STATUS_READY, ':lim' => 10));
+        $statement->execute(array(
+            ':status' => JobQueue::STATUS_READY,
+            ':lim' => $this->getSiteConfiguration()->getJobQueueBatchSize()
+        ));
+
         /** @var JobQueue[] $queuedJobs */
         $queuedJobs = $statement->fetchAll(PDO::FETCH_CLASS, JobQueue::class);
 

--- a/includes/DataObjects/JobQueue.php
+++ b/includes/DataObjects/JobQueue.php
@@ -20,18 +20,25 @@ class JobQueue extends DataObject
     /*
      * Status workflow is this:
      *
-     * 1) Ready. The job has been added to the queue
-     * 1) Waiting. The job has been picked up by the worker
-     * 2) Running. The job is actively being processed.
-     * 3) Complete / Failed. The job has been processed
+     * 1) Queued. The job has been added to the queue.
+     * 2) Ready. The job is ready to be run in the next queue run.
+     * 3) Waiting. The job has been picked up by the worker
+     * 4) Running. The job is actively being processed.
+     * 5) Complete / Failed. The job has been processed
+     *
+     * A job can move to Cancelled at any point, and will be cancelled automatically.
+     *
+     * 'held' is not used by the system, and is intended for manual pauses.
      *
      */
+
+    const STATUS_QUEUED = 'queued';
     const STATUS_READY = 'ready';
     const STATUS_WAITING = 'waiting';
     const STATUS_RUNNING = 'running';
     const STATUS_COMPLETE = 'complete';
-    const STATUS_CANCELLED = 'cancelled';
     const STATUS_FAILED = 'failed';
+    const STATUS_CANCELLED = 'cancelled';
     const STATUS_HELD = 'held';
 
     /** @var string */
@@ -78,8 +85,8 @@ class JobQueue extends DataObject
         if ($this->isNew()) {
             // insert
             $statement = $this->dbObject->prepare(<<<SQL
-                INSERT INTO jobqueue (task, user, request, emailtemplate, parameters, parent) 
-                VALUES (:task, :user, :request, :emailtemplate, :parameters, :parent)
+                INSERT INTO jobqueue (task, user, request, emailtemplate, parameters, parent, status) 
+                VALUES (:task, :user, :request, :emailtemplate, :parameters, :parent, 'queued')
 SQL
             );
             $statement->bindValue(":task", $this->task);

--- a/includes/Helpers/IrcNotificationHelper.php
+++ b/includes/Helpers/IrcNotificationHelper.php
@@ -367,6 +367,15 @@ class IrcNotificationHelper
     }
 
     /**
+     * @param Request $request
+     * @param User    $triggerUser
+     */
+    public function requestWelcomeFailed(Request $request, User $triggerUser)
+    {
+        $this->send("Request {$request->getId()} ({$request->getName()}) failed welcome for {$triggerUser->getUsername()}.");
+    }
+
+    /**
      * Summary of sentMail
      *
      * @param Request $request

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -165,6 +165,7 @@ class LogHelper
             'JobCompleted'        => 'completed a background job',
             'JobAcknowledged'     => 'acknowledged a job failure',
             'JobRequeued'         => 'requeued a job for re-execution',
+            'JobCancelled'        => 'cancelled execution of a job',
             'EnqueuedJobQueue'    => 'scheduled for creation',
             'Hospitalised'        => 'sent to the hospital',
         );
@@ -231,6 +232,7 @@ class LogHelper
                 'JobCompleted'        => 'completed a background job',
                 'JobAcknowledged'     => 'acknowledged a job failure',
                 'JobRequeued'         => 'requeued a job for re-execution',
+                'JobCancelled'        => 'cancelled execution of a job',
                 'EnqueuedJobQueue'    => 'scheduled for creation',
                 'Hospitalised'        => 'sent to the hospital',
             ],

--- a/includes/Helpers/Logger.php
+++ b/includes/Helpers/Logger.php
@@ -374,6 +374,11 @@ class Logger
         self::createLogEntry($database, $job, 'JobIssue', serialize($data), User::getCommunity());
     }
 
+    public static function backgroundJobCancelled(PdoDatabase $database, JobQueue $job)
+    {
+        self::createLogEntry($database, $job, 'JobCancelled', $job->getError());
+    }
+
     public static function backgroundJobRequeued(PdoDatabase $database, JobQueue $job)
     {
         self::createLogEntry($database, $job, 'JobRequeued');

--- a/includes/Helpers/Logger.php
+++ b/includes/Helpers/Logger.php
@@ -379,9 +379,9 @@ class Logger
         self::createLogEntry($database, $job, 'JobRequeued');
     }
 
-    public static function backgroundJobAcknowledged(PdoDatabase $database, JobQueue $job)
+    public static function backgroundJobAcknowledged(PdoDatabase $database, JobQueue $job, $comment = null)
     {
-        self::createLogEntry($database, $job, 'JobAcknowledged');
+        self::createLogEntry($database, $job, 'JobAcknowledged', $comment);
     }
     #endregion
 }

--- a/includes/Pages/PageJobQueue.php
+++ b/includes/Pages/PageJobQueue.php
@@ -281,7 +281,7 @@ class PageJobQueue extends PagedInternalPageBase
             throw new ApplicationLogicException('No job specified');
         }
 
-        /** @var JobQueue $job */
+        /** @var JobQueue|false $job */
         $job = JobQueue::getById($jobId, $database);
 
         if ($job === false) {

--- a/includes/Pages/PageJobQueue.php
+++ b/includes/Pages/PageJobQueue.php
@@ -42,7 +42,7 @@ class PageJobQueue extends PagedInternalPageBase
 
         /** @var JobQueue[] $jobList */
         $jobList = JobQueueSearchHelper::get($database)
-            ->statusIn(array('ready', 'waiting', 'running', 'failed'))
+            ->statusIn(array('queued', 'ready', 'waiting', 'running', 'failed'))
             ->notAcknowledged()
             ->fetch();
 
@@ -273,6 +273,7 @@ class PageJobQueue extends PagedInternalPageBase
             JobQueue::STATUS_CANCELLED => 'The job was cancelled',
             JobQueue::STATUS_COMPLETE  => 'The job completed successfully',
             JobQueue::STATUS_FAILED    => 'The job encountered an error',
+            JobQueue::STATUS_QUEUED    => 'The job is in the queue',
             JobQueue::STATUS_READY     => 'The job is ready to be picked up by the next job runner execution',
             JobQueue::STATUS_RUNNING   => 'The job is being run right now by the job runner',
             JobQueue::STATUS_WAITING   => 'The job has been picked up by a job runner',

--- a/includes/Pages/PageJobQueue.php
+++ b/includes/Pages/PageJobQueue.php
@@ -288,7 +288,7 @@ class PageJobQueue extends PagedInternalPageBase
             throw new ApplicationLogicException('Could not find requested job');
         }
 
-        $job->setStatus(JobQueue::STATUS_READY);
+        $job->setStatus(JobQueue::STATUS_QUEUED);
         $job->setUpdateVersion(WebRequest::postInt('updateVersion'));
         $job->setAcknowledged(null);
         $job->setError(null);

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -99,7 +99,9 @@ class PageViewRequest extends InternalPageBase
         }
         $this->assign('canResetOldRequest', $this->barrierTest('reopenOldRequest', $currentUser, 'RequestData'));
         $this->assign('canResetPurgedRequest', $this->barrierTest('reopenClearedRequest', $currentUser, 'RequestData'));
-            
+
+        $this->assign('requestEmailSent', $request->getEmailSent());
+
         if ($allowedPrivateData) {
             $this->setTemplate('view-request/main-with-data.tpl');
             $this->setupPrivateData($request, $config);

--- a/includes/Pages/RequestAction/PageCloseRequest.php
+++ b/includes/Pages/RequestAction/PageCloseRequest.php
@@ -151,7 +151,7 @@ class PageCloseRequest extends RequestActionBase
      */
     protected function confirmAccountCreated(Request $request, EmailTemplate $template)
     {
-        if ($this->checkAccountCreated($request, $template)) {
+        if ($template->getDefaultAction() === EmailTemplate::CREATED && $this->checkAccountCreated($request)) {
             $this->showConfirmation($request, $template, 'close-confirmations/account-created.tpl');
 
             return true;
@@ -160,9 +160,9 @@ class PageCloseRequest extends RequestActionBase
         return false;
     }
 
-    protected function checkAccountCreated(Request $request, EmailTemplate $template)
+    protected function checkAccountCreated(Request $request)
     {
-        if ($template->getDefaultAction() === EmailTemplate::CREATED && !WebRequest::postBoolean('createOverride')) {
+        if (!WebRequest::postBoolean('createOverride')) {
             $parameters = array(
                 'action'  => 'query',
                 'list'    => 'users',

--- a/includes/Pages/RequestAction/PageDeferRequest.php
+++ b/includes/Pages/RequestAction/PageDeferRequest.php
@@ -75,6 +75,8 @@ class PageDeferRequest extends RequestActionBase
                 $job->setStatus(JobQueue::STATUS_CANCELLED);
                 $job->setError('Cancelled by request deferral');
                 $job->save();
+
+                Logger::backgroundJobCancelled($database, $job);
             }
         }
 

--- a/includes/Pages/RequestAction/PageDeferRequest.php
+++ b/includes/Pages/RequestAction/PageDeferRequest.php
@@ -66,6 +66,7 @@ class PageDeferRequest extends RequestActionBase
         if ($request->getStatus() === RequestStatus::JOBQUEUE) {
             /** @var JobQueue[] $pendingJobs */
             $pendingJobs = JobQueueSearchHelper::get($database)->byRequest($request->getId())->statusIn([
+                JobQueue::STATUS_QUEUED,
                 JobQueue::STATUS_READY,
                 JobQueue::STATUS_WAITING,
             ])->fetch();

--- a/includes/Router/RequestRouter.php
+++ b/includes/Router/RequestRouter.php
@@ -194,7 +194,7 @@ class RequestRouter implements IRequestRouter
         'jobQueue'                    =>
             array(
                 'class'   => PageJobQueue::class,
-                'actions' => array('acknowledge', 'requeue', 'view', 'all'),
+                'actions' => array('acknowledge', 'requeue', 'view', 'all', 'cancel'),
             ),
 
         //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/includes/Security/RoleConfiguration.php
+++ b/includes/Security/RoleConfiguration.php
@@ -250,6 +250,7 @@ class RoleConfiguration
             PageJobQueue::class                  => array(
                 'acknowledge' => self::ACCESS_ALLOW,
                 'requeue'     => self::ACCESS_ALLOW,
+                'cancel'      => self::ACCESS_ALLOW,
             ),
             'RequestData'               => array(
                 'reopenClearedRequest'  => self::ACCESS_ALLOW,
@@ -315,6 +316,7 @@ class RoleConfiguration
             ),
             PageJobQueue::class                  => array(
                 'acknowledge' => self::ACCESS_ALLOW,
+                'cancel'      => self::ACCESS_ALLOW
             ),
         ),
 

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -96,6 +96,7 @@ class SiteConfiguration
     private $commonEmailDomains = [];
     private $banMaxIpBlockRange = [4 => 20, 6 => 48];
     private $banMaxIpRange = [4 => 16, 6 => 32];
+    private $jobQueueBatchSize = 10;
 
     /**
      * Gets the base URL of the tool
@@ -1137,4 +1138,24 @@ class SiteConfiguration
     {
         return $this->oauthLegacyConsumerTokens;
     }
+
+    /**
+     * @return int
+     */
+    public function getJobQueueBatchSize(): int
+    {
+        return $this->jobQueueBatchSize;
+    }
+
+    /**
+     * @param int $jobQueueBatchSize
+     *
+     * @return SiteConfiguration
+     */
+    public function setJobQueueBatchSize(int $jobQueueBatchSize): SiteConfiguration
+    {
+        $this->jobQueueBatchSize = $jobQueueBatchSize;
+
+        return $this;
+}
 }

--- a/team.json
+++ b/team.json
@@ -417,7 +417,7 @@
         "Role": ["Developer"],
         "Retired": [],
         "Access": []
-    }
+    },
     "Rich Smith": {
         "IRC": "RichSmith",
         "Cloak": "*!*@wikipedia/RichSmith",

--- a/templates/custom-close.tpl
+++ b/templates/custom-close.tpl
@@ -39,28 +39,28 @@
             <div class="col-md-8 col-lg-6">
                 <select class="form-control" id="inputAction" name="action" required="required">
                     <option value="" {if $defaultAction == ""}selected="selected"{/if}>(please select)</option>
-                    <option value="mail">Only send the email</option>
+                    <option value="mail" {if $preloadAction == "mail"}selected="selected"{/if}>Only send the email</option>
                     <optgroup label="Send email and close request...">
-                        <option value="created" {if $defaultAction == "created" && $currentUser->getCreationMode() == 0}selected="selected"{/if}>
+                        <option value="created" {if $preloadAction == "created" || ($preloadAction === null && $defaultAction == "created" && $currentUser->getCreationMode() == 0)}selected="selected"{/if}>
                             Close request as created
                         </option>
                         {if $canOauthCreate}
-                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH}"  {if $defaultAction == "created" && $currentUser->getCreationMode() == 1}selected="selected"{/if}>
+                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH}"  {if $preloadAction == Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH || ($preloadAction === null && $defaultAction == "created" && $currentUser->getCreationMode() == 1)}selected="selected"{/if}>
                                 Create account (Wikimedia account) & close request as created
                             </option>
                         {/if}
                         {if $canBotCreate}
-                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT}"  {if $defaultAction == "created" && $currentUser->getCreationMode() == 2}selected="selected"{/if}>
+                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT}"  {if $preloadAction == Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT || ($preloadAction === null && $defaultAction == "created" && $currentUser->getCreationMode() == 2)}selected="selected"{/if}>
                                 Create account (via bot) & close request as created
                             </option>
                         {/if}
-                        <option value="not created" {if $defaultAction == "not created"}selected="selected"{/if}>
+                        <option value="not created" {if $preloadAction == "not created" || ($preloadAction === null && $defaultAction == "not created") }selected="selected"{/if}>
                             Close request as NOT created
                         </option>
                     </optgroup>
                     <optgroup label="Send email and defer to...">
                         {foreach $requeststates as $state}
-                            <option value="{$state@key}" {if $defaultAction == $state@key}selected="selected"{/if}>
+                            <option value="{$state@key}" {if $preloadAction == $state@key || ($preloadAction === null && $defaultAction == $state@key )}selected="selected"{/if}>
                                 Defer to {$state.deferto|capitalize}</option>
                         {/foreach}
                     </optgroup>
@@ -71,7 +71,7 @@
         <div class="form-group row">
             <div class="offset-lg-3 offset-xl-2 col">
                 <div class="custom-control custom-checkbox">
-                    <input class="custom-control-input" type="checkbox" id="ccMailingList" name="ccMailingList" checked="checked" {if !$canSkipCcMailingList}disabled="disabled"{/if}/>
+                    <input class="custom-control-input" type="checkbox" id="ccMailingList" name="ccMailingList" {if $ccMailingList === null || $ccMailingList}checked="checked"{/if} {if !$canSkipCcMailingList}disabled="disabled"{/if}/>
                     <label class="custom-control-label" for="ccMailingList">CC to mailing list</label>
                 </div>
             </div>
@@ -80,7 +80,7 @@
         {if $confirmEmailAlreadySent}
         <div class="form-group row">
             <div class="offset-lg-3 offset-xl-2 col">
-                <div class="alert alert-warning alert-block">
+                <div class="alert alert-warning alert-block mb-0">
                     <p>This request has already had an email sent. Please acknowledge that your message is context-aware of the earlier message.</p>
                     <div class="custom-control custom-checkbox">
                         <input class="custom-control-input" type="checkbox" id="confirmEmailAlreadySent" name="confirmEmailAlreadySent" required="required"/>
@@ -97,11 +97,26 @@
             <div class="form-group row">
                 <div class="offset-lg-3 offset-xl-2 col">
                     <div class="custom-control custom-checkbox">
-                        <input type="checkbox" name="skipAutoWelcome" id="skipAutoWelcome" class="custom-control-input" {if $forceWelcomeSkip}disabled="disabled" checked="checked"{/if} />
+                        <input type="checkbox" name="skipAutoWelcome" id="skipAutoWelcome" class="custom-control-input" {if $forceWelcomeSkip}disabled="disabled" checked="checked"{else}{if $skipAutoWelcome}checked="checked"{/if}{/if} />
                         <label for="skipAutoWelcome" class="custom-control-label">Skip automatic welcome on account creation</label>
                         {if $forceWelcomeSkip}
                             <input type="hidden" name="skipAutoWelcome" value="true" />
                         {/if}
+                    </div>
+                </div>
+            </div>
+        {/if}
+
+        {if $showNonExistentAccountWarning}
+            <div class="form-group row">
+                <div class="offset-lg-3 offset-xl-2 col">
+                    <div class="alert alert-warning alert-block mb-0">
+                        <p>You have chosen to mark this request as "created", but the account does not exist on the English
+                            Wikipedia and you have not selected an auto-creation option. Do you wish to proceed?</p>
+                        <div class="custom-control custom-checkbox">
+                            <input type="checkbox" name="createOverride" id="createOverride" class="custom-control-input" required />
+                            <label for="createOverride" class="custom-control-label">Yes, proceed with marking this request as created</label>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/templates/jobqueue/view.tpl
+++ b/templates/jobqueue/view.tpl
@@ -125,6 +125,20 @@
                         {/if}
                     </div>
                 {/if}
+                {if $job->getStatus() == Waca\DataObjects\JobQueue::STATUS_QUEUED
+                    || $job->getStatus() == Waca\DataObjects\JobQueue::STATUS_READY
+                || $job->getStatus() == Waca\DataObjects\JobQueue::STATUS_WAITING}
+                    <div class="col-md-6">
+                        {if $canCancel}
+                            <form method="post" action="{$baseurl}/internal.php/jobQueue/cancel" class="form-inline">
+                                <input type="hidden" name="updateVersion" value="{$job->getUpdateVersion()|escape}" />
+                                <input type="hidden" name="job" value="{$job->getId()|escape}" />
+                                {include file="security/csrf.tpl"}
+                                <button type="submit" class="btn btn-danger btn-block"><i class="fas fa-stop-circle"></i>&nbsp;Cancel</button>
+                            </form>
+                        {/if}
+                    </div>
+                {/if}
             </div>
         </div>
         <div class="col-lg-8 pt-4 pt-lg-0">

--- a/templates/view-request/createbuttons/auto.tpl
+++ b/templates/view-request/createbuttons/auto.tpl
@@ -2,7 +2,10 @@
 <form method="post" action="{$baseurl}/internal.php/viewRequest/create">
     {if !empty($createReasons)}
         <div class="dropright btn-group btn-block">
-            <button class="btn btn-success col" type="submit" name="template" value="{$createdId}">
+            <button class="btn btn-success col jsconfirm" type="submit" name="template" value="{$createdId}"
+                    {if !$currentUser->getAbortPref() && $createdHasJsQuestion}
+                data-template="{$createdId}"
+                    {/if}>
                 Create and close as {$createdName|escape}
             </button>
 
@@ -24,7 +27,10 @@
             </ul>
         </div>
     {else}
-        <button class="btn btn-success btn-block" type="submit" name="template" value="{$createdId}">
+        <button class="btn btn-success btn-block jsconfirm" type="submit" name="template" value="{$createdId}"
+                {if !$currentUser->getAbortPref() && $createdHasJsQuestion}
+            data-template="{$createdId}"
+                {/if}>
             {$createdName|escape}
         </button>
     {/if}

--- a/templates/view-request/main.tpl
+++ b/templates/view-request/main.tpl
@@ -57,7 +57,11 @@
                                         </div>
                                     {/if}
                                     {if $canOauthCreate}
-                                        {if $oauthProblem}
+                                        {if $requestEmailSent}
+                                            <div class="col-md-12 create-button-row {if $currentUser->getCreationMode() !== 1}d-none{/if}" id="createOauth">
+                                                <div class="alert alert-warning mb-0">This request has already had an email sent to the requester. Please do a custom close or fall back to manual creation.</div>
+                                            </div>
+                                        {elseif $oauthProblem}
                                             <div class="col-md-12 create-button-row {if $currentUser->getCreationMode() !== 1}d-none{/if}" id="createOauth">
                                                 <div class="alert alert-warning mb-0">There's an issue with your account setup. Please check your OAuth configuration and ensure you've allowed the necessary grants.</div>
                                             </div>
@@ -68,7 +72,11 @@
                                         {/if}
                                     {/if}
                                     {if $canBotCreate}
-                                        {if $botProblem}
+                                        {if $requestEmailSent}
+                                            <div class="col-md-12 create-button-row {if $currentUser->getCreationMode() !== 1}d-none{/if}" id="createOauth">
+                                                <div class="alert alert-warning mb-0">This request has already had an email sent to the requester. Please do a custom close or fall back to manual creation.</div>
+                                            </div>
+                                        {elseif $botProblem}
                                             <div class="col-md-12 create-button-row {if $currentUser->getCreationMode() !== 1}d-none{/if}" id="createOauth">
                                                 <div class="alert alert-warning mb-0">There's an issue with the tool configuration. Please choose a different creation type above.</div>
                                             </div>

--- a/templates/view-request/request-status-buttons.tpl
+++ b/templates/view-request/request-status-buttons.tpl
@@ -27,7 +27,11 @@
                             <input type="hidden" name="request" value="{$requestId}"/>
                             <input type="hidden" name="updateversion" value="{$updateVersion}"/>
                             <input type="hidden" name="target" value="{$defaultRequestState}"/>
-                            <button class="btn btn-block btn-outline-danger" type="submit">Reset request</button>
+                            {if $requestStatus === Waca\RequestStatus::JOBQUEUE}
+                                <button class="btn btn-block btn-outline-danger" type="submit">Reset request and cancel auto-creation</button>
+                            {else}
+                                <button class="btn btn-block btn-outline-danger" type="submit">Reset request</button>
+                            {/if}
                         </form>
                     </div>
                 {/if}


### PR DESCRIPTION
* Fix invalid JSON introduced in 2449edd69
* Extend checks in the fast closes statistics page to check for enqueue times as well as closure times
* Add JS confirmation popup to auto-create buttons
* Automatically acknowledge failed auto-creation tasks. Requests are automatically deferred to the hospital queue anyway; requiring acknowledgement is unnecessary work.
* Stage jobqueue tasks before they can be run. This is to guarantee users time to cancel a mistaken auto-creation before it actually executes.
* Extract job queue batch size to a configuration option
* Add IRC ping for failed auto-welcome jobs
* Allow cancelling of jobqueue jobs independently. This *will not* move a request out of the jobqueue queue; if there are no creation jobs remaining, then the request will sit in that queue indefinitely.
* Rename the reset button to indicate that it will cancel pending jobs when in the job queue.
* Hide auto-creation buttons when a request has already had an email sent to the user. No change in functionality, just hiding an exception.