### PR TITLE
Make use of request queue UI

### DIFF
--- a/includes/API/Actions/CountAction.php
+++ b/includes/API/Actions/CountAction.php
@@ -73,7 +73,7 @@ class CountAction extends XmlApiPageBase implements IXmlApiAction
 QUERY;
 
         $statement = $this->getDatabase()->prepare($query);
-        $statement->execute(array(":username" => $this->user->getUsername(), ":created" => EmailTemplate::CREATED));
+        $statement->execute(array(":username" => $this->user->getUsername(), ":created" => EmailTemplate::ACTION_CREATED));
         $result = $statement->fetchColumn();
         $statement->closeCursor();
 
@@ -97,7 +97,7 @@ QUERY;
         $statement = $this->getDatabase()->prepare($query);
         $statement->bindValue(":username", $this->user->getUsername());
         $statement->bindValue(":date", date('Y-m-d') . "%");
-        $statement->bindValue(":created", EmailTemplate::CREATED);
+        $statement->bindValue(":created", EmailTemplate::ACTION_CREATED);
         $statement->execute();
         $today = $statement->fetchColumn();
         $statement->closeCursor();

--- a/includes/Background/CreationTaskBase.php
+++ b/includes/Background/CreationTaskBase.php
@@ -78,6 +78,7 @@ abstract class CreationTaskBase extends BackgroundTaskBase
             $this->performCreation($user);
 
             $this->request->setStatus(RequestStatus::CLOSED);
+            $this->request->setQueue(null);
             $this->request->setReserved(null);
             $this->request->setEmailSent(true);
             $this->request->save();
@@ -131,6 +132,7 @@ abstract class CreationTaskBase extends BackgroundTaskBase
     protected function markFailed($reason = null, bool $acknowledged = false)
     {
         $this->request->setStatus(RequestStatus::HOSPITAL);
+        $this->request->setQueue(null);
         $this->request->save();
 
         $this->getNotificationHelper()->requestCreationFailed($this->request, $this->getTriggerUser());

--- a/includes/ConsoleTasks/MigrateToDomains.php
+++ b/includes/ConsoleTasks/MigrateToDomains.php
@@ -16,61 +16,6 @@ class MigrateToDomains extends ConsoleTaskBase
 {
     public function execute()
     {
-        $siteConfiguration = $this->getSiteConfiguration();
-
-        /** @noinspection PhpDeprecationInspection */
-        $requestStates = $siteConfiguration->getRequestStates();
-        $database = $this->getDatabase();
-
-        $domain = new Domain();
-        $domain->setEnabled(true);
-        $domain->setShortName('enwiki');
-        $domain->setLongName('English Wikipedia');
-        $domain->setWikiArticlePath($siteConfiguration->getMediawikiScriptPath());
-        $domain->setWikiApiPath($siteConfiguration->getMediawikiWebServiceEndpoint());
-        $domain->setEnabled(true);
-        /** @noinspection PhpDeprecationInspection */
-        $domain->setDefaultClose($siteConfiguration->getDefaultCreatedTemplateId());
-        $domain->setDefaultLanguage('en');
-        $domain->setEmailSender('accounts-enwiki-l@lists.wikimedia.org');
-        $domain->setNotificationTarget($siteConfiguration->getIrcNotificationType());
-
-        $domain->setDatabase($database);
-        $domain->save();
-
-        foreach ($requestStates as $key => $data) {
-            $state = new RequestQueue();
-
-            /** @noinspection PhpDeprecationInspection */
-            if ($siteConfiguration->getDefaultRequestStateKey() === $key) {
-                $state->setDefault(true);
-            }
-
-            /** @noinspection PhpDeprecationInspection */
-            if ($siteConfiguration->getDefaultRequestDeferredStateKey() === $key) {
-                $state->setDefaultAntispoof(true);
-                $state->setDefaultTitleBlacklist(true);
-            }
-
-            $state->setDomain($domain->getId());
-            $state->setApiName($data['api']);
-            $state->setDisplayName($data['deferto']);
-            $state->setHeader($data['header']);
-            /** @noinspection PhpDeprecationInspection */
-            $state->setLogName($data['defertolog']);
-            /** @noinspection PhpDeprecationInspection */
-            $state->setLegacyStatus($key);
-            $state->setEnabled(true);
-
-            if (isset($data['help'])) {
-                $state->setHelp($data['help']);
-            }
-
-            $state->setDatabase($database);
-            $state->save();
-        }
-
-        /** @noinspection SqlWithoutWhere */
-        $database->exec("UPDATE schemaversion SET version = 37;");
+        echo "This migration script must be run with the entire application at an earlier version.";
     }
 }

--- a/includes/DataObjects/Ban.php
+++ b/includes/DataObjects/Ban.php
@@ -41,7 +41,7 @@ class Ban extends DataObject
     private $duration;
     private $active;
     private $action = self::ACTION_BLOCK;
-    private $actiontarget;
+    private $targetqueue;
     private $visibility = 'user';
 
     /**
@@ -134,8 +134,8 @@ SQL
         if ($this->isNew()) {
             // insert
             $statement = $this->dbObject->prepare(<<<SQL
-INSERT INTO `ban` (name, email, ip, ipmask, useragent, user, reason, date, duration, active, action, actiontarget, visibility)
-VALUES (:name, :email, :ip, :ipmask, :useragent, :user, :reason, CURRENT_TIMESTAMP(), :duration, :active, :action, :actionTarget, :visibility);
+INSERT INTO `ban` (name, email, ip, ipmask, useragent, user, reason, date, duration, active, action, targetqueue, visibility)
+VALUES (:name, :email, :ip, :ipmask, :useragent, :user, :reason, CURRENT_TIMESTAMP(), :duration, :active, :action, :targetqueue, :visibility);
 SQL
             );
 
@@ -150,7 +150,7 @@ SQL
             $statement->bindValue(":duration", $this->duration);
             $statement->bindValue(":active", $this->active);
             $statement->bindValue(":action", $this->action);
-            $statement->bindValue(":actionTarget", $this->actiontarget);
+            $statement->bindValue(":targetqueue", $this->targetqueue);
             $statement->bindValue(":visibility", $this->visibility);
 
             if ($statement->execute()) {
@@ -164,8 +164,8 @@ SQL
             // update
             $statement = $this->dbObject->prepare(<<<SQL
 UPDATE `ban`
-SET duration = :duration, active = :active, user = :user, action = :action, actiontarget = :actionTarget, 
-    visibility = :visibility, updateversion = updateversion + 1
+SET duration = :duration, active = :active, user = :user, action = :action, visibility = :visibility, 
+    targetqueue = :targetqueue, updateversion = updateversion + 1
 WHERE id = :id AND updateversion = :updateversion;
 SQL
             );
@@ -176,7 +176,7 @@ SQL
             $statement->bindValue(':active', $this->active);
             $statement->bindValue(':user', $this->user);
             $statement->bindValue(":action", $this->action);
-            $statement->bindValue(":actionTarget", $this->actiontarget);
+            $statement->bindValue(":targetqueue", $this->targetqueue);
             $statement->bindValue(":visibility", $this->visibility);
 
             if (!$statement->execute()) {
@@ -280,22 +280,6 @@ SQL
     }
 
     /**
-     * @return string|null
-     */
-    public function getActionTarget()
-    {
-        return $this->actiontarget;
-    }
-
-    /**
-     * @param string|null $actionTarget
-     */
-    public function setActionTarget($actionTarget): void
-    {
-        $this->actiontarget = $actionTarget;
-    }
-
-    /**
      * @return string
      */
     public function getVisibility() : string
@@ -393,5 +377,31 @@ SQL
     public function setUseragent(?string $useragent): void
     {
         $this->useragent = $useragent;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTargetQueue(): ?int
+    {
+        return $this->targetqueue;
+    }
+
+    /**
+     * @return RequestQueue|null
+     */
+    public function getTargetQueueObject(): ?RequestQueue
+    {
+        /** @var RequestQueue $queue */
+        $queue = RequestQueue::getById($this->targetqueue, $this->getDatabase());
+        return $queue === false ? null : $queue;
+    }
+
+    /**
+     * @param int|null $targetQueue
+     */
+    public function setTargetQueue(?int $targetQueue): void
+    {
+        $this->targetqueue = $targetQueue;
     }
 }

--- a/includes/DataObjects/EmailTemplate.php
+++ b/includes/DataObjects/EmailTemplate.php
@@ -21,12 +21,9 @@ use Waca\PdoDatabase;
  */
 class EmailTemplate extends DataObject
 {
-    /** Note, also used in template-table.tpl */
-    const CREATED = "created";
-    /** Note, also used in template-table.tpl */
-    const NOT_CREATED = "not created";
-    /** Note, also used in template-table.tpl */
     const NONE = null;
+    const ACTION_CREATED = 'created';
+    const ACTION_NOT_CREATED = 'not created';
     /** @var string the name of the template */
     private $name;
     private $text;
@@ -34,7 +31,7 @@ class EmailTemplate extends DataObject
     private $jsquestion;
     private $active = 1;
     private $preloadonly = 0;
-    private $defaultaction = self::NOT_CREATED;
+    private $defaultaction = self::ACTION_NOT_CREATED;
 
     /**
      * Gets active non-preload templates

--- a/includes/DataObjects/EmailTemplate.php
+++ b/includes/DataObjects/EmailTemplate.php
@@ -21,9 +21,11 @@ use Waca\PdoDatabase;
  */
 class EmailTemplate extends DataObject
 {
-    const NONE = null;
     const ACTION_CREATED = 'created';
     const ACTION_NOT_CREATED = 'not created';
+    const ACTION_NONE = 'none';
+    const ACTION_DEFER = 'defer';
+
     /** @var string the name of the template */
     private $name;
     private $text;
@@ -32,11 +34,12 @@ class EmailTemplate extends DataObject
     private $active = 1;
     private $preloadonly = 0;
     private $defaultaction = self::ACTION_NOT_CREATED;
+    private $queue;
 
     /**
      * Gets active non-preload templates
      *
-     * @param string      $defaultAction Default action to take (EmailTemplate::CREATED or EmailTemplate::NOT_CREATED)
+     * @param string      $defaultAction Default action to take (EmailTemplate::ACTION_CREATED or EmailTemplate::ACTION_NOT_CREATED)
      * @param PdoDatabase $database
      *
      * @return array|false
@@ -68,8 +71,8 @@ SQL
     /**
      * Gets active non-preload and preload templates, optionally filtered by the default action.
      *
-     * @param null|bool|string $defaultAction Default action to take (EmailTemplate::CREATED,
-     *                                        EmailTemplate::NOT_CREATED, or EmailTemplate::NONE), or optionally null to
+     * @param null|bool|string $defaultAction Default action to take (EmailTemplate::ACTION_CREATED,
+     *                                        EmailTemplate::ACTION_NOT_CREATED, or EmailTemplate::ACTION_NONE), or optionally null to
      *                                        just get everything.
      * @param PdoDatabase      $database
      *
@@ -154,6 +157,7 @@ SQL
         $t = new EmailTemplate();
         $t->id = 0;
         $t->active = 1;
+        $t->defaultaction = self::ACTION_NONE;
         $t->name = 'Dropped';
 
         return $t;
@@ -167,8 +171,8 @@ SQL
         if ($this->isNew()) {
             // insert
             $statement = $this->dbObject->prepare(<<<SQL
-INSERT INTO `emailtemplate` (name, text, jsquestion, defaultaction, active, preloadonly)
-VALUES (:name, :text, :jsquestion, :defaultaction, :active, :preloadonly);
+INSERT INTO `emailtemplate` (name, text, jsquestion, defaultaction, active, preloadonly, queue)
+VALUES (:name, :text, :jsquestion, :defaultaction, :active, :preloadonly, :queue);
 SQL
             );
             $statement->bindValue(":name", $this->name);
@@ -177,6 +181,7 @@ SQL
             $statement->bindValue(":defaultaction", $this->defaultaction);
             $statement->bindValue(":active", $this->active);
             $statement->bindValue(":preloadonly", $this->preloadonly);
+            $statement->bindValue(":queue", $this->queue);
 
             if ($statement->execute()) {
                 $this->id = (int)$this->dbObject->lastInsertId();
@@ -195,6 +200,7 @@ SET name = :name,
 	defaultaction = :defaultaction,
 	active = :active,
 	preloadonly = :preloadonly,
+    queue = :queue,
 	updateversion = updateversion + 1
 WHERE id = :id AND updateversion = :updateversion;
 SQL
@@ -208,6 +214,7 @@ SQL
             $statement->bindValue(":defaultaction", $this->defaultaction);
             $statement->bindValue(":active", $this->active);
             $statement->bindValue(":preloadonly", $this->preloadonly);
+            $statement->bindValue(":queue", $this->queue);
 
             if (!$statement->execute()) {
                 throw new Exception($statement->errorInfo());
@@ -323,5 +330,40 @@ SQL
     public function setPreloadOnly($preloadonly)
     {
         $this->preloadonly = $preloadonly ? 1 : 0;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getQueue(): ?int
+    {
+        return $this->queue;
+    }
+
+    /**
+     * @return RequestQueue|null
+     */
+    public function getQueueObject(): ?RequestQueue
+    {
+        if ($this->queue === null) {
+            return null;
+        }
+
+        /** @var $dataObject RequestQueue|false */
+        $dataObject = RequestQueue::getById($this->queue, $this->getDatabase());
+
+        if ($dataObject === false) {
+            return null;
+        }
+
+        return $dataObject;
+    }
+
+    /**
+     * @param int|null $queue
+     */
+    public function setQueue(?int $queue): void
+    {
+        $this->queue = $queue;
     }
 }

--- a/includes/DataObjects/Request.php
+++ b/includes/DataObjects/Request.php
@@ -354,7 +354,7 @@ SQL
             return $logAction === "Closed custom-y";
         }
 
-        return $defaultAction === EmailTemplate::CREATED;
+        return $defaultAction === EmailTemplate::ACTION_CREATED;
     }
 
     /**

--- a/includes/Fragments/RequestData.php
+++ b/includes/Fragments/RequestData.php
@@ -9,6 +9,7 @@
 namespace Waca\Fragments;
 
 use Waca\DataObjects\Request;
+use Waca\DataObjects\RequestQueue;
 use Waca\DataObjects\User;
 use Waca\Exceptions\ApplicationLogicException;
 use Waca\Helpers\SearchHelpers\RequestSearchHelper;
@@ -259,8 +260,15 @@ trait RequestData
         $this->assign('requestDate', $request->getDate());
         $this->assign('requestStatus', $request->getStatus());
 
-        $isClosed = !array_key_exists($request->getStatus(), $config->getRequestStates())
-            && $request->getStatus() !== RequestStatus::HOSPITAL;
+        $this->assign('requestQueue', null);
+        if ($request->getQueue() !== null) {
+            /** @var RequestQueue $queue */
+            $queue = RequestQueue::getById($request->getQueue(), $this->getDatabase());
+            $this->assign('requestQueue', $queue->getHeader());
+            $this->assign('requestQueueApiName', $queue->getApiName());
+        }
+
+        $isClosed = $request->getStatus() === RequestStatus::CLOSED || $request->getStatus() === RequestStatus::JOBQUEUE;
         $this->assign('requestIsClosed', $isClosed);
     }
 

--- a/includes/Helpers/IrcNotificationHelper.php
+++ b/includes/Helpers/IrcNotificationHelper.php
@@ -14,6 +14,7 @@ use Waca\DataObjects\Comment;
 use Waca\DataObjects\EmailTemplate;
 use Waca\DataObjects\Notification;
 use Waca\DataObjects\Request;
+use Waca\DataObjects\RequestQueue;
 use Waca\DataObjects\User;
 use Waca\DataObjects\WelcomeTemplate;
 use Waca\ExceptionHandler;
@@ -41,8 +42,6 @@ class IrcNotificationHelper
     private $instanceName;
     /** @var string */
     private $baseUrl;
-    /** @var array */
-    private $requestStates;
     /** @var SiteConfiguration */
     private $siteConfiguration;
 
@@ -72,7 +71,6 @@ class IrcNotificationHelper
         $this->notificationType = $siteConfiguration->getIrcNotificationType();
         $this->instanceName = $siteConfiguration->getIrcNotificationsInstance();
         $this->baseUrl = $siteConfiguration->getBaseUrl();
-        $this->requestStates = $siteConfiguration->getRequestStates();
 
         $this->currentUser = User::getCurrent($primaryDatabase);
     }
@@ -303,9 +301,10 @@ class IrcNotificationHelper
      */
     public function requestDeferred(Request $request)
     {
-        $availableRequestStates = $this->requestStates;
+        /** @var RequestQueue $queue */
+        $queue = RequestQueue::getById($request->getQueue(), $request->getDatabase());
 
-        $deferTo = $availableRequestStates[$request->getStatus()]['deferto'];
+        $deferTo = $queue->getDisplayName();
         $username = $this->currentUser->getUsername();
 
         $this->send("Request {$request->getId()} ({$request->getName()}) deferred to {$deferTo} by {$username}");
@@ -319,9 +318,10 @@ class IrcNotificationHelper
      */
     public function requestDeferredWithMail(Request $request)
     {
-        $availableRequestStates = $this->requestStates;
+        /** @var RequestQueue $queue */
+        $queue = RequestQueue::getById($request->getQueue(), $request->getDatabase());
 
-        $deferTo = $availableRequestStates[$request->getStatus()]['deferto'];
+        $deferTo = $queue->getDisplayName();
         $username = $this->currentUser->getUsername();
         $id = $request->getId();
         $name = $request->getName();

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -245,12 +245,13 @@ class LogHelper
             ],
         );
 
-        $statement = $database->query(<<<SQL
-SELECT CONCAT('Closed ', id) AS k, CONCAT('closed (',name,')') AS v
-FROM emailtemplate;
+        $databaseDrivenLogKeys = $database->query(<<<SQL
+SELECT CONCAT('Closed ', id) AS k, CONCAT('closed (',name,')') AS v FROM emailtemplate
+UNION ALL
+SELECT CONCAT('Deferred to ', logname) AS k, CONCAT('deferred to ', displayname) AS v FROM requestqueue;
 SQL
         );
-        foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        foreach ($databaseDrivenLogKeys->fetchAll(PDO::FETCH_ASSOC) as $row) {
             $lookup["Requests"][$row['k']] = $row['v'];
         }
 

--- a/includes/Helpers/SearchHelpers/RequestSearchHelper.php
+++ b/includes/Helpers/SearchHelpers/RequestSearchHelper.php
@@ -185,8 +185,8 @@ class RequestSearchHelper extends SearchHelperBase
         return $this;
     }
 
-    public function fetchByStatus($statuses)
+    public function fetchByQueue($queues)
     {
-        return $this->fetchByParameter(' AND status = ?', $statuses);
+        return $this->fetchByParameter(' AND queue = ?', $queues);
     }
 }

--- a/includes/Pages/PageEmailManagement.php
+++ b/includes/Pages/PageEmailManagement.php
@@ -100,7 +100,7 @@ class PageEmailManagement extends InternalPageBase
             }
 
             if ($template->getId() === $createdId) {
-                $template->setDefaultAction(EmailTemplate::CREATED);
+                $template->setDefaultAction(EmailTemplate::ACTION_CREATED);
                 $template->setActive(true);
                 $template->setPreloadOnly(false);
             }

--- a/includes/Pages/PageExpandedRequestList.php
+++ b/includes/Pages/PageExpandedRequestList.php
@@ -8,9 +8,11 @@
 
 namespace Waca\Pages;
 
-use PDO;
-use Waca\DataObjects\Request;
+use Waca\DataObjects\RequestQueue;
 use Waca\Fragments\RequestListData;
+use Waca\Helpers\SearchHelpers\RequestSearchHelper;
+use Waca\RequestStatus;
+use Waca\SiteConfiguration;
 use Waca\Tasks\InternalPageBase;
 use Waca\WebRequest;
 
@@ -25,56 +27,45 @@ class PageExpandedRequestList extends InternalPageBase
      */
     protected function main()
     {
+        if(WebRequest::getString('queue') === null) {
+            $this->redirect('');
+            return;
+        }
+
+        $database = $this->getDatabase();
+
+        // FIXME: domains
+        $queue = RequestQueue::getByApiName($database, WebRequest::getString('queue'), 1);
+
+        if ($queue === false) {
+            $this->redirect('');
+            return;
+        }
+
+        /** @var SiteConfiguration $config */
         $config = $this->getSiteConfiguration();
 
-        $requestedStatus = WebRequest::getString('status');
-        $requestStates = $config->getRequestStates();
+        $this->assignCSRFToken();
 
-        if ($requestedStatus !== null && isset($requestStates[$requestedStatus])) {
+        $this->assign('queuehelp', $queue->getHelp());
 
-            $this->assignCSRFToken();
+        $search = RequestSearchHelper::get($database);
+        $search->byStatus(RequestStatus::OPEN);
 
-            $database = $this->getDatabase();
-
-            $help = $requestStates[$requestedStatus]['queuehelp'];
-            $this->assign('queuehelp', $help);
-
-            if ($config->getEmailConfirmationEnabled()) {
-                $query = "SELECT * FROM request WHERE status = :type AND emailconfirm = 'Confirmed';";
-                $totalQuery = "SELECT COUNT(id) FROM request WHERE status = :type AND emailconfirm = 'Confirmed';";
-            }
-            else {
-                $query = "SELECT * FROM request WHERE status = :type;";
-                $totalQuery = "SELECT COUNT(id) FROM request WHERE status = :type;";
-            }
-
-            $statement = $database->prepare($query);
-            $totalRequestsStatement = $database->prepare($totalQuery);
-
-            $statement->bindValue(":type", $requestedStatus);
-            $statement->execute();
-
-            $requests = $statement->fetchAll(PDO::FETCH_CLASS, Request::class);
-
-            /** @var Request $req */
-            foreach ($requests as $req) {
-                $req->setDatabase($database);
-            }
-
-            $this->assign('requests', $this->prepareRequestData($requests));
-            $this->assign('header', $requestedStatus);
-            $this->assign('requestLimitShowOnly', $config->getMiserModeLimit());
-            $this->assign('defaultRequestState', $config->getDefaultRequestStateKey());
-
-            $totalRequestsStatement->bindValue(':type', $requestedStatus);
-            $totalRequestsStatement->execute();
-            $totalRequests = $totalRequestsStatement->fetchColumn();
-            $totalRequestsStatement->closeCursor();
-            $this->assign('totalRequests', $totalRequests);
-
-
-            $this->setHtmlTitle('{$header|escape}{if $totalRequests > 0} [{$totalRequests|escape}]{/if}');
-            $this->setTemplate('mainpage/expandedrequestlist.tpl');
+        if ($config->getEmailConfirmationEnabled()) {
+            $search->withConfirmedEmail();
         }
+
+        $queuesById = [$queue->getId() => $queue];
+        $requestsByQueue = $search->fetchByQueue(array_keys($queuesById));
+        $requestData = $requestsByQueue[$queue->getId()];
+
+        $this->assign('requests', $this->prepareRequestData($requestData['data']));
+        $this->assign('totalRequests', $requestData['count']);
+        $this->assign('header', $queue->getHeader());
+        $this->assign('requestLimitShowOnly', $config->getMiserModeLimit());
+
+        $this->setHtmlTitle('{$header|escape}{if $totalRequests > 0} [{$totalRequests|escape}]{/if}');
+        $this->setTemplate('mainpage/expandedrequestlist.tpl');
     }
 }

--- a/includes/Pages/PageMain.php
+++ b/includes/Pages/PageMain.php
@@ -10,6 +10,7 @@ namespace Waca\Pages;
 
 use PDO;
 use Waca\DataObjects\Request;
+use Waca\DataObjects\RequestQueue;
 use Waca\DataObjects\User;
 use Waca\Fragments\RequestListData;
 use Waca\Helpers\SearchHelpers\RequestSearchHelper;
@@ -34,7 +35,9 @@ class PageMain extends InternalPageBase
         $currentUser = User::getCurrent($database);
 
         // general template configuration
-        $this->assign('defaultRequestState', $config->getDefaultRequestStateKey());
+        // FIXME: domains!
+        $defaultQueue = RequestQueue::getDefaultQueue($database, 1);
+        $this->assign('defaultRequestState', $defaultQueue->getApiName());
         $this->assign('requestLimitShowOnly', $config->getMiserModeLimit());
 
         $seeAllRequests = $this->barrierTest('seeAllRequests', $currentUser, PageViewRequest::class);
@@ -163,26 +166,34 @@ SQL;
         SiteConfiguration $config,
         &$requestSectionData
     ) {
-        $search = RequestSearchHelper::get($database)->limit($config->getMiserModeLimit())->notHospitalised();
+        $search = RequestSearchHelper::get($database)->limit($config->getMiserModeLimit());
+        $search->byStatus(RequestStatus::OPEN);
 
         if ($config->getEmailConfirmationEnabled()) {
             $search->withConfirmedEmail();
         }
 
-        $allRequestStates = $config->getRequestStates();
-        $requestsByStatus = $search->fetchByStatus(array_keys($allRequestStates));
+        // FIXME: domains!
+        $requestQueues = RequestQueue::getAllQueues($database);
+        $queuesById = array_reduce($requestQueues, function($result, RequestQueue $item) {
+            $result[$item->getId()] = $item;
+            return $result;
+        }, array());
 
-        foreach ($allRequestStates as $requestState => $requestStateConfig) {
+        $requestsByQueue = $search->fetchByQueue(array_keys($queuesById));
 
-            $requestSectionData[$requestStateConfig['header']] = array(
-                'requests' => $this->prepareRequestData($requestsByStatus[$requestState]['data']),
-                'total'    => $requestsByStatus[$requestState]['count'],
-                'api'      => $requestStateConfig['api'],
-                'type'     => $requestState,
-                'special'  => null,
-                'help'     => $requestStateConfig['queuehelp'],
-                'showAll'  => true
-            );
+        foreach ($requestsByQueue as $queueId => $queueData) {
+            if($queueData['count'] > 0 || $queuesById[$queueId]->isEnabled()) {
+                $requestSectionData[$queuesById[$queueId]->getHeader()] = array(
+                    'requests' => $this->prepareRequestData($queueData['data']),
+                    'total'    => $queueData['count'],
+                    'api'      => $queuesById[$queueId]->getApiName(),
+                    'type'     => $queueId,
+                    'special'  => null,
+                    'help'     => $queuesById[$queueId]->getHelp(),
+                    'showAll'  => true
+                );
+            }
         }
     }
 }

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -11,10 +11,12 @@ namespace Waca\Pages;
 use Exception;
 use DateTime;
 use Waca\DataObjects\Comment;
+use Waca\DataObjects\Domain;
 use Waca\DataObjects\EmailTemplate;
 use Waca\DataObjects\JobQueue;
 use Waca\DataObjects\Log;
 use Waca\DataObjects\Request;
+use Waca\DataObjects\RequestQueue;
 use Waca\DataObjects\User;
 use Waca\Exceptions\ApplicationLogicException;
 use Waca\Fragments\RequestData;
@@ -144,16 +146,16 @@ class PageViewRequest extends InternalPageBase
      */
     protected function setupGeneralData(PdoDatabase $database)
     {
-        $config = $this->getSiteConfiguration();
-
         $this->assign('createAccountReason', 'Requested account at [[WP:ACC]], request #');
 
-        $this->assign('defaultRequestState', $config->getDefaultRequestStateKey());
-
-        $this->assign('requestStates', $config->getRequestStates());
+        // FIXME: domains
+        /** @var Domain $domain */
+        $domain = Domain::getById(1, $database);
+        $this->assign('defaultRequestState', RequestQueue::getDefaultQueue($database, 1)->getApiName());
+        $this->assign('activeRequestQueues', RequestQueue::getEnabledQueues($database));
 
         /** @var EmailTemplate $createdTemplate */
-        $createdTemplate = EmailTemplate::getById($config->getDefaultCreatedTemplateId(), $database);
+        $createdTemplate = EmailTemplate::getById($domain->getDefaultClose(), $database);
 
         $this->assign('createdHasJsQuestion', $createdTemplate->getJsquestion() != '');
         $this->assign('createdId', $createdTemplate->getId());

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -158,14 +158,14 @@ class PageViewRequest extends InternalPageBase
         $this->assign('createdId', $createdTemplate->getId());
         $this->assign('createdName', $createdTemplate->getName());
 
-        $createReasons = EmailTemplate::getActiveTemplates(EmailTemplate::CREATED, $database);
+        $createReasons = EmailTemplate::getActiveTemplates(EmailTemplate::ACTION_CREATED, $database);
         $this->assign("createReasons", $createReasons);
-        $declineReasons = EmailTemplate::getActiveTemplates(EmailTemplate::NOT_CREATED, $database);
+        $declineReasons = EmailTemplate::getActiveTemplates(EmailTemplate::ACTION_NOT_CREATED, $database);
         $this->assign("declineReasons", $declineReasons);
 
-        $allCreateReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::CREATED, $database);
+        $allCreateReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::ACTION_CREATED, $database);
         $this->assign("allCreateReasons", $allCreateReasons);
-        $allDeclineReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::NOT_CREATED, $database);
+        $allDeclineReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::ACTION_NOT_CREATED, $database);
         $this->assign("allDeclineReasons", $allDeclineReasons);
         $allOtherReasons = EmailTemplate::getAllActiveTemplates(false, $database);
         $this->assign("allOtherReasons", $allOtherReasons);

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -21,6 +21,7 @@ use Waca\Fragments\RequestData;
 use Waca\Helpers\LogHelper;
 use Waca\Helpers\OAuthUserHelper;
 use Waca\PdoDatabase;
+use Waca\RequestStatus;
 use Waca\Tasks\InternalPageBase;
 use Waca\WebRequest;
 
@@ -124,7 +125,7 @@ class PageViewRequest extends InternalPageBase
     protected function setupTitle(Request $request)
     {
         $statusSymbol = self::STATUS_SYMBOL_OPEN;
-        if ($request->getStatus() === 'Closed') {
+        if ($request->getStatus() === RequestStatus::CLOSED) {
             if ($request->getWasCreated()) {
                 $statusSymbol = self::STATUS_SYMBOL_ACCEPTED;
             }

--- a/includes/Pages/Request/PageRequestAccount.php
+++ b/includes/Pages/Request/PageRequestAccount.php
@@ -11,6 +11,7 @@ namespace Waca\Pages\Request;
 use Exception;
 use Waca\DataObjects\Comment;
 use Waca\DataObjects\Request;
+use Waca\DataObjects\RequestQueue;
 use Waca\Exceptions\OptimisticLockFailedException;
 use Waca\Helpers\BanHelper;
 use Waca\SessionAlert;
@@ -90,8 +91,12 @@ class PageRequestAccount extends PublicInterfacePageBase
      */
     protected function createNewRequest()
     {
+        $database = $this->getDatabase();
+
         $request = new Request();
-        $request->setDatabase($this->getDatabase());
+        // FIXME: domains!
+        $request->setQueue(RequestQueue::getDefaultQueue($database, 1)->getId());
+        $request->setDatabase($database);
 
         $request->setName(trim(WebRequest::postString('name')));
         $request->setEmail(WebRequest::postEmail('email'));

--- a/includes/Pages/RequestAction/PageCloseRequest.php
+++ b/includes/Pages/RequestAction/PageCloseRequest.php
@@ -17,6 +17,7 @@ use Waca\Helpers\Logger;
 use Waca\Helpers\OAuthUserHelper;
 use Waca\Helpers\RequestEmailHelper;
 use Waca\PdoDatabase;
+use Waca\RequestStatus;
 use Waca\SessionAlert;
 use Waca\WebRequest;
 
@@ -41,7 +42,7 @@ class PageCloseRequest extends RequestActionBase
         $request = $this->getRequest($database);
         $request->setUpdateVersion(WebRequest::postInt('updateversion'));
 
-        if ($request->getStatus() === 'Closed') {
+        if ($request->getStatus() === RequestStatus::CLOSED) {
             throw new ApplicationLogicException('Request is already closed');
         }
 
@@ -58,7 +59,7 @@ class PageCloseRequest extends RequestActionBase
         }
 
         // I think we're good here...
-        $request->setStatus('Closed');
+        $request->setStatus(RequestStatus::CLOSED);
         $request->setReserved(null);
 
         Logger::closeRequest($database, $request, $template->getId(), null);

--- a/includes/Pages/RequestAction/PageCloseRequest.php
+++ b/includes/Pages/RequestAction/PageCloseRequest.php
@@ -60,6 +60,7 @@ class PageCloseRequest extends RequestActionBase
 
         // I think we're good here...
         $request->setStatus(RequestStatus::CLOSED);
+        $request->setQueue(null);
         $request->setReserved(null);
 
         Logger::closeRequest($database, $request, $template->getId(), null);
@@ -152,7 +153,7 @@ class PageCloseRequest extends RequestActionBase
      */
     protected function confirmAccountCreated(Request $request, EmailTemplate $template)
     {
-        if ($template->getDefaultAction() === EmailTemplate::CREATED && $this->checkAccountCreated($request)) {
+        if ($template->getDefaultAction() === EmailTemplate::ACTION_CREATED && $this->checkAccountCreated($request)) {
             $this->showConfirmation($request, $template, 'close-confirmations/account-created.tpl');
 
             return true;

--- a/includes/Pages/RequestAction/PageCloseRequest.php
+++ b/includes/Pages/RequestAction/PageCloseRequest.php
@@ -193,12 +193,12 @@ class PageCloseRequest extends RequestActionBase
     protected function sendMail(Request $request, $mailText, User $currentUser, $ccMailingList)
     {
         if (
-        ($request->getEmail() != $this->getSiteConfiguration()->getDataClearEmail()) && 
+        ($request->getEmail() != $this->getSiteConfiguration()->getDataClearEmail()) &&
         ($request->getIp() != $this->getSiteConfiguration()->getDataClearIp())
         ) {
             $requestEmailHelper = new RequestEmailHelper($this->getEmailHelper());
             $requestEmailHelper->sendMail($request, $mailText, $currentUser, $ccMailingList);
-            
+
             $request->setEmailSent(true);
             $request->save();
         }
@@ -241,7 +241,7 @@ class PageCloseRequest extends RequestActionBase
         $database = $this->getDatabase();
         $currentUser = User::getCurrent($database);
 
-        if ($action !== EmailTemplate::CREATED) {
+        if ($action !== EmailTemplate::ACTION_CREATED) {
             return;
         }
 

--- a/includes/Pages/RequestAction/PageCreateRequest.php
+++ b/includes/Pages/RequestAction/PageCreateRequest.php
@@ -114,7 +114,7 @@ class PageCreateRequest extends RequestActionBase
             throw new ApplicationLogicException('Invalid or inactive template specified');
         }
 
-        if ($template->getDefaultAction() !== EmailTemplate::CREATED) {
+        if ($template->getDefaultAction() !== EmailTemplate::ACTION_CREATED) {
             throw new ApplicationLogicException('Specified template is not a creation template!');
         }
 

--- a/includes/Pages/RequestAction/PageCustomClose.php
+++ b/includes/Pages/RequestAction/PageCustomClose.php
@@ -213,9 +213,9 @@ class PageCustomClose extends PageCloseRequest
         $action = WebRequest::postString('action');
         $availableRequestStates = $this->getSiteConfiguration()->getRequestStates();
 
-        if ($action === EmailTemplate::CREATED || $action === EmailTemplate::NOT_CREATED) {
+        if ($action === EmailTemplate::ACTION_CREATED || $action === EmailTemplate::ACTION_NOT_CREATED) {
 
-            if ($action === EmailTemplate::CREATED) {
+            if ($action === EmailTemplate::ACTION_CREATED) {
                 if ($this->checkAccountCreated($request)) {
                     $this->assignCSRFToken();
                     $this->showCustomCloseForm($database, $request);
@@ -297,7 +297,7 @@ class PageCustomClose extends PageCloseRequest
         // Perform the notifications and stuff *after* we've successfully saved, since the save can throw an OLE and
         // be rolled back.
 
-        if ($action == EmailTemplate::CREATED) {
+        if ($action == EmailTemplate::ACTION_CREATED) {
             $logCloseType = 'custom-y';
             $notificationCloseType = "Custom, Created";
         }
@@ -415,6 +415,6 @@ class PageCustomClose extends PageCloseRequest
         SessionAlert::success("Request {$request->getId()} has been queued for autocreation");
 
         // forge this since it is actually a creation.
-        $this->processWelcome(EmailTemplate::CREATED, $creationTaskId);
+        $this->processWelcome(EmailTemplate::ACTION_CREATED, $creationTaskId);
     }
 }

--- a/includes/Pages/RequestAction/PageCustomClose.php
+++ b/includes/Pages/RequestAction/PageCustomClose.php
@@ -40,7 +40,7 @@ class PageCustomClose extends PageCloseRequest
         $request = $this->getRequest($database);
         $currentUser = User::getCurrent($this->getDatabase());
 
-        if ($request->getStatus() === 'Closed') {
+        if ($request->getStatus() === RequestStatus::CLOSED) {
             throw new ApplicationLogicException('Request is already closed');
         }
 
@@ -201,7 +201,7 @@ class PageCustomClose extends PageCloseRequest
             $ccMailingList = WebRequest::postBoolean('ccMailingList');
         }
 
-        if ($request->getStatus() === 'Closed') {
+        if ($request->getStatus() === RequestStatus::CLOSED) {
             throw new ApplicationLogicException('Request is already closed');
         }
 
@@ -289,7 +289,7 @@ class PageCustomClose extends PageCloseRequest
      */
     protected function closeRequest(Request $request, PdoDatabase $database, $action, $messageBody)
     {
-        $request->setStatus('Closed');
+        $request->setStatus(RequestStatus::CLOSED);
         $request->setReserved(null);
         $request->setUpdateVersion(WebRequest::postInt('updateversion'));
         $request->save();

--- a/includes/Pages/RequestAction/PageCustomClose.php
+++ b/includes/Pages/RequestAction/PageCustomClose.php
@@ -14,6 +14,7 @@ use Waca\Background\Task\UserCreationTask;
 use Waca\DataObjects\EmailTemplate;
 use Waca\DataObjects\JobQueue;
 use Waca\DataObjects\Request;
+use Waca\DataObjects\RequestQueue;
 use Waca\DataObjects\User;
 use Waca\Exceptions\AccessDeniedException;
 use Waca\Exceptions\ApplicationLogicException;
@@ -126,17 +127,19 @@ class PageCustomClose extends PageCloseRequest
 
         // Preload data
         $this->assign('defaultAction', '');
+        $this->assign('defaultQueue', null);
         $this->assign('preloadText', '');
         $this->assign('preloadTitle', '');
 
         if ($template !== null) {
             $this->assign('defaultAction', $template->getDefaultAction());
+            $this->assign('defaultQueue', $template->getQueue());
             $this->assign('preloadText', $template->getText());
             $this->assign('preloadTitle', $template->getName());
         }
 
         // Static data
-        $this->assign('requeststates', $config->getRequestStates());
+        $this->assign('requestQueues', $requestQueues = RequestQueue::getEnabledQueues($database));
 
         // request data
         $this->assign('requestId', $request->getIp());
@@ -211,7 +214,6 @@ class PageCustomClose extends PageCloseRequest
         }
 
         $action = WebRequest::postString('action');
-        $availableRequestStates = $this->getSiteConfiguration()->getRequestStates();
 
         if ($action === EmailTemplate::ACTION_CREATED || $action === EmailTemplate::ACTION_NOT_CREATED) {
 
@@ -247,9 +249,30 @@ class PageCustomClose extends PageCloseRequest
             return true;
         }
 
-        // If action is a state key, defer to other state
-        if (array_key_exists($action, $availableRequestStates)) {
-            $this->deferRequest($request, $database, $action, $availableRequestStates, $messageBody);
+        if ($action === 'mail') {
+            $request->setReserved(null);
+            $request->setUpdateVersion(WebRequest::postInt('updateversion'));
+            $request->save();
+
+            // Perform the notifications and stuff *after* we've successfully saved, since the save can throw an OLE
+            // and be rolled back.
+
+            // Send mail
+            $this->sendMail($request, $messageBody, $currentUser, $ccMailingList);
+
+            Logger::sentMail($database, $request, $messageBody);
+            Logger::unreserve($database, $request);
+
+            $this->getNotificationHelper()->sentMail($request);
+            SessionAlert::success("Sent mail to Request {$request->getId()}");
+
+            return true;
+        }
+
+        $targetQueue = RequestQueue::getByApiName($database, $action, 1);
+        if ($targetQueue !== false) {
+            // Defer to other state
+            $this->deferRequest($request, $database, $targetQueue, $messageBody);
 
             // Send the mail after the save, since save can be rolled back
             $this->sendMail($request, $messageBody, $currentUser, $ccMailingList);
@@ -257,25 +280,7 @@ class PageCustomClose extends PageCloseRequest
             return true;
         }
 
-        // Any other scenario, just send the email.
-
-        $request->setReserved(null);
-        $request->setUpdateVersion(WebRequest::postInt('updateversion'));
-        $request->save();
-
-        // Perform the notifications and stuff *after* we've successfully saved, since the save can throw an OLE
-        // and be rolled back.
-
-        // Send mail
-        $this->sendMail($request, $messageBody, $currentUser, $ccMailingList);
-
-        Logger::sentMail($database, $request, $messageBody);
-        Logger::unreserve($database, $request);
-
-        $this->getNotificationHelper()->sentMail($request);
-        SessionAlert::success("Sent mail to Request {$request->getId()}");
-
-        return true;
+        throw new ApplicationLogicException('Unknown action for custom close.');
     }
 
     /**
@@ -290,6 +295,7 @@ class PageCustomClose extends PageCloseRequest
     protected function closeRequest(Request $request, PdoDatabase $database, $action, $messageBody)
     {
         $request->setStatus(RequestStatus::CLOSED);
+        $request->setQueue(null);
         $request->setReserved(null);
         $request->setUpdateVersion(WebRequest::postInt('updateversion'));
         $request->save();
@@ -314,23 +320,21 @@ class PageCustomClose extends PageCloseRequest
     }
 
     /**
-     * @param Request     $request
-     * @param PdoDatabase $database
-     * @param string      $action
-     * @param             $availableRequestStates
-     * @param string      $messageBody
+     * @param Request      $request
+     * @param PdoDatabase  $database
+     * @param RequestQueue $targetQueue
+     * @param string       $messageBody
      *
-     * @throws Exception
      * @throws OptimisticLockFailedException
      */
     protected function deferRequest(
         Request $request,
         PdoDatabase $database,
-        $action,
-        $availableRequestStates,
+        RequestQueue $targetQueue,
         $messageBody
     ) {
-        $request->setStatus($action);
+        $request->setStatus(RequestStatus::OPEN);
+        $request->setQueue($targetQueue->getId());
         $request->setReserved(null);
         $request->setUpdateVersion(WebRequest::postInt('updateversion'));
         $request->save();
@@ -338,13 +342,13 @@ class PageCustomClose extends PageCloseRequest
         // Perform the notifications and stuff *after* we've successfully saved, since the save can throw an OLE
         // and be rolled back.
 
-        $deferToLog = $availableRequestStates[$action]['defertolog'];
+        $deferToLog = $targetQueue->getLogName();
         Logger::sentMail($database, $request, $messageBody);
         Logger::deferRequest($database, $request, $deferToLog);
 
         $this->getNotificationHelper()->requestDeferredWithMail($request);
 
-        $deferTo = $availableRequestStates[$action]['deferto'];
+        $deferTo = htmlentities($targetQueue->getDisplayName(), ENT_COMPAT, 'UTF-8');
         SessionAlert::success("Request {$request->getId()} deferred to $deferTo, sending an email.");
     }
 

--- a/includes/Pages/RequestAction/PageReservation.php
+++ b/includes/Pages/RequestAction/PageReservation.php
@@ -12,6 +12,7 @@ use DateTime;
 use Waca\DataObjects\User;
 use Waca\Exceptions\ApplicationLogicException;
 use Waca\Helpers\Logger;
+use Waca\RequestStatus;
 use Waca\SessionAlert;
 use Waca\WebRequest;
 
@@ -34,7 +35,7 @@ class PageReservation extends RequestActionBase
         $oneweek = $date->format("Y-m-d H:i:s");
 
         $currentUser = User::getCurrent($database);
-        if ($request->getStatus() == "Closed" && $closureDate < $oneweek) {
+        if ($request->getStatus() == RequestStatus::CLOSED && $closureDate < $oneweek) {
             if (!$this->barrierTest('reopenOldRequest', $currentUser, 'RequestData')) {
                 throw new ApplicationLogicException(
                     "You are not allowed to reserve a request that has been closed for over a week.");

--- a/includes/Pages/Statistics/StatsTopCreators.php
+++ b/includes/Pages/Statistics/StatsTopCreators.php
@@ -135,7 +135,7 @@ SQL;
         $database = $this->getDatabase();
         foreach ($queries as $name => $sql) {
             $statement = $database->prepare($sql);
-            $statement->execute([":created" => EmailTemplate::CREATED]);
+            $statement->execute([":created" => EmailTemplate::ACTION_CREATED]);
             $data = $statement->fetchAll(PDO::FETCH_ASSOC);
             $this->assign($name, $data);
         }

--- a/includes/Pages/Statistics/StatsUsers.php
+++ b/includes/Pages/Statistics/StatsUsers.php
@@ -99,7 +99,7 @@ WHERE user.username = :username
 ORDER BY log.timestamp;
 SQL
         );
-        $usersCreatedQuery->execute(array(":username" => $user->getUsername(), ':created' => EmailTemplate::CREATED));
+        $usersCreatedQuery->execute(array(":username" => $user->getUsername(), ':created' => EmailTemplate::ACTION_CREATED));
         $usersCreated = $usersCreatedQuery->fetchAll(PDO::FETCH_ASSOC);
         $this->assign("created", $usersCreated);
 
@@ -115,7 +115,7 @@ WHERE user.username = :username
 ORDER BY log.timestamp;
 SQL
         );
-        $usersNotCreatedQuery->execute(array(":username" => $user->getUsername(), ':created' => EmailTemplate::NOT_CREATED));
+        $usersNotCreatedQuery->execute(array(":username" => $user->getUsername(), ':created' => EmailTemplate::ACTION_NOT_CREATED));
         $usersNotCreated = $usersNotCreatedQuery->fetchAll(PDO::FETCH_ASSOC);
         $this->assign("notcreated", $usersNotCreated);
 

--- a/includes/RequestStatus.php
+++ b/includes/RequestStatus.php
@@ -13,4 +13,5 @@ class RequestStatus
     const HOSPITAL = 'Hospital';
     const JOBQUEUE = 'JobQueue';
     const CLOSED = 'Closed';
+    const OPEN = 'Open';
 }

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -19,7 +19,7 @@ class SiteConfiguration
 {
     private $baseUrl;
     private $filePath;
-    private $schemaVersion = 37;
+    private $schemaVersion = 38;
     private $debuggingTraceEnabled;
     private $dataClearIp = '127.0.0.1';
     private $dataClearEmail = 'acc@toolserver.org';

--- a/includes/Validation/RequestValidationHelper.php
+++ b/includes/Validation/RequestValidationHelper.php
@@ -12,6 +12,7 @@ use Exception;
 use Waca\DataObjects\Ban;
 use Waca\DataObjects\Comment;
 use Waca\DataObjects\Request;
+use Waca\DataObjects\RequestQueue;
 use Waca\ExceptionHandler;
 use Waca\Exceptions\CurlException;
 use Waca\Helpers\HttpHelper;
@@ -123,7 +124,7 @@ class RequestValidationHelper
         if (preg_match("/[" . preg_quote("#@/<>[]|{}", "/") . "]/", $request->getName()) === 1) {
             $errorList[ValidationError::NAME_INVALIDCHAR] = new ValidationError(ValidationError::NAME_INVALIDCHAR);
         }
-        
+
         // username is an IP
         if (filter_var($request->getName(), FILTER_VALIDATE_IP)) {
             $errorList[ValidationError::NAME_IP] = new ValidationError(ValidationError::NAME_IP);
@@ -233,7 +234,8 @@ class RequestValidationHelper
             }
 
             if ($ban->getAction() == Ban::ACTION_DEFER) {
-                $this->deferRequest($request, $ban->getActionTarget(), 'Request deferred automatically due to matching rule.');
+                $targetQueue = RequestQueue::getById($ban->getTargetQueue(), $this->database);
+                $this->deferRequest($request, $targetQueue, 'Request deferred automatically due to matching rule.');
             }
         }
     }
@@ -243,8 +245,10 @@ class RequestValidationHelper
         try {
             if (count($this->antiSpoofProvider->getSpoofs($request->getName())) > 0) {
                 // If there were spoofs an Admin should handle the request.
-                $this->deferRequest($request, 'Flagged users',
-                    'Request automatically deferred to flagged users due to AntiSpoof hit');
+                // FIXME: domains!
+                $defaultQueue = RequestQueue::getDefaultQueue($this->database, 1, RequestQueue::DEFAULT_ANTISPOOF);
+                $this->deferRequest($request, $defaultQueue,
+                    'Request automatically deferred due to AntiSpoof hit');
             }
         }
         catch (Exception $ex) {
@@ -281,8 +285,11 @@ class RequestValidationHelper
             }
 
             if (!$requestIsOk) {
-                $this->deferRequest($request, 'Flagged users',
-                    'Request automatically deferred to flagged users due to title blacklist hit');
+                // FIXME: domains!
+                $defaultQueue = RequestQueue::getDefaultQueue($this->database, 1, RequestQueue::DEFAULT_TITLEBLACKLIST);
+
+                $this->deferRequest($request, $defaultQueue,
+                    'Request automatically deferred due to title blacklist hit');
             }
         }
     }
@@ -369,12 +376,12 @@ class RequestValidationHelper
         return $statement->fetchColumn() > 0;
     }
 
-    private function deferRequest(Request $request, $targetQueue, $deferComment): void
+    private function deferRequest(Request $request, RequestQueue $targetQueue, $deferComment): void
     {
-        $request->setStatus($targetQueue);
+        $request->setQueue($targetQueue->getId());
         $request->save();
 
-        $logTarget = $this->siteConfiguration->getRequestStates()[$targetQueue]['defertolog'];
+        $logTarget = $targetQueue->getLogName();
 
         Logger::deferRequest($this->database, $request, $logTarget);
 

--- a/sql/patches/patch38-requestqueuemigration.sql
+++ b/sql/patches/patch38-requestqueuemigration.sql
@@ -1,0 +1,104 @@
+-- -----------------------------------------------------------------------------
+-- Hey!
+-- 
+-- This is a new patch-creation script which SHOULD stop double-patching and
+-- running patches out-of-order.
+--
+-- If you're running patches, please close this file, and run this from the 
+-- command line:
+--   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
+-- where:
+--      USERNAME = a user with CREATE/ALTER access to the schema
+--      SCHEMA = the schema to run the changes against
+--      patch-XX-this-file.sql = this file
+--
+-- If you are writing patches, you need to copy this template to a numbered 
+-- patch file, update the patchversion variable, and add the SQL code to upgrade
+-- the database where indicated below.
+
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
+DELIMITER ';;'
+CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
+    -- -------------------------------------------------------------------------
+    -- Developers - set the number of the schema patch here!
+    -- -------------------------------------------------------------------------
+    DECLARE patchversion INT DEFAULT 38;
+    -- -------------------------------------------------------------------------
+    -- working variables
+    DECLARE currentschemaversion INT DEFAULT 0;
+    DECLARE lastversion INT;
+	
+    -- check the schema has a version table
+    IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'schemaversion' AND table_schema = DATABASE()) THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please ensure patches are run in order! This database does not have a schemaversion table.';
+    END IF;
+    
+    -- get the current version
+    SELECT version INTO currentschemaversion FROM schemaversion;
+    
+    -- check schema is not ahead of this patch
+    IF currentschemaversion >= patchversion THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'This patch has already been applied!';
+    END IF;
+    
+    -- check schema is up-to-date
+    SET lastversion = patchversion - 1;
+    IF currentschemaversion != lastversion THEN
+		SET @message_text = CONCAT('Please ensure patches are run in order! This patch upgrades to version ', patchversion, ', but the database is not version ', lastversion);
+        SIGNAL SQLSTATE '45000' SET message_text = @message_text;
+    END IF;
+
+    -- -------------------------------------------------------------------------
+    -- Developers - put your upgrade statements here!
+    -- -------------------------------------------------------------------------
+
+    -- request table - queue/status columns
+    alter table request
+        add queue int unsigned null after status,
+        add constraint request_requestqueue_id_fk foreign key (queue) references requestqueue (id);
+
+    update request r
+    set queue = (select id from requestqueue rq where rq.legacystatus = r.status)
+    where 1 = 1;
+
+    update request r set status = 'Open' where queue is not null and status not in ('Closed', 'JobQueue', 'Hospital');
+
+    -- email template - defer target column
+    alter table emailtemplate
+        add queue int unsigned null after defaultaction,
+        add constraint emailtemplate_requestqueue_id_fk foreign key (queue) references requestqueue (id);
+
+    update emailtemplate et
+    set queue = (select id from requestqueue rq where rq.legacystatus = et.defaultaction)
+    where 1 = 1;
+
+    update emailtemplate set defaultaction = 'defer' where queue is not null;
+    update emailtemplate set defaultaction = 'none' where defaultaction is null;
+
+    alter table emailtemplate
+        add constraint emailtemplate_defaultaction check (defaultaction in ('created', 'not created', 'defer', 'none'));
+
+    -- ban table - defer target
+    alter table ban
+        add column targetqueue int unsigned null after action,
+        add constraint ban_requestqueue_id_fk foreign key (targetqueue) references requestqueue (id);
+
+    # noinspection SqlResolve @ column/"actiontarget"
+    update ban b set b.updateversion = b.updateversion + 1,
+                     b.targetqueue = (select rq.id from requestqueue rq where rq.legacystatus = b.actiontarget)
+    where b.actiontarget is not null and b.action = 'defer';
+
+    # noinspection SqlResolve @ column/"actiontarget"
+    alter table ban
+        drop column actiontarget;
+
+    alter table ban
+        add constraint ban_action check (action in ('block', 'drop', 'defer', 'none')),
+        add constraint ban_targetqueue check (case when action = 'defer' and targetqueue is null then false else true end);
+
+    alter table requestqueue drop column legacystatus;
+
+END;;
+DELIMITER ';'
+CALL SCHEMA_UPGRADE_SCRIPT();
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;

--- a/templates/bans/banform.tpl
+++ b/templates/bans/banform.tpl
@@ -132,8 +132,8 @@
                                 </div>
                                 <div class="col-sm-8 col-md-5 col-lg-8 col-xl-6">
                                     <select class="form-control" name="banActionTarget" required="required" id="banActionTarget">
-                                        {foreach $requestStates as $key => $state}
-                                            <option value="{$key}">{$state.deferto|capitalize}</option>
+                                        {foreach $requestQueues as $queue}
+                                            <option value="{$queue->getApiName()|escape}">{$queue->getHeader()|escape}</option>
                                         {/foreach}
                                     </select>
                                 </div>

--- a/templates/bans/list.tpl
+++ b/templates/bans/list.tpl
@@ -20,7 +20,7 @@
             <td>
                 {if $ban->getAction() == $ban::ACTION_BLOCK}<abbr title="Blocks the user from submitting the request" data-toggle="tooltip">Block</abbr>{/if}
                 {if $ban->getAction() == $ban::ACTION_DROP}<abbr title="Accepts the request for processing, but immediately drops it." data-toggle="tooltip">Drop</abbr>{/if}
-                {if $ban->getAction() == $ban::ACTION_DEFER}<abbr title="Defers the request into the specified queue" data-toggle="tooltip">Defer to {$ban->getActionTarget()|escape}</abbr>{/if}
+                {if $ban->getAction() == $ban::ACTION_DEFER}<abbr title="Defers the request into the specified queue" data-toggle="tooltip">Defer</abbr> to {$ban->getTargetQueueObject()->getDisplayName()|escape}{/if}
                 {if $ban->getAction() == $ban::ACTION_NONE}<abbr title="Does nothing but flag the request." data-toggle="tooltip">Report only</abbr>{/if}
             </td>
             <td>{include file="bans/banreason.tpl"}</td>

--- a/templates/custom-close.tpl
+++ b/templates/custom-close.tpl
@@ -38,7 +38,7 @@
             </div>
             <div class="col-md-8 col-lg-6">
                 <select class="form-control" id="inputAction" name="action" required="required">
-                    <option value="" {if $defaultAction == ""}selected="selected"{/if}>(please select)</option>
+                    <option value="" {if $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_NONE}selected="selected"{/if}>(please select)</option>
                     <option value="mail" {if $preloadAction == "mail"}selected="selected"{/if}>Only send the email</option>
                     <optgroup label="Send email and close request...">
                         <option value="created" {if $preloadAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED && $currentUser->getCreationMode() == 0)}selected="selected"{/if}>
@@ -59,9 +59,12 @@
                         </option>
                     </optgroup>
                     <optgroup label="Send email and defer to...">
-                        {foreach $requeststates as $state}
-                            <option value="{$state@key}" {if $preloadAction == $state@key || ($preloadAction === null && $defaultAction == $state@key )}selected="selected"{/if}>
-                                Defer to {$state.deferto|capitalize}</option>
+                        {foreach $requestQueues as $queue}
+                            {assign "queueSelected" "{$defaultAction == Waca\DataObjects\EmailTemplate::ACTION_DEFER && $defaultQueue == $queue->getId()}" }
+                            {if $queue->getApiName() !== $requestQueueApiName || {$queueSelected} }
+                                <option value="{$queue->getApiName()|escape}" {if $queueSelected}selected="selected"{/if}>
+                                    Defer to {$queue->getDisplayName()|escape}</option>
+                            {/if}
                         {/foreach}
                     </optgroup>
                 </select>

--- a/templates/custom-close.tpl
+++ b/templates/custom-close.tpl
@@ -41,20 +41,20 @@
                     <option value="" {if $defaultAction == ""}selected="selected"{/if}>(please select)</option>
                     <option value="mail" {if $preloadAction == "mail"}selected="selected"{/if}>Only send the email</option>
                     <optgroup label="Send email and close request...">
-                        <option value="created" {if $preloadAction == "created" || ($preloadAction === null && $defaultAction == "created" && $currentUser->getCreationMode() == 0)}selected="selected"{/if}>
+                        <option value="created" {if $preloadAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED && $currentUser->getCreationMode() == 0)}selected="selected"{/if}>
                             Close request as created
                         </option>
                         {if $canOauthCreate}
-                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH}"  {if $preloadAction == Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH || ($preloadAction === null && $defaultAction == "created" && $currentUser->getCreationMode() == 1)}selected="selected"{/if}>
+                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH}"  {if $preloadAction == Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED && $currentUser->getCreationMode() == 1)}selected="selected"{/if}>
                                 Create account (Wikimedia account) & close request as created
                             </option>
                         {/if}
                         {if $canBotCreate}
-                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT}"  {if $preloadAction == Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT || ($preloadAction === null && $defaultAction == "created" && $currentUser->getCreationMode() == 2)}selected="selected"{/if}>
+                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT}"  {if $preloadAction == Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED && $currentUser->getCreationMode() == 2)}selected="selected"{/if}>
                                 Create account (via bot) & close request as created
                             </option>
                         {/if}
-                        <option value="not created" {if $preloadAction == "not created" || ($preloadAction === null && $defaultAction == "not created") }selected="selected"{/if}>
+                        <option value="not created" {if $preloadAction == Waca\DataObjects\EmailTemplate::ACTION_NOT_CREATED || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_NOT_CREATED) }selected="selected"{/if}>
                             Close request as NOT created
                         </option>
                     </optgroup>

--- a/templates/email-management/edit.tpl
+++ b/templates/email-management/edit.tpl
@@ -59,10 +59,12 @@
                                 No default
                             </option>
                             <optgroup label="Close request...">
-                                <option value="created" {if $emailTemplate->getDefaultAction() == "created"}selected="selected"{/if}>
+                                <option value="{Waca\DataObjects\EmailTemplate::ACTION_CREATED}"
+                                        {if $emailTemplate->getDefaultAction() == Waca\DataObjects\EmailTemplate::ACTION_CREATED}selected="selected"{/if}>
                                     Close request as created (with autocreate if allowed)
                                 </option>
-                                <option value="not created" {if $emailTemplate->getDefaultAction() == "not created"}selected="selected"{/if}>
+                                <option value="{Waca\DataObjects\EmailTemplate::ACTION_NOT_CREATED}"
+                                        {if $emailTemplate->getDefaultAction() == Waca\DataObjects\EmailTemplate::ACTION_NOT_CREATED}selected="selected"{/if}>
                                     Close request as NOT created
                                 </option>
                             </optgroup>

--- a/templates/email-management/edit.tpl
+++ b/templates/email-management/edit.tpl
@@ -55,7 +55,7 @@
 
                         <select class="form-control" id="inputDefaultAction" aria-describedby="templateDefaultActionHelp"
                                 name="defaultaction" {if $id == $createdid} disabled{/if}>
-                            <option value="" {if $emailTemplate->getDefaultAction() == ""}selected="selected"{/if}>
+                            <option value="{Waca\DataObjects\EmailTemplate::ACTION_NONE}" {if $emailTemplate->getDefaultAction() == Waca\DataObjects\EmailTemplate::ACTION_NONE}selected="selected"{/if}>
                                 No default
                             </option>
                             <optgroup label="Close request...">
@@ -69,10 +69,9 @@
                                 </option>
                             </optgroup>
                             <optgroup label="Defer to...">
-                                {foreach $requeststates as $state}
-                                    <option value="{$state@key}" {if $emailTemplate->getDefaultAction() == $state@key}selected="selected"{/if}>
-                                        Defer to {$state.deferto|capitalize}
-                                    </option>
+                                {foreach $requestQueues as $queue}
+                                    <option value="{$queue->getApiName()|escape}" {if $emailTemplate->getQueue() == $queue->getId() && $emailTemplate->getDefaultAction() == 'defer'}selected="selected"{/if}>
+                                        Defer to {$queue->getDisplayName()|escape}</option>
                                 {/foreach}
                             </optgroup>
                         </select>

--- a/templates/email-management/template-table.tpl
+++ b/templates/email-management/template-table.tpl
@@ -3,9 +3,9 @@
         <tr>
             <th>{$row->getName()|escape}</th>
             <td class="text-nowrap">
-                {if $row->getDefaultAction() === 'created'}
+                {if $row->getDefaultAction() === Waca\DataObjects\EmailTemplate::ACTION_CREATED}
                     <span class="badge badge-success">Create</span>
-                {elseif $row->getDefaultAction() === 'not created'}
+                {elseif $row->getDefaultAction() === Waca\DataObjects\EmailTemplate::ACTION_NOT_CREATED}
                     <span class="badge badge-danger">Decline</span>
                 {elseif $row->getDefaultAction() == null}
                     <span class="badge badge-secondary">No default</span>

--- a/templates/email-management/template-table.tpl
+++ b/templates/email-management/template-table.tpl
@@ -7,10 +7,10 @@
                     <span class="badge badge-success">Create</span>
                 {elseif $row->getDefaultAction() === Waca\DataObjects\EmailTemplate::ACTION_NOT_CREATED}
                     <span class="badge badge-danger">Decline</span>
-                {elseif $row->getDefaultAction() == null}
+                {elseif $row->getDefaultAction() === Waca\DataObjects\EmailTemplate::ACTION_NONE}
                     <span class="badge badge-secondary">No default</span>
-                {else}
-                    <span class="badge badge-info">Defer to {$row->getDefaultAction()|escape}</span>
+                {elseif $row->getDefaultAction() === Waca\DataObjects\EmailTemplate::ACTION_DEFER}
+                    <span class="badge badge-info">Defer to {$row->getQueueObject()->getDisplayName()|escape}</span>
                 {/if}
 
                 {if $row->getPreloadOnly()}<span class="d-md-none"><br /><span class="badge badge-info">Preload only</span></span>{/if}

--- a/templates/email-management/view.tpl
+++ b/templates/email-management/view.tpl
@@ -48,9 +48,9 @@
                 <div class="col-sm-9 col-lg-5 col-xl-4 lead">
                     {if $emailTemplate->getDefaultAction() == ""}
                         <span class="badge badge-secondary">No default action</span>
-                    {elseif $emailTemplate->getDefaultAction() == "created"}
+                    {elseif $emailTemplate->getDefaultAction() == Waca\DataObjects\EmailTemplate::ACTION_CREATED}
                         <span class="badge badge-success">Close request as created</span>
-                    {elseif $emailTemplate->getDefaultAction() == "not created"}
+                    {elseif $emailTemplate->getDefaultAction() == Waca\DataObjects\EmailTemplate::ACTION_NOT_CREATED}
                         <span class="badge badge-danger">Close request as NOT created</span>
                     {else}
                         <span class="badge badge-info">Defer to {$requeststates[$emailTemplate->getDefaultAction()].deferto|capitalize}</span>

--- a/templates/email-management/view.tpl
+++ b/templates/email-management/view.tpl
@@ -46,14 +46,14 @@
                     <label class="col-form-label" for="inputDefaultAction">Default action</label>
                 </div>
                 <div class="col-sm-9 col-lg-5 col-xl-4 lead">
-                    {if $emailTemplate->getDefaultAction() == ""}
+                    {if $emailTemplate->getDefaultAction() == Waca\DataObjects\EmailTemplate::ACTION_NONE}
                         <span class="badge badge-secondary">No default action</span>
                     {elseif $emailTemplate->getDefaultAction() == Waca\DataObjects\EmailTemplate::ACTION_CREATED}
                         <span class="badge badge-success">Close request as created</span>
                     {elseif $emailTemplate->getDefaultAction() == Waca\DataObjects\EmailTemplate::ACTION_NOT_CREATED}
                         <span class="badge badge-danger">Close request as NOT created</span>
-                    {else}
-                        <span class="badge badge-info">Defer to {$requeststates[$emailTemplate->getDefaultAction()].deferto|capitalize}</span>
+                    {elseif $emailTemplate->getDefaultAction() == Waca\DataObjects\EmailTemplate::ACTION_DEFER}
+                        <span class="badge badge-info">Defer to {$emailTemplate->getQueueObject()->getDisplayName()|escape}</span>
                     {/if}
                 </div>
             </div>

--- a/templates/mainpage/accordiongroup.tpl
+++ b/templates/mainpage/accordiongroup.tpl
@@ -9,7 +9,7 @@
             </div>
             {if $section.total > 0 && $section.showAll}
                 <div class="col-auto">
-                    <a href="{$baseurl}/internal.php/requestList?status={$section.type|escape:'url'}" class="btn text-muted">Show all</a>
+                    <a href="{$baseurl}/internal.php/requestList?queue={$section.api|escape:'url'}" class="btn text-muted">Show all</a>
                 </div>
             {/if}
         </div>
@@ -17,9 +17,7 @@
     <div id="collapse{$section.api|escape}" class="collapse" data-parent="#requestListAccordion">
         <div class="card-body">
             {if $section.help !== null}
-                <div class="alert alert-info alert-accordion">
-                    {$section.help}{* this data is either hard-coded, or set to a html string in config. No user data here. *}
-                </div>
+                <div class="alert alert-info alert-accordion prewrap">{$section.help|escape}</div>
             {/if}
             {include file="mainpage/requestlist.tpl" showStatus={$section.special !== null}}
         </div>

--- a/templates/mainpage/expandedrequestlist.tpl
+++ b/templates/mainpage/expandedrequestlist.tpl
@@ -4,7 +4,7 @@
     <div class="row">
         <div class="col-md-12" >
             <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                <h1 class="h2">List {$header|escape|lower} requests</h1>
+                <h1 class="h2">{$header|escape}: All requests</h1>
             </div>
         </div>
     </div>
@@ -12,7 +12,7 @@
     <div class="row">
         <div class="col-12">
             {if $queuehelp}
-                <p>{$queuehelp}</p>
+                <p class="prewrap">{$queuehelp}</p>
             {/if}
             <p>There {if $totalRequests !== 1}are {$totalRequests} requests{else}is 1 request{/if} open in this queue.</p>
             {if $totalRequests > $requestLimitShowOnly}<p>Not all of these requests will show on the main page, as the main page is limited to showing {$requestLimitShowOnly} requests.</p>{/if}

--- a/templates/mainpage/lastFive.tpl
+++ b/templates/mainpage/lastFive.tpl
@@ -28,7 +28,7 @@
                             <input class="form-control" type="hidden" name="request" value="{$req.id}"/>
                             <input class="form-control" type="hidden" name="updateversion"
                                    value="{$req.updateversion}"/>
-                            <input class="form-control" type="hidden" name="target" value="{$defaultRequestState}"/>
+                            <input class="form-control" type="hidden" name="target" value="{$defaultRequestState|escape}"/>
                             <button class="btn btn-warning btn-sm" type="submit">
                                 <i class="fas fa-sync"></i>&nbsp;Reset
                             </button>

--- a/templates/queue-management/edit.tpl
+++ b/templates/queue-management/edit.tpl
@@ -47,20 +47,21 @@
                                     <label for="apiName" class="col-form-label">API name:</label>
                                 </div>
                                 <div class="col-sm-5 col-md-4 col-lg-5 col-xl-4">
-                                    <input type="text" class="form-control" id="apiName" name="apiName" maxlength="20" required="required" placeholder="checkuser" value="{$apiName|escape}" {if !$createMode}disabled{/if}/>
-                                    <small class="form-text text-muted" id="apiNameHelp">The key to use for this queue in the API. Cannot be changed after creation.</small>
+                                    <input type="text" class="form-control" id="apiName" name="apiName" maxlength="20" required="required" placeholder="checkuser" pattern="^[A-Za-z][a-zA-Z0-9_-]*$" value="{$apiName|escape}" {if !$createMode}disabled{/if}/>
+                                    <small class="form-text text-muted" id="apiNameHelp">The key to use for this queue in the API. Cannot be changed after creation. Must start with a letter, and only contain letters, numbers, hyphens and underscores.</small>
                                 </div>
                             </div>
 
                             <div class="form-group row">
                                 <div class="offset-sm-4 offset-md-3 offset-lg-4 offset-xl-3 col-md-9">
                                     <div class="custom-control custom-switch">
-                                        <input class="custom-control-input" type="checkbox" id="enabled" name="enabled" {if $enabled}checked{/if} {if $default || $antispoof || $titleblacklist}disabled{/if} />
+                                        <input class="custom-control-input" type="checkbox" id="enabled" name="enabled" {if $enabled}checked{/if} {if $default || $antispoof || $titleblacklist || $isTarget}disabled{/if} />
                                         <label class="custom-control-label" for="enabled">Enabled</label>
                                         <small class="form-text text-muted" id="defaultHelp">Allow new requests to enter this queue. Disabled queues still show in the interface if they contain requests.</small>
                                         {if $default}<small class="form-text text-danger">To unset this, please first mark another queue as the default queue.</small>{/if}
                                         {if $antispoof}<small class="form-text text-danger">To unset this, please first mark another queue as the default AntiSpoof queue.</small>{/if}
                                         {if $titleblacklist}<small class="form-text text-danger">To unset this, please first mark another queue as the default TitleBlacklist queue.</small>{/if}
+                                        {if $isTarget}<small class="form-text text-danger">To unset this, please first remove this queue as the target of an active email template. This can be done by deactivating the email template or by moving the email template to a new queue.</small>{/if}
                                     </div>
                                 </div>
                             </div>
@@ -109,7 +110,7 @@
                                 </div>
                                 <div class="col-sm-8 col-md-9 col-lg-8 col-xl-9">
                                     <textarea class="form-control" id="help" rows="5" name="help">{$help|escape}</textarea>
-                                    <small class="form-text text-muted" id="helpHelp">Help text for this queue.</small>
+                                    <small class="form-text text-muted" id="helpHelp">Help text for this queue. While multiple lines are supported, please keep it short!</small>
                                 </div>
                             </div>
                         </fieldset>
@@ -121,14 +122,7 @@
                                 </div>
                                 <div class="col-sm-5 col-md-4 col-lg-5 col-xl-4">
                                     <input type="text" class="form-control" id="logName" name="logName" maxlength="50" required="required" placeholder="checkuser" value="{$logName|escape}" {if !$createMode}disabled{/if}/>
-                                </div>
-                            </div>
-                            <div class="form-group row">
-                                <div class="col-sm-4 col-md-3 col-lg-4 col-xl-3">
-                                    <label for="legacyStatus" class="col-form-label">Legacy status:</label>
-                                </div>
-                                <div class="col-sm-5 col-md-4 col-lg-5 col-xl-4">
-                                    <input type="text" class="form-control" id="legacyStatus" name="legacyStatus" maxlength="40" required="required" placeholder="Checkuser" value="{$legacyStatus|escape}" {if !$createMode}disabled{/if}/>
+                                    <small class="form-text text-muted" id="helpHelp">Database key for log messages. Should be lowercase, preferably a single word</small>
                                 </div>
                             </div>
                         </fieldset>

--- a/templates/queue-management/main.tpl
+++ b/templates/queue-management/main.tpl
@@ -23,7 +23,6 @@
                         <th>Target display name</th>
                         <th>API name</th>
                         <th>Help text</th>
-                        <th class="text-muted">Legacy status</th>
                         <th class="text-muted">Legacy log name</th>
                         {if $canEdit}
                             <th></th>
@@ -59,9 +58,6 @@
                                 {$queue->getApiName()|escape}
                             </td>
                             <td class="prewrap">{$queue->getHelp()|escape}</td>
-                            <td class="text-nowrap text-muted">
-                                {$queue->getLegacyStatus()|escape}
-                            </td>
                             <td class="text-nowrap text-muted">
                                 {$queue->getLogName()|escape}
                             </td>

--- a/templates/view-request/defer-button.tpl
+++ b/templates/view-request/defer-button.tpl
@@ -8,10 +8,12 @@
         <input type="hidden" name="updateversion" value="{$updateVersion}"/>
 
         <div class="dropdown-menu">
-            {foreach $requestStates as $state}
-                <button class="btn-link dropdown-item" name="target" value="{$state@key}" type="submit">
-                    {$state.deferto|capitalize}
-                </button>
+            {foreach $activeRequestQueues as $queue}
+                {if $queue->getApiName() !== $requestQueueApiName}
+                    <button class="btn-link dropdown-item" name="target" value="{$queue->getApiName()|escape}" type="submit">
+                        Defer to {$queue->getDisplayName()|escape}
+                    </button>
+                {/if}
             {/foreach}
         </div>
     </div>

--- a/templates/view-request/related-requests.tpl
+++ b/templates/view-request/related-requests.tpl
@@ -9,7 +9,7 @@
             </td>
             <td>{$others->getName()|escape}</td>
             <td>
-                {if $others->getStatus() == 'Closed'}
+                {if $others->getStatus() == Waca\RequestStatus::CLOSED}
                     <span class="badge badge-danger">{$others->getStatus()|escape} - {$others->getClosureReason()|escape}</span>
                 {else}
                     <span class="badge badge-success">{$others->getStatus()|escape}</span>

--- a/templates/view-request/related-requests.tpl
+++ b/templates/view-request/related-requests.tpl
@@ -12,7 +12,7 @@
                 {if $others->getStatus() == Waca\RequestStatus::CLOSED}
                     <span class="badge badge-danger">{$others->getStatus()|escape} - {$others->getClosureReason()|escape}</span>
                 {else}
-                    <span class="badge badge-success">{$others->getStatus()|escape}</span>
+                    <span class="badge badge-success">{$others->getQueueObject()->getHeader()|escape}</span>
                 {/if}
             </td>
         </tr>

--- a/templates/view-request/request-info.tpl
+++ b/templates/view-request/request-info.tpl
@@ -22,6 +22,17 @@
         </div>
     </div>
 
+    {if $requestQueue !== null}
+    <div class="row">
+        <div class="col-md-4">
+            <strong>Queue:</strong>
+        </div>
+        <div class="col-md-8">
+            {$requestQueue|escape}
+        </div>
+    </div>
+    {/if}
+
     {block name="requestDataPrimary"}<!-- Request data not available in this template -->{/block}
 
     {block name="requestDataPrimaryCheckUser"}<!-- Request data not available in this template -->{/block}

--- a/templates/view-request/request-status-buttons.tpl
+++ b/templates/view-request/request-status-buttons.tpl
@@ -26,7 +26,7 @@
                             {include file="security/csrf.tpl"}
                             <input type="hidden" name="request" value="{$requestId}"/>
                             <input type="hidden" name="updateversion" value="{$updateVersion}"/>
-                            <input type="hidden" name="target" value="{$defaultRequestState}"/>
+                            <input type="hidden" name="target" value="{$defaultRequestState|escape}"/>
                             {if $requestStatus === Waca\RequestStatus::JOBQUEUE}
                                 <button class="btn btn-block btn-outline-danger" type="submit">Reset request and cancel auto-creation</button>
                             {else}


### PR DESCRIPTION
Switches the tool over to use the request queues stored in the database, rather than the queues stored in configuration files

Fixes #602 #603 