### PR TITLE
Persist table sorting on any request table

### DIFF
--- a/includes/Pages/PageExpandedRequestList.php
+++ b/includes/Pages/PageExpandedRequestList.php
@@ -39,6 +39,10 @@ class PageExpandedRequestList extends InternalPageBase
             $help = $requestStates[$requestedStatus]['queuehelp'];
             $this->assign('queuehelp', $help);
 
+            list($defaultSort, $defaultSortDirection) = WebRequest::requestListDefaultSort();
+            $this->assign('defaultSort', $defaultSort);
+            $this->assign('defaultSortDirection', $defaultSortDirection);
+
             if ($config->getEmailConfirmationEnabled()) {
                 $query = "SELECT * FROM request WHERE status = :type AND emailconfirm = 'Confirmed';";
                 $totalQuery = "SELECT COUNT(id) FROM request WHERE status = :type AND emailconfirm = 'Confirmed';";

--- a/includes/Pages/PageMain.php
+++ b/includes/Pages/PageMain.php
@@ -17,6 +17,7 @@ use Waca\PdoDatabase;
 use Waca\RequestStatus;
 use Waca\SiteConfiguration;
 use Waca\Tasks\InternalPageBase;
+use Waca\WebRequest;
 
 class PageMain extends InternalPageBase
 {
@@ -38,6 +39,10 @@ class PageMain extends InternalPageBase
         $this->assign('requestLimitShowOnly', $config->getMiserModeLimit());
 
         $seeAllRequests = $this->barrierTest('seeAllRequests', $currentUser, PageViewRequest::class);
+
+        list($defaultSort, $defaultSortDirection) = WebRequest::requestListDefaultSort();
+        $this->assign('defaultSort', $defaultSort);
+        $this->assign('defaultSortDirection', $defaultSortDirection);
 
         // Fetch request data
         $requestSectionData = array();

--- a/includes/Pages/PageSearch.php
+++ b/includes/Pages/PageSearch.php
@@ -60,6 +60,10 @@ class PageSearch extends InternalPageBase
             $this->assign('term', $searchTerm);
             $this->assign('target', $searchType);
 
+            list($defaultSort, $defaultSortDirection) = WebRequest::requestListDefaultSort();
+            $this->assign('defaultSort', $defaultSort);
+            $this->assign('defaultSortDirection', $defaultSortDirection);
+
             $this->assignCSRFToken();
             $this->setTemplate('search/searchResult.tpl');
         }

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -598,4 +598,16 @@ class WebRequest
 
         return false;
     }
+
+    public static function requestListDefaultSort()
+    {
+        $cookie = &self::$globalStateProvider->getCookieSuperGlobal();
+
+        if (isset($cookie['request_table_sort'])) {
+            return explode('/', $cookie['request_table_sort'], 2);
+        }
+        else {
+            return ['id', 'asc'];
+        }
+    }
 }

--- a/resources/global.js
+++ b/resources/global.js
@@ -144,6 +144,31 @@ $(".sitenotice-show").click(function() {
     document.cookie = 'sitenotice=invalid;expires=' + date.toUTCString() + ";path=/";
 })
 
+$(".request-table th").click(function() {
+    let expiryDate = new Date();
+    let sort = '';
+
+    let classes = $(this).attr('class').split(/\s+/);
+    if( $.inArray('sorted', classes )) {
+        // is sorted
+        expiryDate.setTime(expiryDate.getTime() + 365 * 24 * 60 * 60 * 1000);
+        sort = $(this).data('sortname');
+
+        if (classes.includes("up")) {
+            sort += "/asc";
+        } else if (classes.includes("down")) {
+            sort += "/desc";
+        } else {
+            sort += "/asc";
+        }
+    } else {
+        expiryDate.setTime(expiryDate.getTime() - 1);
+    }
+
+    document.cookie = 'request_table_sort=' + sort + ';expires=' + expiryDate.toUTCString() + ";path=/"
+})
+
+
 $("#banAction").change(function() {
     var selectedOption = $(this).children("option:selected").val();
 

--- a/resources/scss/_common.scss
+++ b/resources/scss/_common.scss
@@ -18,10 +18,11 @@ $font-size-base: 0.9rem;
 
 $overflows: auto, hidden, visible;
 
-$sortabletable-marker: #ccc !default;
-$sortabletable-hover: #efefef !default;
-
 @import "../../vendor/twbs/bootstrap/scss/bootstrap";
+
+$sortabletable-marker: $gray-600 !default;
+$sortabletable-hover: $gray-200 !default;
+
 @import "_viewRequest.scss";
 @import "_login.scss";
 @import "_mainPage.scss";

--- a/resources/scss/bootstrap-alt.scss
+++ b/resources/scss/bootstrap-alt.scss
@@ -67,7 +67,7 @@ $alert-color-level: -10;
 
 $progress-bg: $gray-800;
 
-$sortabletable-marker: $gray-600;
+$sortabletable-marker: $gray-500;
 $sortabletable-hover: $gray-800;
 
 @import "common";

--- a/smarty-plugins/function.defaultsort.php
+++ b/smarty-plugins/function.defaultsort.php
@@ -1,0 +1,39 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+/**
+ * Sets up the cookie-based default sorting on request tables
+ *
+ * @param                          $params
+ * @param Smarty_Internal_Template $template
+ *
+ * @return string
+ */
+function smarty_function_defaultsort($params, Smarty_Internal_Template $template)
+{
+    if (empty($params['id'])) {
+        return "";
+    }
+
+    $attr = 'data-sortname="' . htmlspecialchars($params['id'], ENT_QUOTES) . '"';
+
+    if (empty($params['req'])) {
+        return $attr;
+    }
+
+    if ($params['dir'] !== 'asc' && $params['dir'] !== 'desc') {
+        $params['dir'] = 'asc';
+    }
+
+    $sort = '';
+    if ($params['req'] === $params['id']) {
+        $sort = ' data-defaultsort="' . htmlspecialchars($params['dir'], ENT_QUOTES) . '"';
+    }
+
+    return $attr . $sort;
+}

--- a/templates/mainpage/expandedrequestlist.tpl
+++ b/templates/mainpage/expandedrequestlist.tpl
@@ -22,7 +22,7 @@
     <div class="row">
         <div class="col-12">
         {if count($totalRequests) > 0}
-            {include file="mainpage/requesttable.tpl" showStatus=false list=$requests}
+            {include file="mainpage/requesttable.tpl" showStatus=false list=$requests sort=$defaultSort dir=$defaultSortDirection}
         {else}
             <span class="font-italic text-muted">No requests at this time</span>
         {/if}

--- a/templates/mainpage/requestlist.tpl
+++ b/templates/mainpage/requestlist.tpl
@@ -9,7 +9,7 @@
     </div>
 {/if}
 {if $section.total > 0}
-    {include file="mainpage/requesttable.tpl" list=$section.requests}
+    {include file="mainpage/requesttable.tpl" list=$section.requests sort=$defaultSort dir=$defaultSortDirection}
 {else}
     <span class="font-italic text-muted">No requests at this time</span>
 {/if}

--- a/templates/mainpage/requesttable.tpl
+++ b/templates/mainpage/requesttable.tpl
@@ -1,17 +1,17 @@
-<table class="table table-striped table-sm sortable mb-0">
+<table class="table table-striped table-sm sortable mb-0 request-table">
     <thead>
     <tr>
-        <th data-defaultsort="asc"><span class="d-none d-sm-inline">#</span></th>
+        <th {defaultsort id="id" req=$sort dir=$dir}><span class="d-none d-sm-inline">#</span></th>
         {if $showStatus}
-            <th><span class="d-none d-sm-inline">Request state</span></th>
+            <th {defaultsort id="status" req=$sort dir=$dir}><span class="d-none d-sm-inline">Request state</span></th>
         {/if}
         {if $list->showPrivateData}
-            <th><span class="d-none d-md-inline">Email address</span></th>
-            <th>IP address</th>
+            <th {defaultsort id="email" req=$sort dir=$dir}><span class="d-none d-md-inline">Email address</span></th>
+            <th {defaultsort id="ip" req=$sort dir=$dir}>IP address</th>
         {/if}
-        <th>Username</th>
-        <th><span class="d-none d-md-inline">Request time</span></th>
-        <th><span class="d-none {if $list->showPrivateData}d-lg-inline{else}d-md-inline{/if}">Last updated</span></th>
+        <th {defaultsort id="username" req=$sort dir=$dir}>Username</th>
+        <th {defaultsort id="date" req=$sort dir=$dir}><span class="d-none d-md-inline">Request time</span></th>
+        <th {defaultsort id="updated" req=$sort dir=$dir}><span class="d-none {if $list->showPrivateData}d-lg-inline{else}d-md-inline{/if}">Last updated</span></th>
         <th data-defaultsort="disabled"><!-- ban --></th>
         <th data-defaultsort="disabled"><!-- reserve status --></th>
         <th data-defaultsort="disabled"><!--reserve button--></th>

--- a/templates/search/searchResult.tpl
+++ b/templates/search/searchResult.tpl
@@ -14,7 +14,7 @@
             {if $resultCount == 0}
                 {include file="alert.tpl" alertblock=false alerttype="alert-info" alertclosable=false alertheader='' alertmessage='No requests found!'}
             {else}
-                {include file="mainpage/requesttable.tpl" showStatus=true list=$requests}
+                {include file="mainpage/requesttable.tpl" showStatus=true list=$requests sort=$defaultSort dir=$defaultSortDirection}
             {/if}
         </div>
     </div>


### PR DESCRIPTION
My proposed solution here is to just persist the last sort which was applied to any request table.

No new user preferences, and no restrictions by user rights. With #694 there are potentially several fields worthy of being sorted on by non-admin users - Request ID, username, request date, or last updated date. For some request tables, there's also request status too. I see no reason to limit sorting to just tool admin; we just don't allow sorting on table fields which the user cannot see. 

Since the sorting is done by Javascript anyway, there's no way to sort on a field which isn't visible so IMHO there's no reason to restrict this by user rights