### PR TITLE
Basic domain management UI

### DIFF
--- a/includes/DataObjects/EmailTemplate.php
+++ b/includes/DataObjects/EmailTemplate.php
@@ -41,20 +41,20 @@ class EmailTemplate extends DataObject
      *
      * @param string      $defaultAction Default action to take (EmailTemplate::ACTION_CREATED or EmailTemplate::ACTION_NOT_CREATED)
      * @param PdoDatabase $database
+     * @param int|null    $filter Template IDs to filter out
      *
      * @return array|false
      */
-    public static function getActiveTemplates($defaultAction, PdoDatabase $database)
+    public static function getActiveNonpreloadTemplates($defaultAction, PdoDatabase $database, ?int $filter = null)
     {
-        global $createdid;
-
         $statement = $database->prepare(<<<SQL
 SELECT * FROM `emailtemplate`
-WHERE defaultaction = :forcreated AND active = 1 AND preloadonly = 0 AND id != :createdid;
+WHERE defaultaction = :forcreated AND active = 1 AND preloadonly = 0 AND (:skipFilter = 1 OR id <> :filter);
 SQL
         );
-        $statement->bindValue(":createdid", $createdid);
         $statement->bindValue(":forcreated", $defaultAction);
+        $statement->bindValue(":filter", $filter);
+        $statement->bindValue(":skipFilter", $filter === null ? 1 : 0);
 
         $statement->execute();
 

--- a/includes/Fragments/NavigationMenuAccessControl.php
+++ b/includes/Fragments/NavigationMenuAccessControl.php
@@ -9,6 +9,7 @@
 namespace Waca\Fragments;
 
 use Waca\Pages\PageBan;
+use Waca\Pages\PageDomainManagement;
 use Waca\Pages\PageEmailManagement;
 use Waca\Pages\PageErrorLogViewer;
 use Waca\Pages\PageJobQueue;
@@ -67,6 +68,9 @@ trait NavigationMenuAccessControl
                     $currentUser) === SecurityManager::ALLOWED);
         $this->assign('nav__canJobQueue', $this->getSecurityManager()
                 ->allows(PageJobQueue::class, RoleConfiguration::MAIN,
+                    $currentUser) === SecurityManager::ALLOWED);
+        $this->assign('nav__canDomainMgmt', $this->getSecurityManager()
+                ->allows(PageDomainManagement::class, RoleConfiguration::MAIN,
                     $currentUser) === SecurityManager::ALLOWED);
         $this->assign('nav__canFlaggedComments', $this->getSecurityManager()
                 ->allows(PageListFlaggedComments::class, RoleConfiguration::MAIN,

--- a/includes/Fragments/TemplateOutput.php
+++ b/includes/Fragments/TemplateOutput.php
@@ -90,6 +90,7 @@ trait TemplateOutput
         $this->assign('nav__canViewRequest', false);
         $this->assign('nav__canJobQueue', false);
         $this->assign('nav__canFlaggedComments', false);
+        $this->assign('nav__canDomainMgmt', false);
         $this->assign('nav__canQueueMgmt', false);
         $this->assign('nav__canErrorLog', false);
 

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -13,6 +13,7 @@ use PDO;
 use Waca\DataObject;
 use Waca\DataObjects\Ban;
 use Waca\DataObjects\Comment;
+use Waca\DataObjects\Domain;
 use Waca\DataObjects\EmailTemplate;
 use Waca\DataObjects\JobQueue;
 use Waca\DataObjects\Log;
@@ -173,6 +174,8 @@ class LogHelper
             'Hospitalised'        => 'sent to the hospital',
             'QueueCreated'        => 'created a request queue',
             'QueueEdited'         => 'edited a request queue',
+            'DomainCreated'        => 'created a domain',
+            'DomainEdited'         => 'edited a domain',
         );
 
         if (array_key_exists($entry->getAction(), $lookup)) {
@@ -247,6 +250,10 @@ class LogHelper
                 'QueueCreated'        => 'created a request queue',
                 'QueueEdited'         => 'edited a request queue',
             ],
+            "Domains" => [
+                'DomainCreated'       => 'created a domain',
+                'DomainEdited'        => 'edited a domain',
+            ],
         );
 
         $databaseDrivenLogKeys = $database->query(<<<SQL
@@ -273,7 +280,8 @@ SQL
             'SiteNotice'      => 'Site notice',
             'User'            => 'User',
             'WelcomeTemplate' => 'Welcome template',
-            'RequestQueue'    => 'Request queue'
+            'RequestQueue'    => 'Request queue',
+            'Domain'          => 'Domain'
         );
     }
 
@@ -395,6 +403,16 @@ HTML;
                 $queueHeader = htmlentities($queue->getHeader(), ENT_COMPAT, 'UTF-8');
 
                 return "<a href=\"{$baseurl}/internal.php/queueManagement/edit?queue={$objectId}\">{$queueHeader}</a>";
+            case 'Domain':
+                /** @var Domain $domain */
+                $domain = Domain::getById($objectId, $database);
+
+                if($domain === false ){
+                    return "Domain #{$objectId}";
+                }
+
+                $domainName = htmlentities($domain->getShortName(), ENT_COMPAT, 'UTF-8');
+                return "<a href=\"{$baseurl}/internal.php/domainManagement/edit?domain={$objectId}\">{$domainName}</a>";
             default:
                 return '[' . $objectType . " " . $objectId . ']';
         }

--- a/includes/Helpers/Logger.php
+++ b/includes/Helpers/Logger.php
@@ -12,6 +12,7 @@ use Exception;
 use Waca\DataObject;
 use Waca\DataObjects\Ban;
 use Waca\DataObjects\Comment;
+use Waca\DataObjects\Domain;
 use Waca\DataObjects\EmailTemplate;
 use Waca\DataObjects\JobQueue;
 use Waca\DataObjects\Log;
@@ -418,6 +419,17 @@ class Logger
     public static function requestQueueEdited(PdoDatabase $database, RequestQueue $queue)
     {
         self::createLogEntry($database, $queue, 'QueueEdited');
+    }
+    #endregion
+    #region Domains
+    public static function domainCreated(PdoDatabase $database, Domain $domain)
+    {
+        self::createLogEntry($database, $domain, 'DomainCreated');
+    }
+
+    public static function domainEdited(PdoDatabase $database, Domain $domain)
+    {
+        self::createLogEntry($database, $domain, 'DomainEdited');
     }
     #endregion
 }

--- a/includes/Pages/PageDomainManagement.php
+++ b/includes/Pages/PageDomainManagement.php
@@ -12,6 +12,7 @@ use Waca\DataObjects\Domain;
 use Waca\DataObjects\EmailTemplate;
 use Waca\DataObjects\User;
 use Waca\Exceptions\AccessDeniedException;
+use Waca\Helpers\Logger;
 use Waca\SessionAlert;
 use Waca\Tasks\InternalPageBase;
 use Waca\WebRequest;
@@ -79,6 +80,7 @@ class PageDomainManagement extends InternalPageBase
 
             $domain->save();
 
+            Logger::domainCreated($database, $domain);
             $this->redirect('domainManagement');
         }
         else {
@@ -138,6 +140,7 @@ class PageDomainManagement extends InternalPageBase
 
             $domain->save();
 
+            Logger::domainEdited($database, $domain);
             $this->redirect('domainManagement');
         }
         else {

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -162,9 +162,9 @@ class PageViewRequest extends InternalPageBase
         $this->assign('createdId', $createdTemplate->getId());
         $this->assign('createdName', $createdTemplate->getName());
 
-        $createReasons = EmailTemplate::getActiveTemplates(EmailTemplate::ACTION_CREATED, $database);
+        $createReasons = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_CREATED, $database, $domain->getDefaultClose());
         $this->assign("createReasons", $createReasons);
-        $declineReasons = EmailTemplate::getActiveTemplates(EmailTemplate::ACTION_NOT_CREATED, $database);
+        $declineReasons = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_NOT_CREATED, $database);
         $this->assign("declineReasons", $declineReasons);
 
         $allCreateReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::ACTION_CREATED, $database);

--- a/includes/Router/RequestRouter.php
+++ b/includes/Router/RequestRouter.php
@@ -11,6 +11,7 @@ namespace Waca\Router;
 use Exception;
 use Waca\Pages\Page404;
 use Waca\Pages\PageBan;
+use Waca\Pages\PageDomainManagement;
 use Waca\Pages\PageEditComment;
 use Waca\Pages\PageEmailManagement;
 use Waca\Pages\PageErrorLogViewer;
@@ -203,6 +204,11 @@ class RequestRouter implements IRequestRouter
             array(
                 'class'   => PageJobQueue::class,
                 'actions' => array('acknowledge', 'requeue', 'view', 'all', 'cancel'),
+            ),
+        'domainManagement'            =>
+            array(
+                'class'   => PageDomainManagement::class,
+                'actions' => array('create', 'edit'),
             ),
         'flaggedComments'             =>
             array(

--- a/includes/Security/RoleConfiguration.php
+++ b/includes/Security/RoleConfiguration.php
@@ -10,6 +10,7 @@ namespace Waca\Security;
 
 use Waca\DataObjects\User;
 use Waca\Pages\PageBan;
+use Waca\Pages\PageDomainManagement;
 use Waca\Pages\PageEditComment;
 use Waca\Pages\PageEmailManagement;
 use Waca\Pages\PageErrorLogViewer;
@@ -219,6 +220,9 @@ class RoleConfiguration
                 'acknowledge' => self::ACCESS_ALLOW,
                 'cancel'      => self::ACCESS_ALLOW
             ),
+            PageDomainManagement::class          => array(
+                self::MAIN => self::ACCESS_ALLOW,
+            ),
             'RequestCreation'                    => array(
                 User::CREATION_MANUAL => self::ACCESS_ALLOW,
                 User::CREATION_OAUTH  => self::ACCESS_ALLOW,
@@ -269,6 +273,9 @@ class RoleConfiguration
                 'edit'     => self::ACCESS_ALLOW,
                 'create'   => self::ACCESS_ALLOW,
             ),
+            PageDomainManagement::class          => array(
+                'edit'     => self::ACCESS_ALLOW,
+            ),
         ),
         'checkuser'         => array(
             '_description'            => 'A user with CheckUser access',
@@ -306,6 +313,12 @@ class RoleConfiguration
             PageMultiFactor::class => array(
                 'enableU2F'         => self::ACCESS_ALLOW,
                 'disableU2F'        => self::ACCESS_ALLOW,
+            ),
+            PageDomainManagement::class => array(
+                self::MAIN => self::ACCESS_ALLOW,
+                'editAll'  => self::ACCESS_ALLOW,
+                'edit'     => self::ACCESS_ALLOW,
+                'create'   => self::ACCESS_ALLOW,
             ),
             PageErrorLogViewer::class => array(
                 self::MAIN      => self::ACCESS_ALLOW,

--- a/resources/scss/_common.scss
+++ b/resources/scss/_common.scss
@@ -91,6 +91,10 @@ td.table-button-cell {
     min-width: 20px;
 }
 
+$borderwidth: 1, 2, 3;
+@each $size in $borderwidth {
+    .border-w#{$size} { border-width: #{$size}px !important; }
+}
 .badge-pill svg.svg-inline--fa.fa-w-16 {
     min-width: 1.2em;
 }

--- a/templates/domain-management/edit.tpl
+++ b/templates/domain-management/edit.tpl
@@ -1,0 +1,147 @@
+{extends file="pagebase.tpl"}
+{block name="content"}
+    <div class="row">
+        <div class="col-md-12">
+            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                <h1 class="h2">Domain Management <small class="text-muted">Manage security domain settings</small></h1>
+                {if $canCreate && $canEditAll}
+                    <div class="btn-toolbar mb-2 mb-md-0">
+                        <a class="btn btn-sm btn-outline-success"
+                           href="{$baseurl}/internal.php/domainManagement/create"><i class="fas fa-plus"></i>&nbsp;Create
+                            domain</a>
+                    </div>
+                {/if}
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-12">
+            <form method="post">
+                {include file="security/csrf.tpl"}
+
+                <div class="row">
+                    <div class="col-lg-6 col-xs-12">
+                        <fieldset>
+                            <legend>Wiki instance</legend>
+
+                            <div class="form-group row">
+                                <div class="col-sm-4 col-md-3 col-lg-4 col-xl-3">
+                                    <label for="shortName" class="col-form-label">Short name:</label>
+                                </div>
+                                <div class="col-sm-5 col-md-4 col-lg-6 col-xl-4">
+                                    <input type="text" class="form-control" id="shortName" name="shortName" maxlength="20" required="required" placeholder="enwiki" value="{$shortName|escape}" {if !$createMode}readonly{/if}/>
+                                    <small class="form-text text-muted" id="shortNameHelp">The short "database" name of the wiki. <strong>Note: this cannot be changed after creation.</strong></small>
+                                </div>
+                            </div>
+
+                            <div class="form-group row">
+                                <div class="col-sm-4 col-md-3 col-lg-4 col-xl-3">
+                                    <label for="longName" class="col-form-label">Long name:</label>
+                                </div>
+                                <div class="col-sm-8 col-md-6 col-lg-8 col-xl-6">
+                                    <input type="text" class="form-control" id="longName" name="longName" maxlength="255" required="required" placeholder="English Wikipedia" value="{$longName|escape}"/>
+                                    <small class="form-text text-muted" id="longNameHelp">The full name of the wiki</small>
+                                </div>
+                            </div>
+
+                            <div class="form-group row">
+                                <div class="col-sm-4 col-md-3 col-lg-4 col-xl-3">
+                                    <label for="articlePath" class="col-form-label">Article path:</label>
+                                </div>
+                                <div class="col-sm-8 col-md-9 col-lg-8 col-xl-9">
+                                    <input type="text" class="form-control" id="articlePath" name="articlePath" maxlength="255" required="required" placeholder="https://en.wikipedia.org/w/index.php" value="{$articlePath|escape}" {if !$canEditAll}readonly{/if}/>
+                                    <small class="form-text text-muted" id="articlePathHelp">The base path of an article</small>
+                                </div>
+                            </div>
+                            <div class="form-group row">
+                                <div class="col-sm-4 col-md-3 col-lg-4 col-xl-3">
+                                    <label for="apiPath" class="col-form-label">API path:</label>
+                                </div>
+                                <div class="col-sm-8 col-md-9 col-lg-8 col-xl-9">
+                                    <input type="text" class="form-control" id="apiPath" name="apiPath" maxlength="255" required="required" placeholder="https://en.wikipedia.org/w/api.php" value="{$apiPath|escape}" {if !$canEditAll}readonly{/if}/>
+                                    <small class="form-text text-muted" id="apiPathHelp">The path to the API</small>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <div class="col-lg-6 col-xs-12">
+                        <fieldset>
+                            <legend>Domain settings</legend>
+
+                            <div class="form-group row">
+                                <div class="offset-sm-4 offset-md-3 offset-lg-4 offset-xl-3 col-md-9">
+                                    <div class="custom-control custom-switch">
+                                        <input class="custom-control-input" type="checkbox" id="enabled" name="enabled" {if $enabled}checked{/if}  {if (!$canEditAll)}disabled{/if}/>
+                                        <label class="custom-control-label" for="enabled">Enabled</label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="form-group row">
+                                <div class="col-sm-4 col-md-3 col-lg-4 col-xl-3">
+                                    <label for="defaultClose" class="col-form-label">Default creation template:</label>
+                                </div>
+                                <div class="col-sm-8 col-md-9 col-lg-8 col-xl-9">
+                                    {if $createMode}
+                                        <div class="alert alert-warning">
+                                            This setting cannot be set at domain creation. Please create the domain, then
+                                            configure some email templates within the domain, and finally return here to set
+                                            the default creation template.
+                                        </div>
+                                    {else}
+                                        <select class="form-control" name="defaultClose" id="defaultClose">
+                                            {foreach $closeTemplates as $template}
+                                                <option value="{$template->getId()}" {if $defaultClose == $template->getId()}selected="selected"{/if}>{$template->getName()|escape}</option>
+                                            {/foreach}
+                                        </select>
+                                    {/if}
+                                    <small class="form-text text-muted" id="defaultCloseHelp">The default creation template to use</small>
+
+                                </div>
+                            </div>
+
+                            <div class="form-group row">
+                                <div class="col-sm-4 col-md-3 col-lg-4 col-xl-3">
+                                    <label for="defaultLanguage" class="col-form-label">Default language:</label>
+                                </div>
+                                <div class="col-sm-3 col-md-3 col-lg-4 col-xl-3">
+                                    <input type="text" class="form-control" id="defaultLanguage" name="defaultLanguage" maxlength="10" required="required" placeholder="en" value="{$defaultLanguage|escape}"/>
+                                    <small class="form-text text-muted" id="defaultLanguageHelp">The default language for new users</small>
+                                </div>
+                            </div>
+
+                            <div class="form-group row">
+                                <div class="col-sm-4 col-md-3 col-lg-4 col-xl-3">
+                                    <label for="emailSender" class="col-form-label">Email sender address:</label>
+                                </div>
+                                <div class="col-sm-8 col-md-9 col-lg-8 col-xl-9">
+                                    <input type="email" class="form-control" id="emailSender" name="emailSender" maxlength="255" required="required" placeholder="accounts-enwiki-l@lists.wikimedia.org" value="{$emailSender|escape}" {if !$canEditAll}readonly{/if}/>
+                                    <small class="form-text text-muted" id="emailSenderHelp">The email address to send emails from. This is also used as a Reply-To address.</small>
+                                </div>
+                            </div>
+
+                            <div class="form-group row">
+                                <div class="col-sm-4 col-md-3 col-lg-4 col-xl-3">
+                                    <label for="notificationTarget" class="col-form-label">IRC notification target:</label>
+                                </div>
+                                <div class="col-sm-8 col-md-9 col-lg-8 col-xl-9">
+                                    <input type="text" class="form-control" id="notificationTarget" name="notificationTarget" maxlength="255" placeholder="" value="{$notificationTarget|escape}" {if !$canEditAll}readonly{/if}/>
+                                    <small class="form-text text-muted" id="notificationTargetHelp">The target to send IRC notifications to via Helpmebot.</small>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-6 col-xs-12">
+                        <div class="form-group row">
+                            <div class="offset-sm-4 offset-md-3 offset-lg-4 offset-xl-3 col-sm-8 col-md-9 col-lg-8 col-xl-9">
+                                <button type="submit" class="btn btn-block btn-primary"><i class="fas fa-save"></i>&nbsp;Save</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+{/block}

--- a/templates/domain-management/main.tpl
+++ b/templates/domain-management/main.tpl
@@ -1,0 +1,70 @@
+{extends file="pagebase.tpl"}
+{block name="content"}
+    <div class="row">
+        <div class="col-md-12">
+            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                <h1 class="h2">Domain Management <small class="text-muted">Manage security domain settings</small></h1>
+                {if $canCreate && $canEditAll}
+                    <div class="btn-toolbar mb-2 mb-md-0">
+                        <a class="btn btn-sm btn-outline-success" href="{$baseurl}/internal.php/domainManagement/create"><i class="fas fa-plus"></i>&nbsp;Create domain</a>
+                    </div>
+                {/if}
+            </div>
+        </div>
+    </div>
+    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3">
+        {foreach from=$domains item=domain}
+            <div class="col">
+                <div class="card mb-4 ">
+                    <div class="card-header {if $domain->isEnabled()}border-success{else}border-danger{/if} border-w2">
+                        <h5 class="d-inline-block mb-0 mt-1">{$domain->getShortName()|escape}</h5>
+                        {if ($currentDomain->getId() == $domain->getId() && $canEdit) || ($canEdit && $canEditAll)}
+                            <a href="{$baseurl}/internal.php/domainManagement/edit?domain={$domain->getId()|escape}" class="btn btn-secondary btn-sm float-right ml-4">
+                                <i class="fas fa-edit"></i>&nbsp; Edit
+                            </a>
+                        {/if}
+                    </div>
+                    <div class="card-body">
+                        <p class="h5 d-inline-block float-right">
+                            <span class="badge badge-{if $domain->isEnabled()}success{else}danger{/if}">{if $domain->isEnabled()}Enabled{else}Disabled{/if}</span>
+                        </p>
+                        <h4 class="card-title">{$domain->getLongName()|escape}</h4>
+                        <table class="table table-borderless table-sm">
+                            <tr>
+                                <th>Article path</th><td><a href="{$domain->getWikiArticlePath()|escape}">{$domain->getWikiArticlePath()|escape}</a></td>
+                            </tr>
+                            {if ($currentDomain->getId() == $domain->getId() && $canEdit) || $canEditAll}
+                            <tr>
+                                <th>API</th><td><a href="{$domain->getWikiApiPath()|escape}">{$domain->getWikiApiPath()|escape}</a></td>
+                            </tr>
+                            {/if}
+                            <tr>
+                                <th>Language</th><td>{$domain->getDefaultLanguage()|escape}</td>
+                            </tr>
+                            <tr>
+                                <th>Email sender</th><td>{$domain->getEmailSender()}</td>
+                            </tr>
+                            {if ($currentDomain->getId() == $domain->getId() && $canEdit) || $canEditAll}
+                                <tr>
+                                    <th>Notification target</th><td>{$domain->getNotificationTarget()}</td>
+                                </tr>
+                            {/if}
+                            {if $currentDomain->getId() == $domain->getId() || $canEditAll}
+                                <tr>
+                                    <th>Default creation close</th>
+                                    <td>
+                                    {if $domain->getDefaultClose() !== null}
+                                        <a href="{$baseurl}/internal.php/emailManagement/view?id={$domain->getDefaultClose()}">{$closeTemplates[$domain->getDefaultClose()]->getName()}</a>
+                                    {else}
+                                        <span class="badge badge-secondary">Not set</span>
+                                    {/if}
+                                    </td>
+                                </tr>
+                            {/if}
+                        </table>
+                    </div>
+                </div>
+            </div>
+        {/foreach}
+    </div>
+{/block}

--- a/templates/navigation-menu.tpl
+++ b/templates/navigation-menu.tpl
@@ -23,7 +23,7 @@
                 </div>
             </li>
         {/if}
-        {if $nav__canBan || $nav__canEmailMgmt || $nav__canWelcomeMgmt || $nav__canSiteNoticeMgmt || $nav__canUserMgmt || $nav__canJobQueue || $nav__canFlaggedComments || $nav__canQueueMgmt || $nav__canErrorLog}
+        {if $nav__canBan || $nav__canEmailMgmt || $nav__canWelcomeMgmt || $nav__canSiteNoticeMgmt || $nav__canUserMgmt || $nav__canJobQueue || $nav__canFlaggedComments || $nav__canQueueMgmt || $nav__canDomainMgmt || $nav__canErrorLog}
             <li class="nav-item dropdown">
                 <a href="#" class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown"><i class="fas fa-wrench"></i>&nbsp;Admin</a>
                 <div class="dropdown-menu">
@@ -50,6 +50,9 @@
                     {/if}
                     {if $nav__canQueueMgmt}
                         <a class="dropdown-item" href="{$baseurl}/internal.php/queueManagement"><i class="fas fa-list-ol"></i> Request Queue Management</a>
+                    {/if}
+                    {if $nav__canDomainMgmt}
+                        <a class="dropdown-item" href="{$baseurl}/internal.php/domainManagement"><i class="fas fa-globe-europe"></i> Domain Management</a>
                     {/if}
                     {if $nav__canErrorLog}
                         <a class="dropdown-item" href="{$baseurl}/internal.php/errorLog"><i class="fas fa-bug"></i> Exception Log</a>


### PR DESCRIPTION
As of this pull request, it does almost nothing other than look pretty, with the exception of managing the default close template for requests.

ACLs for this one are slightly complex.
* Tool users can see a simplified set of the configuration for all domains
* Tool admins can see all the configuration for their current domain, plus a simplified set of the configuration for all other domains. Tool admins can also change basic settings (name, default close template, default language) for their current domain.
* Tool roots can create domains and change anything.

As an example from a tool admin for enwiki perspective:
![image](https://user-images.githubusercontent.com/722710/137824522-dbc3c9b5-16b4-470f-9198-0326b6468778.png)

The next PR in this series will actually use a lot more configuration which is defined in this window.

Fixes #591