### PR TITLE
Add bullseye link to IP info

### DIFF
--- a/redir.php
+++ b/redir.php
@@ -17,7 +17,8 @@ $toolList = array(
     'domain'             => 'http://%DATA%/',
     'rangefinder'        => 'https://tools.wmflabs.org/rangeblockfinder/?ip=%DATA%',
     'ipcheck'            => 'https://ipcheck.toolforge.org/index.php?ip=%DATA%',
-    'bgpview'            => 'https://bgpview.io/ip/%DATA%'
+    'bgpview'            => 'https://bgpview.io/ip/%DATA%',
+    'bullseye'           => 'https://bullseye.toolforge.org/ip/%DATA%'
 );
 
 if (!isset($_GET['tool'])

--- a/templates/view-request/ip-links.tpl
+++ b/templates/view-request/ip-links.tpl
@@ -61,6 +61,10 @@
        href="{$baseurl}/redir.php?tool=ipcheck&amp;data={$ipaddress}">
         IP Check
     </a>
+    <a id="Bullseye-{$index}" class="btn btn-sm btn-outline-secondary visit-tracking" target="_blank"
+       href="{$baseurl}/redir.php?tool=bullseye&amp;data={$ipaddress}">
+        Bullseye
+    </a>
     <a id="IPBGPView-{$index}" class="btn btn-sm btn-outline-secondary visit-tracking" target="_blank"
        href="{$baseurl}/redir.php?tool=bgpview&amp;data={$ipaddress}">
         BGP Prefixes


### PR DESCRIPTION
Adds a link to my Bullseye tool (used by a lot of CUs and proxy checkers already for IP info). I haven't gotten a test environment set up yet, so would appreciate if someone could double-check this, but it's a straight-up copy of existing code.