### PR TITLE
Fix breakage of access denied errors and non-identified errors

### DIFF
--- a/includes/Exceptions/AccessDeniedException.php
+++ b/includes/Exceptions/AccessDeniedException.php
@@ -28,21 +28,18 @@ class AccessDeniedException extends ReadableException
 {
     use NavigationMenuAccessControl;
 
-    /**
-     * @var SecurityManager
-     */
+    /** @var SecurityManager */
     private $securityManager;
-
-    /** @var DomainAccessManager|null */
+    /** @var DomainAccessManager */
     private $domainAccessManager;
 
     /**
      * AccessDeniedException constructor.
      *
-     * @param SecurityManager          $securityManager
-     * @param DomainAccessManager|null $domainAccessManager
+     * @param SecurityManager     $securityManager
+     * @param DomainAccessManager $domainAccessManager
      */
-    public function __construct(SecurityManager $securityManager = null, DomainAccessManager $domainAccessManager = null)
+    public function __construct(SecurityManager $securityManager, DomainAccessManager $domainAccessManager)
     {
         $this->securityManager = $securityManager;
         $this->domainAccessManager = $domainAccessManager;
@@ -109,10 +106,7 @@ class AccessDeniedException extends ReadableException
         return $logs[0]->getComment();
     }
 
-    /**
-     * @return SecurityManager
-     */
-    protected function getSecurityManager()
+    protected function getSecurityManager(): SecurityManager
     {
         return $this->securityManager;
     }

--- a/includes/Exceptions/NotIdentifiedException.php
+++ b/includes/Exceptions/NotIdentifiedException.php
@@ -12,24 +12,28 @@ use Waca\DataObjects\Domain;
 use Waca\DataObjects\User;
 use Waca\Fragments\NavigationMenuAccessControl;
 use Waca\PdoDatabase;
+use Waca\Security\DomainAccessManager;
 use Waca\Security\SecurityManager;
 
 class NotIdentifiedException extends ReadableException
 {
     use NavigationMenuAccessControl;
-    /**
-     * @var SecurityManager
-     */
+
+    /** @var SecurityManager */
     private $securityManager;
+    /** @var DomainAccessManager */
+    private $domainAccessManager;
 
     /**
      * NotIdentifiedException constructor.
      *
-     * @param SecurityManager $securityManager
+     * @param SecurityManager     $securityManager
+     * @param DomainAccessManager $domainAccessManager
      */
-    public function __construct(SecurityManager $securityManager = null)
+    public function __construct(SecurityManager $securityManager, DomainAccessManager $domainAccessManager)
     {
         $this->securityManager = $securityManager;
+        $this->domainAccessManager = $domainAccessManager;
     }
 
     /**
@@ -57,11 +61,13 @@ class NotIdentifiedException extends ReadableException
         return $this->fetchTemplate("exception/not-identified.tpl");
     }
 
-    /**
-     * @return SecurityManager
-     */
-    protected function getSecurityManager()
+    protected function getSecurityManager(): SecurityManager
     {
         return $this->securityManager;
+    }
+
+    public function getDomainAccessManager(): DomainAccessManager
+    {
+        return $this->domainAccessManager;
     }
 }

--- a/includes/Fragments/NavigationMenuAccessControl.php
+++ b/includes/Fragments/NavigationMenuAccessControl.php
@@ -87,6 +87,9 @@ trait NavigationMenuAccessControl
         $this->assign('nav__canViewRequest', $this->getSecurityManager()
                 ->allows(PageViewRequest::class, RoleConfiguration::MAIN, $currentUser) === SecurityManager::ALLOWED);
 
-        $this->assign('nav__domainList', $this->getDomainAccessManager()->getAllowedDomains($currentUser));
+        $this->assign('nav__domainList', []);
+        if ($this->getDomainAccessManager() !== null) {
+            $this->assign('nav__domainList', $this->getDomainAccessManager()->getAllowedDomains($currentUser));
+        }
     }
 }

--- a/includes/Pages/PageBan.php
+++ b/includes/Pages/PageBan.php
@@ -103,7 +103,7 @@ class PageBan extends InternalPageBase
         if (!$banHelper->canUnban($ban)) {
             // triggered when a user tries to unban a ban they can't see the entirety of.
             // there's no UI way to get to this, so a raw exception is fine.
-            throw new AccessDeniedException($this->getSecurityManager());
+            throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
         }
 
         // dual mode

--- a/includes/Pages/PageDomainManagement.php
+++ b/includes/Pages/PageDomainManagement.php
@@ -59,7 +59,7 @@ class PageDomainManagement extends InternalPageBase
         // new domains either. With any luck, a competent developer would never grant create without editAll to a role
         // anyway, so this will never be hit.
         if (!$this->barrierTest('editAll', $currentUser)) {
-            throw new AccessDeniedException();
+            throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
         }
 
         if (WebRequest::wasPosted()) {

--- a/includes/Pages/PageEditComment.php
+++ b/includes/Pages/PageEditComment.php
@@ -43,19 +43,19 @@ class PageEditComment extends InternalPageBase
 
         $currentUser = User::getCurrent($database);
         if ($comment->getUser() !== $currentUser->getId() && !$this->barrierTest('editOthers', $currentUser)) {
-            throw new AccessDeniedException($this->getSecurityManager());
+            throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
         }
 
         if ($comment->getVisibility() === 'admin'
             && !$this->barrierTest('seeRestrictedComments', $currentUser, 'RequestData')
             && $comment->getUser() !== $currentUser->getId()) {
-            throw new AccessDeniedException($this->getSecurityManager());
+            throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
         }
 
         if ($comment->getVisibility() === 'checkuser'
             && !$this->barrierTest('seeCheckuserComments', $currentUser, 'RequestData')
             && $comment->getUser() !== $currentUser->getId()) {
-            throw new AccessDeniedException($this->getSecurityManager());
+            throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
         }
 
         /** @var Request|false $request */

--- a/includes/Pages/PageFlagComment.php
+++ b/includes/Pages/PageFlagComment.php
@@ -47,7 +47,7 @@ class PageFlagComment extends InternalPageBase
 
         if ($comment->getFlagged() && !$this->barrierTest('unflag', User::getCurrent($database))) {
             // user isn't allowed to unflag comments
-            throw new AccessDeniedException();
+            throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
         }
 
         $comment->setFlagged($flagState == 1);

--- a/includes/Pages/Registration/PageRegisterBase.php
+++ b/includes/Pages/Registration/PageRegisterBase.php
@@ -32,7 +32,7 @@ abstract class PageRegisterBase extends InternalPageBase
     {
         $useOAuthSignup = $this->getSiteConfiguration()->getUseOAuthSignup();
         if (!$this->getSiteConfiguration()->isRegistrationAllowed()) {
-            throw new AccessDeniedException();
+            throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
         }
 
         // Dual-mode page

--- a/includes/Pages/RequestAction/PageBreakReservation.php
+++ b/includes/Pages/RequestAction/PageBreakReservation.php
@@ -40,7 +40,7 @@ class PageBreakReservation extends RequestActionBase
                 $this->doBreakReserve($request, $database);
             }
             else {
-                throw new AccessDeniedException($this->getSecurityManager());
+                throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
             }
         }
     }

--- a/includes/Pages/RequestAction/PageCreateRequest.php
+++ b/includes/Pages/RequestAction/PageCreateRequest.php
@@ -54,12 +54,12 @@ class PageCreateRequest extends RequestActionBase
         if ($secMgr->allows('RequestCreation', User::CREATION_BOT, $user) !== SecurityManager::ALLOWED
             && $creationMode === 'bot'
         ) {
-            throw new AccessDeniedException($secMgr);
+            throw new AccessDeniedException($secMgr, $this->getDomainAccessManager());
         }
         elseif ($secMgr->allows('RequestCreation', User::CREATION_OAUTH, $user) !== SecurityManager::ALLOWED
             && $creationMode === 'oauth'
         ) {
-            throw new AccessDeniedException($secMgr);
+            throw new AccessDeniedException($secMgr, $this->getDomainAccessManager());
         }
 
         if ($request->getEmailSent()) {

--- a/includes/Pages/RequestAction/PageCustomClose.php
+++ b/includes/Pages/RequestAction/PageCustomClose.php
@@ -120,7 +120,7 @@ class PageCustomClose extends PageCloseRequest
         $allowedPrivateData = $this->isAllowedPrivateData($request, $currentUser);
         if (!$allowedPrivateData) {
             // we probably shouldn't be showing the user this form if they're not allowed to access private data...
-            throw new AccessDeniedException($this->getSecurityManager());
+            throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
         }
 
         $template = $this->getTemplate($database);
@@ -376,7 +376,7 @@ class PageCustomClose extends PageCloseRequest
 
         if ($action === self::CREATE_OAUTH) {
             if (!$canOauthCreate) {
-                throw new AccessDeniedException($this->getSecurityManager());
+                throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
             }
 
             $creationTaskClass = UserCreationTask::class;
@@ -384,7 +384,7 @@ class PageCustomClose extends PageCloseRequest
 
         if ($action === self::CREATE_BOT) {
             if (!$canBotCreate) {
-                throw new AccessDeniedException($this->getSecurityManager());
+                throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
             }
 
             $creationTaskClass = BotCreationTask::class;

--- a/includes/Pages/UserAuth/PageOAuth.php
+++ b/includes/Pages/UserAuth/PageOAuth.php
@@ -59,7 +59,7 @@ class PageOAuth extends InternalPageBase
     protected function detach()
     {
         if ($this->getSiteConfiguration()->getEnforceOAuth()) {
-            throw new AccessDeniedException($this->getSecurityManager());
+            throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
         }
 
         $database = $this->getDatabase();

--- a/includes/Security/DomainAccessManager.php
+++ b/includes/Security/DomainAccessManager.php
@@ -17,6 +17,16 @@ use Waca\WebRequest;
 class DomainAccessManager
 {
     /**
+     * @var SecurityManager
+     */
+    private $securityManager;
+
+    public function __construct(SecurityManager $securityManager)
+    {
+        $this->securityManager = $securityManager;
+    }
+
+    /**
      * @param User $user
      *
      * @return Domain[]
@@ -42,7 +52,7 @@ class DomainAccessManager
             WebRequest::setActiveDomain($newDomain);
         }
         else {
-            throw new AccessDeniedException();
+            throw new AccessDeniedException($this->securityManager, $this);
         }
     }
 }

--- a/includes/Tasks/InternalPageBase.php
+++ b/includes/Tasks/InternalPageBase.php
@@ -166,11 +166,11 @@ abstract class InternalPageBase extends PageBase
 
             if ($denyReason === SecurityManager::ERROR_NOT_IDENTIFIED) {
                 // Not identified
-                throw new NotIdentifiedException($this->getSecurityManager());
+                throw new NotIdentifiedException($this->getSecurityManager(), $this->getDomainAccessManager());
             }
             elseif ($denyReason === SecurityManager::ERROR_DENIED) {
                 // Nope, plain old access denied
-                throw new AccessDeniedException($this->getSecurityManager());
+                throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
             }
             else {
                 throw new Exception('Unknown response from security manager.');

--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -87,7 +87,7 @@ class WebStart extends ApplicationBase
                     $page->setBlacklistHelper(new BlacklistHelper($page->getHttpHelper(), $database));
                 }
 
-                $page->setDomainAccessManager(new DomainAccessManager());
+                $page->setDomainAccessManager(new DomainAccessManager($page->getSecurityManager()));
             }
         }
     }


### PR DESCRIPTION
This was caused by a dependency on DomainAccessManager, which wasn't passed in where it needed to be.

Fixed in two ways - a) passing it in where it needs to be, and b) making it fail more gracefully when it's not passed in (just in case this happens again in the future)