### PR TITLE
Assign users to domains

### DIFF
--- a/includes/DataObjects/Domain.php
+++ b/includes/DataObjects/Domain.php
@@ -65,6 +65,26 @@ class Domain extends DataObject
         return self::$currentDomain;
     }
 
+    public static function getByShortName(string $shortName, PdoDatabase $database)
+    {
+        $statement = $database->prepare(<<<SQL
+            SELECT * FROM domain WHERE shortname = :name;
+SQL
+        );
+
+        $statement->execute([
+            ':name' => $shortName,
+        ]);
+
+        /** @var RequestForm|false $result */
+        $result = $statement->fetchObject(get_called_class());
+
+        if ($result !== false) {
+            $result->setDatabase($database);
+        }
+
+        return $result;
+    }
 
     public static function getAll(PdoDatabase $database) {
         $statement = $database->prepare("SELECT * FROM domain;");

--- a/includes/DataObjects/Domain.php
+++ b/includes/DataObjects/Domain.php
@@ -35,6 +35,8 @@ class Domain extends DataObject
     private $emailsender;
     /** @var string|null */
     private $notificationtarget;
+    /** @var string */
+    private $localdocumentation;
 
     /** @var Domain Cache variable of the current domain */
     private static $currentDomain;
@@ -111,10 +113,10 @@ SQL
             $statement = $this->dbObject->prepare(<<<SQL
                 INSERT INTO domain (
                     shortname, longname, wikiarticlepath, wikiapipath, enabled, defaultclose, defaultlanguage, 
-                    emailsender, notificationtarget
+                    emailsender, notificationtarget, localdocumentation
                 ) VALUES (
                     :shortname, :longname, :wikiarticlepath, :wikiapipath, :enabled, :defaultclose, :defaultlanguage,
-                    :emailsender, :notificationtarget
+                    :emailsender, :notificationtarget, :localdocumentation
                 );
 SQL
             );
@@ -128,6 +130,8 @@ SQL
             $statement->bindValue(":defaultlanguage", $this->defaultlanguage);
             $statement->bindValue(":emailsender", $this->emailsender);
             $statement->bindValue(":notificationtarget", $this->notificationtarget);
+            $statement->bindValue(":localdocumentation", $this->localdocumentation);
+
 
             if ($statement->execute()) {
                 $this->id = (int)$this->dbObject->lastInsertId();
@@ -147,6 +151,7 @@ SQL
                     defaultlanguage = :defaultlanguage,
                     emailsender = :emailsender,
                     notificationtarget = :notificationtarget,
+                    localdocumentation = :localdocumentation,
                 
                     updateversion = updateversion + 1
 				WHERE id = :id AND updateversion = :updateversion;
@@ -161,6 +166,7 @@ SQL
             $statement->bindValue(":defaultlanguage", $this->defaultlanguage);
             $statement->bindValue(":emailsender", $this->emailsender);
             $statement->bindValue(":notificationtarget", $this->notificationtarget);
+            $statement->bindValue(":localdocumentation", $this->localdocumentation);
 
             $statement->bindValue(':id', $this->id);
             $statement->bindValue(':updateversion', $this->updateversion);
@@ -321,5 +327,19 @@ SQL
         $this->notificationtarget = $notificationTarget;
     }
 
+    /**
+     * @return string
+     */
+    public function getLocalDocumentation(): string
+    {
+        return $this->localdocumentation;
+    }
 
+    /**
+     * @param string $localDocumentation
+     */
+    public function setLocalDocumentation(string $localDocumentation): void
+    {
+        $this->localdocumentation = $localDocumentation;
+    }
 }

--- a/includes/Pages/PageDomainManagement.php
+++ b/includes/Pages/PageDomainManagement.php
@@ -77,6 +77,7 @@ class PageDomainManagement extends InternalPageBase
             $domain->setDefaultClose(null);
             $domain->setEmailSender(WebRequest::postString('emailSender'));
             $domain->setNotificationTarget(WebRequest::postString('notificationTarget'));
+            $domain->setLocalDocumentation(WebRequest::postString('localDocumentation'));
 
             $domain->save();
 
@@ -94,6 +95,7 @@ class PageDomainManagement extends InternalPageBase
             $this->assign('defaultLanguage', 'en');
             $this->assign('emailSender', '');
             $this->assign('notificationTarget', '');
+            $this->assign('localDocumentation', '');
 
             $this->assign('createMode', true);
             $this->assign('canEditAll', true);
@@ -118,6 +120,7 @@ class PageDomainManagement extends InternalPageBase
 
             $domain->setLongName(WebRequest::postString('longName'));
             $domain->setDefaultLanguage(WebRequest::postString('defaultLanguage'));
+            $domain->setLocalDocumentation(WebRequest::postString('localDocumentation'));
 
             /** @var EmailTemplate $template */
             $template = EmailTemplate::getById(WebRequest::postInt('defaultClose'), $database);
@@ -158,6 +161,8 @@ class PageDomainManagement extends InternalPageBase
             $this->assign('defaultLanguage', $domain->getDefaultLanguage());
             $this->assign('emailSender', $domain->getEmailSender());
             $this->assign('notificationTarget', $domain->getNotificationTarget());
+            $this->assign('localDocumentation', $domain->getLocalDocumentation());
+
 
             $this->assign('createMode', false);
             $this->assign('canEditAll', $canEditAll);

--- a/includes/Pages/Registration/PageRegisterBase.php
+++ b/includes/Pages/Registration/PageRegisterBase.php
@@ -252,6 +252,7 @@ abstract class PageRegisterBase extends InternalPageBase
             // only notify if we're not using the oauth signup.
             $this->getNotificationHelper()->userNew($user);
             WebRequest::setLoggedInUser($user);
+            $this->getDomainAccessManager()->switchToDefaultDomain($user);
             $this->redirect('preferences');
         }
     }

--- a/includes/Pages/Registration/PageRegisterBase.php
+++ b/includes/Pages/Registration/PageRegisterBase.php
@@ -9,7 +9,9 @@
 namespace Waca\Pages\Registration;
 
 use Exception;
+use Waca\DataObjects\Domain;
 use Waca\DataObjects\User;
+use Waca\DataObjects\UserDomain;
 use Waca\DataObjects\UserRole;
 use Waca\Exceptions\AccessDeniedException;
 use Waca\Exceptions\ApplicationLogicException;
@@ -55,6 +57,19 @@ abstract class PageRegisterBase extends InternalPageBase
             }
         }
         else {
+            $domain = WebRequest::getString('d');
+            if ($domain === null) {
+                throw new ApplicationLogicException("No domain specified.");
+            }
+
+            /** @var Domain|false $domainObject */
+            $domainObject = Domain::getByShortName($domain, $this->getDatabase());
+            if ($domainObject === false || !$domainObject->isEnabled()) {
+                throw new ApplicationLogicException("Unknown domain or domain not enabled.");
+            }
+
+            $this->assign('localDocumentation', $domainObject->getLocalDocumentation());
+
             $this->assignCSRFToken();
             $this->assign("useOAuthSignup", $useOAuthSignup);
             $this->setTemplate($this->getRegistrationTemplate());
@@ -94,6 +109,7 @@ abstract class PageRegisterBase extends InternalPageBase
      * @param $useOAuthSignup
      * @param $confirmationId
      * @param $onwikiUsername
+     * @param Domain|false $domainObject
      *
      * @throws ApplicationLogicException
      */
@@ -103,10 +119,19 @@ abstract class PageRegisterBase extends InternalPageBase
         $username,
         $useOAuthSignup,
         $confirmationId,
-        $onwikiUsername
+        $onwikiUsername,
+        $domainObject
     ) {
         if (!WebRequest::postBoolean('guidelines')) {
             throw new ApplicationLogicException('You must read the interface guidelines before your request may be submitted.');
+        }
+
+        if ($domainObject === false) {
+            throw new ApplicationLogicException('The chosen wiki does not exist on this tool.');
+        }
+
+        if (!$domainObject->isEnabled()) {
+            throw new ApplicationLogicException('The chosen wiki is not currently enabled on this tool.');
         }
 
         $this->validateGeneralInformation($emailAddress, $password, $username);
@@ -173,11 +198,13 @@ abstract class PageRegisterBase extends InternalPageBase
         $confirmationId = WebRequest::postInt('conf_revid');
         $onwikiUsername = WebRequest::postString('wname');
 
+        $database = $this->getDatabase();
+        $domain = WebRequest::getString('d');
+        $domainObject = Domain::getByShortName($domain, $database);
+
         // Do some validation
         $this->validateRequest($emailAddress, $password, $username, $useOAuthSignup, $confirmationId,
-            $onwikiUsername);
-
-        $database = $this->getDatabase();
+            $onwikiUsername, $domainObject);
 
         $user = new User();
         $user->setDatabase($database);
@@ -206,6 +233,12 @@ abstract class PageRegisterBase extends InternalPageBase
         // Log now to get the signup date.
         Logger::newUser($database, $user);
         Logger::userRolesEdited($database, $user, 'Registration', array($defaultRole), array());
+
+        $userDomain = new UserDomain();
+        $userDomain->setDatabase($database);
+        $userDomain->setUser($user->getId());
+        $userDomain->setDomain($domainObject->getId());
+        $userDomain->save();
 
         if ($useOAuthSignup) {
             $oauthProtocolHelper = $this->getOAuthProtocolHelper();

--- a/includes/Pages/Registration/PageRegisterOption.php
+++ b/includes/Pages/Registration/PageRegisterOption.php
@@ -8,6 +8,7 @@
 
 namespace Waca\Pages\Registration;
 
+use Waca\DataObjects\Domain;
 use Waca\Tasks\InternalPageBase;
 
 class PageRegisterOption extends InternalPageBase
@@ -19,6 +20,7 @@ class PageRegisterOption extends InternalPageBase
     protected function main()
     {
         $this->assign('allowRegistration', $this->getSiteConfiguration()->isRegistrationAllowed());
+        $this->assign('domains', Domain::getAll($this->getDatabase()));
         $this->setTemplate('registration/option.tpl');
     }
 

--- a/includes/Pages/UserAuth/Login/LoginCredentialPageBase.php
+++ b/includes/Pages/UserAuth/Login/LoginCredentialPageBase.php
@@ -251,6 +251,7 @@ abstract class LoginCredentialPageBase extends InternalPageBase
         }
 
         WebRequest::setLoggedInUser($user);
+        $this->getDomainAccessManager()->switchToDefaultDomain($user);
 
         $this->goBackWhenceYouCame($user);
     }

--- a/includes/Pages/UserAuth/PageOAuthCallback.php
+++ b/includes/Pages/UserAuth/PageOAuthCallback.php
@@ -75,6 +75,7 @@ class PageOAuthCallback extends InternalPageBase
         // login to a full login
         if (WebRequest::getOAuthPartialLogin() === $user->getId()) {
             WebRequest::setLoggedInUser($user);
+            $this->getDomainAccessManager()->switchToDefaultDomain($user);
         }
 
         // My thinking is there are three cases here:

--- a/includes/Security/DomainAccessManager.php
+++ b/includes/Security/DomainAccessManager.php
@@ -55,4 +55,22 @@ class DomainAccessManager
             throw new AccessDeniedException($this->securityManager, $this);
         }
     }
+
+    /**
+     * Not a very smart way of doing this - just set the user's current domain to the first one in the list.
+     *
+     * We may wish to allow the user to configure a default domain, but I don't expect this to be needed by many people,
+     * so for now they can suffer until someone complains.
+     *
+     * @param User $user
+     *
+     * @return void
+     */
+    public function switchToDefaultDomain(User $user): void
+    {
+        $domains = $this->getAllowedDomains($user);
+        if (count($domains) > 0) {
+            WebRequest::setActiveDomain($domains[0]);
+        }
+    }
 }

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -19,7 +19,7 @@ class SiteConfiguration
 {
     private $baseUrl;
     private $filePath;
-    private $schemaVersion = 39;
+    private $schemaVersion = 40;
     private $debuggingTraceEnabled;
     private $debuggingCssBreakpointsEnabled;
     private $dataClearIp = '127.0.0.1';

--- a/sql/patches/patch40-userdomains.sql
+++ b/sql/patches/patch40-userdomains.sql
@@ -47,9 +47,14 @@ CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
         modify localdocumentation varchar(255) not null;
 
     -- Add every user to every domain. In prod, this will be exactly one domain for now.
+    -- noinspection SqlWithoutWhere
+    delete from userdomain;
+
     insert into userdomain (user, domain)
     select u.id user, d.id domain
     from user u cross join domain d;
+
+    commit;
 
     -- -------------------------------------------------------------------------
     -- finally, update the schema version to indicate success

--- a/sql/patches/patch40-userdomains.sql
+++ b/sql/patches/patch40-userdomains.sql
@@ -45,7 +45,12 @@ CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
 
     alter table domain
         modify localdocumentation varchar(255) not null;
-    
+
+    -- Add every user to every domain. In prod, this will be exactly one domain for now.
+    insert into userdomain (user, domain)
+    select u.id user, d.id domain
+    from user u cross join domain d;
+
     -- -------------------------------------------------------------------------
     -- finally, update the schema version to indicate success
     # noinspection SqlWithoutWhere

--- a/sql/patches/patch40-userdomains.sql
+++ b/sql/patches/patch40-userdomains.sql
@@ -1,0 +1,56 @@
+# noinspection SqlResolveForFile
+
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
+DELIMITER ';;'
+CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
+    -- -------------------------------------------------------------------------
+    -- Developers - set the number of the schema patch here!
+    -- -------------------------------------------------------------------------
+    DECLARE patchversion INT DEFAULT 40;
+    -- -------------------------------------------------------------------------
+    -- working variables
+    DECLARE currentschemaversion INT DEFAULT 0;
+    DECLARE lastversion INT;
+	
+    -- check the schema has a version table
+    IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'schemaversion' AND table_schema = DATABASE()) THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please ensure patches are run in order! This database does not have a schemaversion table.';
+    END IF;
+    
+    -- get the current version
+    SELECT version INTO currentschemaversion FROM schemaversion;
+    
+    -- check schema is not ahead of this patch
+    IF currentschemaversion >= patchversion THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'This patch has already been applied!';
+    END IF;
+    
+    -- check schema is up-to-date
+    SET lastversion = patchversion - 1;
+    IF currentschemaversion != lastversion THEN
+		SET @message_text = CONCAT('Please ensure patches are run in order! This patch upgrades to version ', patchversion, ', but the database is not version ', lastversion);
+        SIGNAL SQLSTATE '45000' SET message_text = @message_text;
+    END IF;
+
+    -- -------------------------------------------------------------------------
+    -- Developers - put your upgrade statements here!
+    -- -------------------------------------------------------------------------
+
+    alter table domain
+        add localdocumentation varchar(255) null;
+
+    -- Yes, I do want to update every row.
+    -- noinspection SqlConstantCondition,SqlConstantExpression
+    update domain set localdocumentation = 'https://en.wikipedia.org/wiki/Wikipedia:Request_an_account/Guide' where 1=1;
+
+    alter table domain
+        modify localdocumentation varchar(255) not null;
+    
+    -- -------------------------------------------------------------------------
+    -- finally, update the schema version to indicate success
+    # noinspection SqlWithoutWhere
+    UPDATE schemaversion SET version = patchversion;
+END;;
+DELIMITER ';'
+CALL SCHEMA_UPGRADE_SCRIPT();
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;

--- a/templates/domain-management/edit.tpl
+++ b/templates/domain-management/edit.tpl
@@ -129,6 +129,17 @@
                                     <small class="form-text text-muted" id="notificationTargetHelp">The target to send IRC notifications to via Helpmebot.</small>
                                 </div>
                             </div>
+
+
+                            <div class="form-group row">
+                                <div class="col-sm-4 col-md-3 col-lg-4 col-xl-3">
+                                    <label for="localDocumentation" class="col-form-label">Tool documentation URL:</label>
+                                </div>
+                                <div class="col-sm-8 col-md-9 col-lg-8 col-xl-9">
+                                    <input type="text" class="form-control" id="localDocumentation" name="localDocumentation" maxlength="255" required="required" placeholder="e.g. https://en.wikipedia.org/wiki/Wikipedia:Request_an_account/Guide" value="{$localDocumentation|escape}"/>
+                                    <small class="form-text text-muted" id="localDocumentationHelp">The URL of the page containing the local tool documentation</small>
+                                </div>
+                            </div>
                         </fieldset>
                     </div>
                 </div>

--- a/templates/domain-management/main.tpl
+++ b/templates/domain-management/main.tpl
@@ -42,7 +42,7 @@
                                 <th>Language</th><td>{$domain->getDefaultLanguage()|escape}</td>
                             </tr>
                             <tr>
-                                <th>Email sender</th><td>{$domain->getEmailSender()}</td>
+                                <th>Email sender</th><td>{$domain->getEmailSender()|escape}</td>
                             </tr>
                             {if ($currentDomain->getId() == $domain->getId() && $canEdit) || $canEditAll}
                                 <tr>
@@ -61,6 +61,9 @@
                                     </td>
                                 </tr>
                             {/if}
+                            <tr>
+                                <th>Documentation</th><td><a href="{$domain->getLocalDocumentation()|escape}">{$domain->getLocalDocumentation()|escape}</a></td>
+                            </tr>
                         </table>
                     </div>
                 </div>

--- a/templates/navigation-menu.tpl
+++ b/templates/navigation-menu.tpl
@@ -120,10 +120,10 @@
                     <div class="dropdown-divider"></div>
 
                     <h6 class="dropdown-header">Help</h6>
-                    <a class="dropdown-item" href="//en.wikipedia.org/wiki/Wikipedia:Request_an_account/Guide" target="_blank">
+                    <a class="dropdown-item" href="{$currentDomain->getLocalDocumentation()|escape}" target="_blank">
                         <i class="fas fa-question-circle"></i>&nbsp;Guide
                     </a>
-                    <a class="dropdown-item" href="//en.wikipedia.org/wiki/Wikipedia:Username_policy" target="_blank">
+                    <a class="dropdown-item" href="https://en.wikipedia.org/wiki/Wikipedia:Username_policy" target="_blank">
                         <i class="fas fa-exclamation-triangle"></i>&nbsp;Username policy
                     </a>
                     <!--suppress HtmlUnknownAnchorTarget -->

--- a/templates/registration/option.tpl
+++ b/templates/registration/option.tpl
@@ -14,20 +14,35 @@
                 <p>Click the button directly below to go to the right place.</p>
                 <p><a class="btn btn-primary btn-large" href="{$baseurl}/index.php">Register for Wikipedia</a></p>
             </div>
-
-            <div class="alert alert-block alert-success">
-                <h3>Standard tool user</h3>
-                <p>
-                    Standard tool access allows you to process all account requests, but requires a lot of experience on
-                    Wikipedia, along with making your identity known to the Wikimedia Foundation. Please make sure you refer to
-                    the Guide to understand the full requirements.
-                </p>
-                {if $allowRegistration}
-                    <p><a class="btn btn-large btn-success" href="{$baseurl}/internal.php/register/standard">Register for tool access</a></p>
-                {else}
-                    <p>Registration for this tool is currently disabled. Please check back later.</p>
-                {/if}
-            </div>
         </div>
+    </div>
+    <div class="row">
+        <div class="col-12">
+            <p>
+                Tool access for a specific wiki allows you to handle requests for that wiki. This requires a lot of
+                experience with the policies of your wiki (especially the username policies), and awareness of other
+                username polices for other wikis.
+            </p>
+            <p>Please make sure you refer to the Guide to understand the full requirements.</p>
+        </div>
+    </div>
+    <div class="row">
+        {foreach $domains as $d}
+            <div class="col-xl-4">
+                <div class="card mb-4">
+                    <div class="card-body">
+                        <h3 class="card-title">{$d->getLongName()|escape} tool access</h3>
+                        <p class="card-text">
+                            Request access to handle requests from {$d->getLongName()|escape}.
+                        </p>
+                        {if $allowRegistration && $d->isEnabled()}
+                            <p class="card-text"><a class="btn btn-large btn-success" href="{$baseurl}/internal.php/register/standard?d={$d->getShortName()|escape}">Register for tool access</a></p>
+                        {else}
+                            <p class="card-text">Registration for this tool is currently disabled. Please check back later.</p>
+                        {/if}
+                    </div>
+                </div>
+            </div>
+        {/foreach}
     </div>
 {/block}

--- a/templates/registration/register.tpl
+++ b/templates/registration/register.tpl
@@ -114,7 +114,7 @@
                             <input class="custom-control-input" id="guidelines" type="checkbox" name="guidelines" required="required"/>
                             <label class="custom-control-label" for="guidelines">
                                 I have read and understand the
-                                <a href="http://en.wikipedia.org/wiki/Wikipedia:Request_an_account/Guide">interface guide</a>.
+                                <a href="{$localDocumentation|escape}">interface documentation and guide</a>.
                             </label>
                         </div>
                     </div>


### PR DESCRIPTION
This PR does four things:
* Adds all existing users to all existing domains. In practice, this means just enwiki, since enwiki is the only domain which exists (in production)
* Defines the current Guide URL to be per-domain
* Allows a user to choose the domain they want access to when they sign up
* Sets the current domain to a domain the user is in on login.