### PR TITLE
API actions: remove unused code

### DIFF
--- a/includes/API/Actions/JsTemplateConfirmsAction.php
+++ b/includes/API/Actions/JsTemplateConfirmsAction.php
@@ -16,8 +16,6 @@ class JsTemplateConfirmsAction extends JsonApiPageBase implements IJsonApiAction
 {
     public function executeApiAction()
     {
-        $this->getDatabase();
-
         /** @var EmailTemplate[] $templates */
         $templates = EmailTemplate::getAllActiveTemplates(null, $this->getDatabase());
 

--- a/includes/API/Actions/JsUsersAction.php
+++ b/includes/API/Actions/JsUsersAction.php
@@ -18,8 +18,6 @@ class JsUsersAction extends JsonApiPageBase implements IJsonApiAction
 {
     public function executeApiAction()
     {
-        $this->getDatabase();
-
         $userSearchHelper = UserSearchHelper::get($this->getDatabase());
 
         if (WebRequest::getString('all') === null) {


### PR DESCRIPTION
TaskBase::getDatabase() has no side effects, and the results is unused, so there is no need to call the method.