### PR TITLE
Replace Deprecated code

### DIFF
--- a/includes/ConsoleTasks/RegenerateStylesheetsTask.php
+++ b/includes/ConsoleTasks/RegenerateStylesheetsTask.php
@@ -21,7 +21,7 @@ class RegenerateStylesheetsTask extends ConsoleTaskBase
         $scss->setImportPaths('resources/scss');
 
         if (!$this->getSiteConfiguration()->getDebuggingTraceEnabled()) {
-            $scss->setFormatter(OutputStyle::COMPRESSED);
+            $scss->setFormatter('\ScssPhp\ScssPhp\OutputStyle::COMPRESSED');
             $scss->setSourceMap(Compiler::SOURCE_MAP_INLINE);
         }
 

--- a/includes/ConsoleTasks/RegenerateStylesheetsTask.php
+++ b/includes/ConsoleTasks/RegenerateStylesheetsTask.php
@@ -32,7 +32,8 @@ class RegenerateStylesheetsTask extends ConsoleTaskBase
         foreach (['bootstrap-main', 'bootstrap-alt', 'bootstrap-auto'] as $file) {
             file_put_contents(
                 self::RESOURCES_GENERATED . '/' . $file . '.css',
-                $scss->compileString('/*! Do not edit this auto-generated file! */ @import "' . $file . '";'));
+                $scss->compileString('/*! Do not edit this auto-generated file! */ @import "' . $file . '";')->getCss()
+            );
         }
     }
 }

--- a/includes/ConsoleTasks/RegenerateStylesheetsTask.php
+++ b/includes/ConsoleTasks/RegenerateStylesheetsTask.php
@@ -21,7 +21,7 @@ class RegenerateStylesheetsTask extends ConsoleTaskBase
         $scss->setImportPaths('resources/scss');
 
         if (!$this->getSiteConfiguration()->getDebuggingTraceEnabled()) {
-            $scss->setFormatter('\ScssPhp\ScssPhp\OutputStyle::COMPRESSED');
+            $scss->setOutputStyle(\ScssPhp\ScssPhp\OutputStyle::COMPRESSED);
             $scss->setSourceMap(Compiler::SOURCE_MAP_INLINE);
         }
 

--- a/includes/ConsoleTasks/RegenerateStylesheetsTask.php
+++ b/includes/ConsoleTasks/RegenerateStylesheetsTask.php
@@ -21,7 +21,7 @@ class RegenerateStylesheetsTask extends ConsoleTaskBase
         $scss->setImportPaths('resources/scss');
 
         if (!$this->getSiteConfiguration()->getDebuggingTraceEnabled()) {
-            $scss->setFormatter('ScssPhp\\ScssPhp\\Formatter\\Compressed');
+            $scss->setFormatter(OutputStyle::COMPRESSED);
             $scss->setSourceMap(Compiler::SOURCE_MAP_INLINE);
         }
 
@@ -32,7 +32,7 @@ class RegenerateStylesheetsTask extends ConsoleTaskBase
         foreach (['bootstrap-main', 'bootstrap-alt', 'bootstrap-auto'] as $file) {
             file_put_contents(
                 self::RESOURCES_GENERATED . '/' . $file . '.css',
-                $scss->compile('/*! Do not edit this auto-generated file! */ @import "' . $file . '";'));
+                $scss->compileString('/*! Do not edit this auto-generated file! */ @import "' . $file . '";'));
         }
     }
 }


### PR DESCRIPTION
scssPhp has deprecated the use of 'ScssPhp\\ScssPhp\\Formatter\\Compressed' and also ->comple. Replaced them with the newer versions