### PR TITLE
Add badges to highlight concern areas

### DIFF
--- a/includes/Fragments/NavigationMenuAccessControl.php
+++ b/includes/Fragments/NavigationMenuAccessControl.php
@@ -109,7 +109,7 @@ trait NavigationMenuAccessControl
      *
      * @return void
      */
-    public function setUpNavBarBadges($currentUser, $database) {
+    public function setUpNavBarBadges(User $currentUser, PdoDatabase $database) {
         // Set up some variables.
         // A size of 0 causes nothing to show up on the page (checked on navigation-menu.tpl) so leaving it 0 here is fine.
         $countOfFlagged = 0;

--- a/includes/Fragments/NavigationMenuAccessControl.php
+++ b/includes/Fragments/NavigationMenuAccessControl.php
@@ -8,6 +8,10 @@
 
 namespace Waca\Fragments;
 
+use Waca\DataObjects\Comment;
+use Waca\DataObjects\JobQueue;
+use Waca\DataObjects\User;
+use Waca\Helpers\SearchHelpers\JobQueueSearchHelper;
 use Waca\Pages\PageBan;
 use Waca\Pages\PageDomainManagement;
 use Waca\Pages\PageEmailManagement;
@@ -24,6 +28,7 @@ use Waca\Pages\PageViewRequest;
 use Waca\Pages\PageWelcomeTemplateManagement;
 use Waca\Pages\Statistics\StatsMain;
 use Waca\Pages\Statistics\StatsUsers;
+use Waca\PdoDatabase;
 use Waca\Security\DomainAccessManager;
 use Waca\Security\RoleConfiguration;
 use Waca\Security\SecurityManager;
@@ -91,5 +96,47 @@ trait NavigationMenuAccessControl
         if ($this->getDomainAccessManager() !== null) {
             $this->assign('nav__domainList', $this->getDomainAccessManager()->getAllowedDomains($currentUser));
         }
+    }
+
+    /**
+     * Sets up the badges to draw attention to issues on various admin pages.
+     *
+     * This function checks to see if a user can access the pages, and if so checks the count of problem areas.
+     * If problem areas are found, a number greater than 0 will cause the badge to show up.
+     *
+     * @param User        $currentUser The current user
+     * @param PdoDatabase $database    Database instance
+     *
+     * @return void
+     */
+    public function setUpNavBarBadges($currentUser, $database) {
+        // Set up some variables.
+        // A size of 0 causes nothing to show up on the page (checked on navigation-menu.tpl) so leaving it 0 here is fine.
+        $countOfFlagged = 0;
+        $countOfJobQueue = 0;
+
+        // Count of flagged comments:
+        if($this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageListFlaggedComments::class)) {
+            // We want all flagged comments that haven't been acknowledged if we can visit the page.
+            $countOfFlagged = sizeof(Comment::getFlaggedComments($database));
+        }
+
+        // Count of failed job queue changes:
+        if($this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageJobQueue::class)) {
+            // We want all failed jobs that haven't been acknowledged if we can visit the page.
+            JobQueueSearchHelper::get($database)
+                ->statusIn([JobQueue::STATUS_FAILED])
+                ->notAcknowledged()
+                ->getRecordCount($countOfJobQueue);
+        }
+
+        // To generate the main badge, add both up.
+        // If we add more badges in the future, don't forget to add them here!
+        $countOfAll = $countOfFlagged + $countOfJobQueue;
+
+        // Set badge variables
+        $this->assign("nav__numFlaggedComments", $countOfFlagged);
+        $this->assign("nav__numJobQueueFailed", $countOfJobQueue);
+        $this->assign("nav__numAdmin", $countOfAll);
     }
 }

--- a/includes/Fragments/TemplateOutput.php
+++ b/includes/Fragments/TemplateOutput.php
@@ -94,6 +94,11 @@ trait TemplateOutput
         $this->assign('nav__canQueueMgmt', false);
         $this->assign('nav__canErrorLog', false);
 
+        // Navigation badges for concern areas.
+        $this->assign("nav__numAdmin", 0);
+        $this->assign("nav__numFlaggedComments", 0);
+        $this->assign("nav__numJobQueueFailed", 0);
+
         // debug helpers
         $this->assign('showDebugCssBreakpoints', $this->getSiteConfiguration()->getDebuggingCssBreakpointsEnabled());
 

--- a/includes/Tasks/InternalPageBase.php
+++ b/includes/Tasks/InternalPageBase.php
@@ -107,6 +107,9 @@ abstract class InternalPageBase extends PageBase
         $database = $this->getDatabase();
         $currentUser = User::getCurrent($database);
 
+        // Load in the badges for the navbar
+        $this->setUpNavBarBadges($currentUser, $database);
+
         if ($this->barrierTest('viewSiteNotice', User::getCurrent($database), 'GlobalInfo')) {
             $siteNotice = SiteNotice::get($this->getDatabase());
             $siteNoticeHash = sha1($siteNotice);

--- a/templates/navigation-menu.tpl
+++ b/templates/navigation-menu.tpl
@@ -25,7 +25,12 @@
         {/if}
         {if $nav__canBan || $nav__canEmailMgmt || $nav__canWelcomeMgmt || $nav__canSiteNoticeMgmt || $nav__canUserMgmt || $nav__canJobQueue || $nav__canFlaggedComments || $nav__canQueueMgmt || $nav__canDomainMgmt || $nav__canErrorLog}
             <li class="nav-item dropdown">
-                <a href="#" class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown"><i class="fas fa-wrench"></i>&nbsp;Admin</a>
+                <a href="#" class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">
+                    <i class="fas fa-wrench"></i>&nbsp;Admin
+                    {if $nav__numAdmin > 0}
+                        <div class="badge badge-danger">{$nav__numAdmin}</div>
+                    {/if}
+                </a>
                 <div class="dropdown-menu">
                     {if $nav__canBan}
                         <a class="dropdown-item" href="{$baseurl}/internal.php/bans"><i class="fas fa-ban"></i>&nbsp;Ban Management</a>
@@ -43,10 +48,24 @@
                         <a class="dropdown-item" href="{$baseurl}/internal.php/userManagement"><i class="fas fa-user"></i> User Management</a>
                     {/if}
                     {if $nav__canJobQueue}
-                        <a class="dropdown-item" href="{$baseurl}/internal.php/jobQueue"><i class="fas fa-tools"></i> Job Queue</a>
+                        <a class="dropdown-item" href="{$baseurl}/internal.php/jobQueue">
+                            <i class="fas fa-tools"></i> Job Queue
+                            {if $nav__numJobQueueFailed > 0}
+                                <span class="badge badge-danger">
+                                        {$nav__numJobQueueFailed}
+                                    </span>
+                            {/if}
+                        </a>
                     {/if}
                     {if $nav__canFlaggedComments}
-                        <a class="dropdown-item" href="{$baseurl}/internal.php/flaggedComments"><i class="fas fa-flag"></i> Flagged Comments</a>
+                        <a class="dropdown-item" href="{$baseurl}/internal.php/flaggedComments">
+                            <i class="fas fa-flag"></i> Flagged Comments
+                            {if $nav__numFlaggedComments > 0}
+                                <span class="badge badge-danger">
+                                    {$nav__numFlaggedComments}
+                                </span>
+                            {/if}
+                        </a>
                     {/if}
                     {if $nav__canQueueMgmt}
                         <a class="dropdown-item" href="{$baseurl}/internal.php/queueManagement"><i class="fas fa-list-ol"></i> Request Queue Management</a>

--- a/templates/navigation-menu.tpl
+++ b/templates/navigation-menu.tpl
@@ -52,8 +52,8 @@
                             <i class="fas fa-tools"></i> Job Queue
                             {if $nav__numJobQueueFailed > 0}
                                 <span class="badge badge-danger">
-                                        {$nav__numJobQueueFailed}
-                                    </span>
+                                    {$nav__numJobQueueFailed}
+                                </span>
                             {/if}
                         </a>
                     {/if}


### PR DESCRIPTION
These badges are for the flagged comments and the job queue.  For flagged comments, any comments that have a flag are counted.  For the job queue, any failed and not acknowledged error is counted.  If we have either, it also shows a badge on the main navigation item to draw attention.

#735

This is a preview of what they look like, for admins and regular users.  
<img width="294" alt="Screen Shot 2022-07-28 at 4 16 25 PM" src="https://user-images.githubusercontent.com/802331/181649426-9212812f-fcc3-4028-9e2f-7fdeda428da7.png">
<img width="297" alt="Screen Shot 2022-07-28 at 4 15 30 PM" src="https://user-images.githubusercontent.com/802331/181649428-40337618-59a7-43c7-86b8-85c1be7de731.png">

Note that as of right now, everyone has access to the job queue.  So, the badge will show for all users.  If we want to limit that, we can.  