### PR TITLE
Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,7 @@ VOLUME /var/www/html/errorlog
 WORKDIR /var/www/html
 COPY . /var/www/html
 
+ENV XDEBUG_CONFIG="client_host=host.docker.internal client_port=9003 discover_client_host=true"
+ENV XDEBUG_MODE="develop,debug,profile"
+
 ENTRYPOINT /var/www/html/docker/entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,14 @@ services:
     volumes:
       - .:/var/www/html/
     ports:
-      - 8080:80
+      - "8080:80"
     depends_on:
       - database
+      - msgbroker
   database:
     image: mariadb:10.3
     ports:
-      - 3306:3306
+      - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: waca
       MYSQL_DATABASE: waca
@@ -23,6 +24,16 @@ services:
       - mysql-data:/var/lib/mysql
       - ./docker/database.sh:/docker-entrypoint-initdb.d/init.sh
       - ./sql:/wacadb
+  msgbroker:
+    image: rabbitmq:3.10-management-alpine
+    ports:
+      - "5672:5672" # Actual message broker port.
+      - "15672:15672" # Management web interface port. Plain HTTP, username guest, password guest.
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+      - ./docker/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+
 volumes:
   mysql-data:
+  rabbitmq-data:
 


### PR DESCRIPTION
- Add a `msgbroker` service running RabbitMQ to docker-compose
- Quote port numbers in docker-compose, as recommended by the spec
- Configure and enable XDebug in the Dockerfile for the application

Tested locally, using PhpStorm's auto-debug functionality (no configuration required; PhpStorm autodetects) and by creating an account request and observing a message enqueued in RabbitMQ (though I had to manually create the exchange, queue, and bindings in the RabbitMQ management interface).

Note that the `rabbitmq.conf` file is deliberately empty, but exists is a placeholder if we want to tweak the behavior of the RabbitMQ instance in `msgbroker`.