### PR TITLE
Introduce manual confirmation

### DIFF
--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -139,6 +139,7 @@ class LogHelper
         $lookup = array(
             'Reserved'            => 'reserved',
             'Email Confirmed'     => 'email-confirmed',
+            'Manually Confirmed'     => 'manually confirmed the request',
             'Unreserved'          => 'unreserved',
             'Approved'            => 'approved',
             'Suspended'           => 'suspended',

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -139,7 +139,7 @@ class LogHelper
         $lookup = array(
             'Reserved'            => 'reserved',
             'Email Confirmed'     => 'email-confirmed',
-            'Manually Confirmed'     => 'manually confirmed the request',
+            'Manually Confirmed'  => 'manually confirmed the request',
             'Unreserved'          => 'unreserved',
             'Approved'            => 'approved',
             'Suspended'           => 'suspended',
@@ -198,6 +198,7 @@ class LogHelper
             "Requests" => [
                 'Reserved'            => 'reserved',
                 'Email Confirmed'     => 'email-confirmed',
+                'Manually Confirmed'  => 'manually confirmed',
                 'Unreserved'          => 'unreserved',
                 'EditComment-c'       => 'edited a comment (by comment ID)',
                 'EditComment-r'       => 'edited a comment (by request)',

--- a/includes/Helpers/Logger.php
+++ b/includes/Helpers/Logger.php
@@ -263,6 +263,11 @@ class Logger
         self::createLogEntry($database, $object, "Closed $target", $comment, $logUser);
     }
 
+    public static function manuallyConfirmRequest(PdoDatabase $database, Request $object)
+    {
+        self::createLogEntry($database, $object, "Manually Confirmed");
+    }
+
     /**
      * @param PdoDatabase $database
      * @param Request     $object

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -59,11 +59,17 @@ class PageViewRequest extends InternalPageBase
         // Shows a page if the email is not confirmed.
         if ($request->getEmailConfirm() !== 'Confirmed') {
             // Show a banner if the user can manually confirm the request
-            $viewConfirm = $this->barrierTest("main", $currentUser, PageManuallyConfirm::class);
+            $viewConfirm = $this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageManuallyConfirm::class);
+
+            // If the request is purged, there's nothing to confirm!
+            if ($request->getEmail() === $this->getSiteConfiguration()->getDataClearEmail()) {
+                $viewConfirm = false;
+            }
 
             // Render
             $this->setTemplate("view-request/not-confirmed.tpl");
             $this->assign("requestId", $request->getId());
+            $this->assign("requestVersion", $request->getUpdateVersion());
             $this->assign('canViewConfirmButton', $viewConfirm);
 
             // Make sure to return, to prevent the leaking of other information.

--- a/includes/Pages/RequestAction/PageManuallyConfirm.php
+++ b/includes/Pages/RequestAction/PageManuallyConfirm.php
@@ -1,0 +1,49 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\Pages\RequestAction;
+
+use Waca\Exceptions\ApplicationLogicException;
+use Waca\Exceptions\OptimisticLockFailedException;
+use Waca\Helpers\Logger;
+
+class PageManuallyConfirm extends RequestActionBase
+{
+    /**
+     * This endpoint manually confirms a request, bypassing email confirmation.
+     *
+     * Only administrators are allowed to do this, for obvious reasons.
+     *
+     * @throws ApplicationLogicException|OptimisticLockFailedException
+     */
+    protected function main()
+    {
+        // This method throws an error if we don't post
+        $this->checkPosted();
+
+        // Retrieve the database.
+        $database = $this->getDatabase();
+
+        // Find the request
+        // This method throws exceptions if there is an error with the request.
+        $request = $this->getRequest($database);
+
+        // Mark the request as confirmed.
+        $request->setEmailConfirm("Confirmed");
+        $request->save();
+
+        // Log that the request was manually confirmed
+        Logger::manuallyConfirmRequest($database, $request);
+
+        // Notify the IRC channel
+        $this->getNotificationHelper()->requestReceived($request);
+
+        // Redirect back to the main request, now it should show the request.
+        $this->redirect('viewRequest', null, array('id' => $request->getId()));
+    }
+}

--- a/includes/Pages/RequestAction/PageManuallyConfirm.php
+++ b/includes/Pages/RequestAction/PageManuallyConfirm.php
@@ -11,6 +11,7 @@ namespace Waca\Pages\RequestAction;
 use Waca\Exceptions\ApplicationLogicException;
 use Waca\Exceptions\OptimisticLockFailedException;
 use Waca\Helpers\Logger;
+use Waca\WebRequest;
 
 class PageManuallyConfirm extends RequestActionBase
 {
@@ -32,6 +33,9 @@ class PageManuallyConfirm extends RequestActionBase
         // Find the request
         // This method throws exceptions if there is an error with the request.
         $request = $this->getRequest($database);
+        $version = WebRequest::postInt('version');
+
+        $request->setUpdateVersion($version);
 
         // Mark the request as confirmed.
         $request->setEmailConfirm("Confirmed");

--- a/includes/Router/RequestRouter.php
+++ b/includes/Router/RequestRouter.php
@@ -23,6 +23,7 @@ use Waca\Pages\PageListFlaggedComments;
 use Waca\Pages\PageQueueManagement;
 use Waca\Pages\PageXffDemo;
 use Waca\Pages\RequestAction\PageCreateRequest;
+use Waca\Pages\RequestAction\PageManuallyConfirm;
 use Waca\Pages\UserAuth\Login\PageOtpLogin;
 use Waca\Pages\UserAuth\Login\PagePasswordLogin;
 use Waca\Pages\UserAuth\Login\PageU2FLogin;
@@ -316,6 +317,11 @@ class RequestRouter implements IRequestRouter
         'viewRequest'                 =>
             array(
                 'class'   => PageViewRequest::class,
+                'actions' => array(),
+            ),
+        'viewRequest/confirm'         =>
+            array(
+                'class'   => PageManuallyConfirm::class,
                 'actions' => array(),
             ),
         'viewRequest/reserve'         =>

--- a/includes/Security/RoleConfiguration.php
+++ b/includes/Security/RoleConfiguration.php
@@ -24,6 +24,7 @@ use Waca\Pages\PageMain;
 use Waca\Pages\PageQueueManagement;
 use Waca\Pages\PageXffDemo;
 use Waca\Pages\RequestAction\PageCreateRequest;
+use Waca\Pages\RequestAction\PageManuallyConfirm;
 use Waca\Pages\UserAuth\PageChangePassword;
 use Waca\Pages\UserAuth\MultiFactor\PageMultiFactor;
 use Waca\Pages\UserAuth\PageOAuth;
@@ -265,6 +266,9 @@ class RoleConfiguration
             ),
             PageSearch::class                    => array(
                 'byComment' => self::ACCESS_ALLOW,
+            ),
+            PageManuallyConfirm::class               => array(
+                self::MAIN => self::ACCESS_ALLOW,
             ),
             PageWelcomeTemplateManagement::class => array(
                 'edit'   => self::ACCESS_ALLOW,

--- a/templates/view-request/not-confirmed.tpl
+++ b/templates/view-request/not-confirmed.tpl
@@ -13,11 +13,12 @@
                 <form method="post" action="{$baseurl}/internal.php/viewRequest/confirm">
                     <div class="alert alert-danger">
                         <input type="hidden" name="request" value="{$requestId}" />
+                        <input type="hidden" name="version" value="{$requestVersion}" />
                         {include file="security/csrf.tpl"}
-                        As a tool administrator, you may manually confirm this request.
-                        <em>This bypasses the email confirmation step, which is not recommended unless the user has replied to the email list.</em>
-                        <br />
-                        <br />
+                        <p>
+                            As a tool administrator, you may manually confirm this request.
+                            <em>This bypasses the email confirmation step, which is not recommended unless the user has replied to the email list.</em>
+                        </p>
                         <button type="submit" class="btn btn-danger">Manually Confirm This Request</button>
                     </div>
                 </form>

--- a/templates/view-request/not-confirmed.tpl
+++ b/templates/view-request/not-confirmed.tpl
@@ -1,0 +1,30 @@
+{extends file="pagebase.tpl"}
+{block name="content"}
+    <div class="row">
+        <div class="col-md-12" >
+            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                <h1 class="h2">View request details <small class="text-muted">for request #{$requestId}</small></h1>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        {if $canViewConfirmButton}
+            <div class="col-lg-12">
+                <form method="post" action="{$baseurl}/internal.php/viewRequest/confirm">
+                    <div class="alert alert-danger">
+                        <input type="hidden" name="request" value="{$requestId}" />
+                        {include file="security/csrf.tpl"}
+                        As a tool administrator, you may manually confirm this request.
+                        <em>This bypasses the email confirmation step, which is not recommended unless the user has replied to the email list.</em>
+                        <br />
+                        <br />
+                        <button type="submit" class="btn btn-danger">Manually Confirm This Request</button>
+                    </div>
+                </form>
+            </div>
+        {/if}
+        <div class="col-lg-12">
+            This request has not been email confirmed.
+        </div>
+    </div>
+{/block}


### PR DESCRIPTION
#259 

This is only available to administrators.  Note, this depends on #751 as that's what I based my branch on.

This commit does replace the throwing of an exception with an actual page explaining that the request is not email confirmed.  If the user is an administrator, it shows a big scary banner(tm) that warns of the consequences.  Because this provides a path to manually confirm requests, I have removed the check for `$enableEmailConfirm` out of the request view.  

User view:
![Screen Shot 2022-08-05 at 12 12 01 PM](https://user-images.githubusercontent.com/802331/183141373-8dbb91ad-f8e9-4cfa-9e21-6c06660aea07.png)

Administrator view:
![Screen Shot 2022-08-05 at 12 11 53 PM](https://user-images.githubusercontent.com/802331/183141413-bbd6208e-963b-4a84-94f8-1dcbeab6bc55.png)

After request is confirmed (note the log):
![Screen Shot 2022-08-05 at 12 12 09 PM](https://user-images.githubusercontent.com/802331/183141588-1921e8a3-c18e-4125-94fa-c5464431f5a6.png)

