### PR TITLE
Fix SearchHelper IN() clause construction

### DIFF
--- a/includes/ConsoleTasks/ClearOAuthDataTask.php
+++ b/includes/ConsoleTasks/ClearOAuthDataTask.php
@@ -8,6 +8,7 @@
 
 namespace Waca\ConsoleTasks;
 
+use PDO;
 use Waca\Helpers\OAuthUserHelper;
 use Waca\Helpers\SearchHelpers\UserSearchHelper;
 use Waca\Tasks\ConsoleTaskBase;
@@ -19,7 +20,7 @@ class ClearOAuthDataTask extends ConsoleTaskBase
         $database = $this->getDatabase();
 
         $users = UserSearchHelper::get($database)->inIds(
-            $database->query('SELECT user FROM oauthtoken WHERE type = \'access\'')->fetchColumn()
+            $database->query('SELECT user FROM oauthtoken WHERE type = \'access\'')->fetchAll(PDO::FETCH_COLUMN)
         );
 
         foreach ($users as $u) {

--- a/includes/Helpers/SearchHelpers/SearchHelperBase.php
+++ b/includes/Helpers/SearchHelpers/SearchHelperBase.php
@@ -260,7 +260,7 @@ abstract class SearchHelperBase
             $colData[] = 'origin.' . $c;
         }
 
-        $query = "SELECT {$this->modifiersClause} /* SearchHelper */ " . implode(', ', $colData) . ' FROM ' . $this->table . ' origin ';
+        $query = "SELECT {$this->modifiersClause} /* " . get_called_class() . " */ " . implode(', ', $colData) . ' FROM ' . $this->table . ' origin ';
         $query .= $this->joinClause . $this->whereClause . $this->groupByClause;
 
         return $query;
@@ -276,6 +276,7 @@ abstract class SearchHelperBase
     protected function inClause($column, $values)
     {
         if (count($values) === 0) {
+            $this->whereClause .= ' AND 1 = 2 /* empty IN() */';
             return;
         }
 


### PR DESCRIPTION
Currently, SearchHelpers will do nothing if you pass an empty list to their SQL `IN(...)` clause generation tools. This means that the IN() is never added to the query, and it's as if you'd never specified that you wanted an `IN(...)` clause at all.

This is not expected, as I'd anticipate that specifying an `IN(...)` clause and passing an empty array would indicate you expect zero results (nothing selected to return). Indeed, several usages of this function are built in this way - for example, pull all usernames for users who reserved this set of requests, but it's an empty set to retrieve *all* usernames.

We also fix one such usage which only passes the *first* result into an `IN(...)` clause, instead of all discovered results.

This issue was spotted in the MariaDB slow query log running these queries:
```
    SELECT origin.id, origin.name FROM request origin WHERE 1 = 1
    SELECT origin.id, origin.username FROM user origin WHERE 1 = 1
```

The first query examined 200k rows on each execution, and took 0.1s to look up all requests. The second only examined 2k rows in 4ms, but was executed a large number of times. After this change, this query will be culled by the optimiser into a zero-row resultset, and shouldn't hit any tables at all.