### PR TITLE
Various Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM php:7.3-apache-buster
 
+ENV DEBIAN_FRONTEND="noninteractive"
+
+COPY docker/msmtprc /etc/msmtprc
+
 # VOLUME /var/www/html
 RUN apt-get update \
-    && apt-get install git unzip -q -y --no-install-recommends \
+    && apt-get install git unzip msmtp msmtp-mta -q -y --no-install-recommends \
     && apt-get clean
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
@@ -20,7 +24,7 @@ VOLUME /var/www/html/errorlog
 WORKDIR /var/www/html
 COPY . /var/www/html
 
-ENV XDEBUG_CONFIG="client_host=host.docker.internal client_port=9003 discover_client_host=true"
+ENV XDEBUG_CONFIG="client_host=host.docker.internal client_port=9003 discover_client_host=false"
 ENV XDEBUG_MODE="develop,debug,profile"
 
 ENTRYPOINT /var/www/html/docker/entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     depends_on:
       - database
       - msgbroker
+      - mailsink
   database:
     image: mariadb:10.3
     ports:
@@ -32,8 +33,13 @@ services:
     volumes:
       - rabbitmq-data:/var/lib/rabbitmq
       - ./docker/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+      - ./docker/rabbitmq-definitions.json:/etc/rabbitmq/definitions.json
+  mailsink:
+    image: nicktriller/mail-sink
+    ports:
+      - "1025:1025" # SMTP target to receive (and sink) emails
+      - "8081:8080" # HTTP web interface to view received emails
 
 volumes:
   mysql-data:
   rabbitmq-data:
-

--- a/docker/config.local.inc.php
+++ b/docker/config.local.inc.php
@@ -1,0 +1,25 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+// Sane defaults for Docker-based ACC development environments. When running `docker compose up`,
+// this file will be copied into the ACC root if a local config file does not already exist.
+
+$toolserver_username = "waca";
+$toolserver_password = "waca";
+$toolserver_host = "database";
+$toolserver_database = "waca";
+
+$whichami = 'docker_dev';
+
+// URL of the current copy of the tool.
+$baseurl = "http://localhost:8080";
+$cookiepath = '/';
+
+$amqpConfiguration = ['host' => 'msgbroker', 'port' => 5672, 'user' => 'guest', 'password' => 'guest', 'vhost' => '/', 'exchange' => 'main', 'tls' => false];
+
+$enableEmailConfirm = 1; // Emails will be sent to the mailsink docker-compose service

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,6 +4,10 @@ cd /var/www/html
 
 chown -R www-data templates_c errorlog
 
+if [[ ! -f config.local.inc.php ]]; then
+    cp docker/config.local.inc.php config.local.inc.php
+fi
+
 php /opt/composer.phar install
 php maintenance/RegenerateStylesheets.php
 

--- a/docker/msmtprc
+++ b/docker/msmtprc
@@ -1,0 +1,11 @@
+defaults
+auth           off
+tls            off
+tls_starttls   off
+
+account        mailsink
+host           mailsink
+port           1025
+from           accounts@wmflabs.org
+
+account default : mailsink

--- a/docker/rabbitmq-definitions.json
+++ b/docker/rabbitmq-definitions.json
@@ -1,0 +1,73 @@
+{
+    "rabbit_version": "3.10.7",
+    "rabbitmq_version": "3.10.7",
+    "product_name": "RabbitMQ",
+    "product_version": "3.10.7",
+    "users": [
+        {
+            "name": "guest",
+            "password_hash": "Qc1Q8iTLO1z51lpulvLJBdICCl0XWo9p32z2tOaszlgRJlcW",
+            "hashing_algorithm": "rabbit_password_hashing_sha256",
+            "tags": [
+                "administrator"
+            ],
+            "limits": {}
+        }
+    ],
+    "vhosts": [
+        {
+            "name": "/"
+        }
+    ],
+    "permissions": [
+        {
+            "user": "guest",
+            "vhost": "/",
+            "configure": ".*",
+            "write": ".*",
+            "read": ".*"
+        }
+    ],
+    "topic_permissions": [],
+    "parameters": [],
+    "global_parameters": [
+        {
+            "name": "internal_cluster_id",
+            "value": "rabbitmq-cluster-id-wb6Nr3IIqXpuiOTPpBz6oA"
+        }
+    ],
+    "policies": [],
+    "queues": [
+        {
+            "name": "main",
+            "vhost": "/",
+            "durable": true,
+            "auto_delete": false,
+            "arguments": {
+                "x-message-ttl": 3600000,
+                "x-queue-type": "classic"
+            }
+        }
+    ],
+    "exchanges": [
+        {
+            "name": "main",
+            "vhost": "/",
+            "type": "fanout",
+            "durable": true,
+            "auto_delete": false,
+            "internal": false,
+            "arguments": {}
+        }
+    ],
+    "bindings": [
+        {
+            "source": "main",
+            "vhost": "/",
+            "destination": "main",
+            "destination_type": "queue",
+            "routing_key": "",
+            "arguments": {}
+        }
+    ]
+}

--- a/docker/rabbitmq.conf
+++ b/docker/rabbitmq.conf
@@ -1,0 +1,1 @@
+management.load_definitions = /etc/rabbitmq/definitions.json

--- a/team.json
+++ b/team.json
@@ -3,12 +3,11 @@
         "IRC": "FastLizard4",
         "ToolID": "18",
         "wiki": "FastLizard4",
-        "WWW": "http://fastlizard4.org/",
+        "WWW": "https://fastlizard4.org/",
         "Name": "Andrew Adams",
         "Role": [
             "Project Lead",
-            "Developer",
-            "OTRS Liaison"
+            "Developer"
         ],
         "Retired": [],
         "Access": [
@@ -17,7 +16,7 @@
             "Mailing list admin",
             "WMCS project"
         ],
-        "Cloak": "*!*@wikipedia/pdpc.active.FastLizard4",
+        "Cloak": "*!*@wikipedia/FastLizard4",
         "Other": null
     },
     "Stwalkerster": {


### PR DESCRIPTION
Various improvements to the Docker setup for local development:

- Adds a default config.local.inc.php that will be added to the root dir if you don't already have one; should work out of the box for any Docker setup
- Adds a RabbitMQ definitions file which creates a "main" exchange and queue (also specified by default in the Docker config.local.inc.php file) that receives all notifications sent by the tool. Uses a fanout exchange so that all notifications are delivered to the same "main" queue regardless of routing key.
- Adds a mailsink service to the docker-compose environment and configures the application service to use it; this allows for easy local testing of email-based functionality.

Secondarily:
- Disable XDebug's `discover_client_host` setting as this was causing more issues than it fixed (and the hard-coded host of `host.docker.internal` should work in almost all environments)
- Update my entry in team.json

Resolves #750.