### PR TITLE
Preferences system overhaul

### DIFF
--- a/includes/API/Actions/StatsAction.php
+++ b/includes/API/Actions/StatsAction.php
@@ -14,6 +14,7 @@ use Waca\API\ApiException;
 use Waca\API\IXmlApiAction;
 use Waca\DataObjects\User;
 use Waca\Helpers\OAuthUserHelper;
+use Waca\Helpers\PreferenceManager;
 use Waca\Tasks\XmlApiPageBase;
 use Waca\WebRequest;
 
@@ -59,10 +60,13 @@ class StatsAction extends XmlApiPageBase implements IXmlApiAction
         $oauth = new OAuthUserHelper($user, $this->getDatabase(), $this->getOAuthProtocolHelper(),
             $this->getSiteConfiguration());
 
+        // FIXME: domains
+        $prefs = new PreferenceManager($this->getDatabase(), $user->getId(), 1);
+
         $userElement->setAttribute("username", $user->getUsername());
         $userElement->setAttribute("status", $user->getStatus());
         $userElement->setAttribute("lastactive", $user->getLastActive());
-        $userElement->setAttribute("welcome_template", $user->getWelcomeTemplate());
+        $userElement->setAttribute("welcome_template", $prefs->getPreference(PreferenceManager::PREF_WELCOMETEMPLATE));
         $userElement->setAttribute("onwikiname", $user->getOnWikiName());
         $userElement->setAttribute("oauth", $oauth->isFullyLinked() ? "true" : "false");
 

--- a/includes/Background/Task/WelcomeUserTask.php
+++ b/includes/Background/Task/WelcomeUserTask.php
@@ -15,6 +15,7 @@ use Waca\DataObjects\User;
 use Waca\DataObjects\WelcomeTemplate;
 use Waca\Helpers\MediaWikiHelper;
 use Waca\Helpers\OAuthUserHelper;
+use Waca\Helpers\PreferenceManager;
 use Waca\PdoDatabase;
 use Waca\RequestStatus;
 
@@ -38,15 +39,19 @@ class WelcomeUserTask extends BackgroundTaskBase
         $database = $this->getDatabase();
         $this->request = $this->getRequest();
         $user = $this->getTriggerUser();
+        //FIXME: domains
+        $userPrefs = new PreferenceManager($database, $user->getId(), 1);
 
-        if ($user->getWelcomeTemplate() === null) {
+        $welcomeTemplate = $userPrefs->getPreference(PreferenceManager::PREF_WELCOMETEMPLATE);
+
+        if ($welcomeTemplate === null) {
             $this->markFailed('Welcome template not specified');
 
             return;
         }
 
         /** @var WelcomeTemplate $template */
-        $template = WelcomeTemplate::getById($user->getWelcomeTemplate(), $database);
+        $template = WelcomeTemplate::getById($welcomeTemplate, $database);
 
         if ($template === false) {
             $this->markFailed('Welcome template missing');

--- a/includes/DataObjects/CommunityUser.php
+++ b/includes/DataObjects/CommunityUser.php
@@ -93,24 +93,6 @@ class CommunityUser extends User
     {
     }
 
-    public function getWelcomeTemplate()
-    {
-        return 0;
-    }
-
-    public function setWelcomeTemplate($welcomeTemplate)
-    {
-    }
-
-    public function getAbortPref()
-    {
-        return 0;
-    }
-
-    public function setAbortPref($abortPreference)
-    {
-    }
-
     public function getConfirmationDiff()
     {
         return null;
@@ -120,14 +102,6 @@ class CommunityUser extends User
     {
     }
 
-    public function getEmailSig()
-    {
-        return null;
-    }
-
-    public function setEmailSig($emailSignature)
-    {
-    }
 
     public function setUseAlternateSkin($useAlternate)
     {

--- a/includes/DataObjects/CommunityUser.php
+++ b/includes/DataObjects/CommunityUser.php
@@ -70,15 +70,6 @@ class CommunityUser extends User
     {
     }
 
-    public function getWelcomeSig()
-    {
-        return null;
-    }
-
-    public function setWelcomeSig($welcomeSig)
-    {
-    }
-
     public function getLastActive()
     {
         $now = new DateTime();

--- a/includes/DataObjects/User.php
+++ b/includes/DataObjects/User.php
@@ -12,7 +12,6 @@ use DateTime;
 use Exception;
 use Waca\DataObject;
 use Waca\Exceptions\OptimisticLockFailedException;
-use Waca\Helpers\PreferenceManager;
 use Waca\IdentificationVerifier;
 use Waca\PdoDatabase;
 use Waca\WebRequest;
@@ -26,13 +25,6 @@ class User extends DataObject
     const STATUS_SUSPENDED = 'Suspended';
     const STATUS_DECLINED = 'Declined';
     const STATUS_NEW = 'New';
-
-    /** @deprecated  */
-    const CREATION_MANUAL = 0;
-    /** @deprecated  */
-    const CREATION_OAUTH = 1;
-    /** @deprecated  */
-    const CREATION_BOT = 2;
 
     private $username;
     private $email;
@@ -358,49 +350,6 @@ SQL
     }
 
     /**
-     * Returns the ID of the welcome template used.
-     * @return int
-     * @deprecated
-     */
-    public function getWelcomeTemplate()
-    {
-        return PreferenceManager::getForCurrent(PdoDatabase::getDatabaseConnection('acc'))->getPreference(PreferenceManager::PREF_WELCOMETEMPLATE);
-    }
-
-    /**
-     * Sets the ID of the welcome template used.
-     *
-     * @param ?int $welcomeTemplate
-     * @deprecated
-     */
-    public function setWelcomeTemplate($welcomeTemplate)
-    {
-        PreferenceManager::getForCurrent(PdoDatabase::getDatabaseConnection('acc'))->setLocalPreference(PreferenceManager::PREF_WELCOMETEMPLATE, $welcomeTemplate);
-    }
-
-    /**
-     * Gets the user's abort preference
-     * @todo this is badly named too! Also a bool that's actually an int.
-     * @return int
-     * @deprecated
-     */
-    public function getAbortPref()
-    {
-        return PreferenceManager::getForCurrent(PdoDatabase::getDatabaseConnection('acc'))->getPreference(PreferenceManager::PREF_SKIP_JS_ABORT);
-    }
-
-    /**
-     * Sets the user's abort preference
-     * @todo rename, retype, and re-comment.
-     * @deprecated
-     * @param int $abortPreference
-     */
-    public function setAbortPref($abortPreference)
-    {
-        PreferenceManager::getForCurrent(PdoDatabase::getDatabaseConnection('acc'))->setLocalPreference(PreferenceManager::PREF_SKIP_JS_ABORT, $abortPreference);
-    }
-
-    /**
      * Gets the user's confirmation diff. Unused if OAuth is in use.
      * @return int the diff ID
      */
@@ -417,64 +366,6 @@ SQL
     public function setConfirmationDiff($confirmationDiff)
     {
         $this->confirmationdiff = $confirmationDiff;
-    }
-
-    /**
-     * Gets the users' email signature used on outbound mail.
-     * @todo rename me!
-     * @return string
-     * @deprecated
-     */
-    public function getEmailSig()
-    {
-        return PreferenceManager::getForCurrent(PdoDatabase::getDatabaseConnection('acc'))->getPreference(PreferenceManager::PREF_EMAIL_SIGNATURE);
-    }
-
-    /**
-     * Sets the user's email signature for outbound mail.
-     *
-     * @param string $emailSignature
-     * @deprecated
-     */
-    public function setEmailSig($emailSignature)
-    {
-        PreferenceManager::getForCurrent(PdoDatabase::getDatabaseConnection('acc'))->setLocalPreference(PreferenceManager::PREF_EMAIL_SIGNATURE, $emailSignature);
-    }
-
-    /**
-     * @return int
-     * @deprecated
-     */
-    public function getCreationMode()
-    {
-        return PreferenceManager::getForCurrent(PdoDatabase::getDatabaseConnection('acc'))->getPreference(PreferenceManager::PREF_CREATION_MODE);
-    }
-
-    /**
-     * @param $creationMode int
-     * @deprecated
-     */
-    public function setCreationMode($creationMode)
-    {
-        PreferenceManager::getForCurrent(PdoDatabase::getDatabaseConnection('acc'))->setLocalPreference(PreferenceManager::PREF_CREATION_MODE, $creationMode);
-    }
-
-    /**
-     * @return string
-     * @deprecated
-     */
-    public function getSkin()
-    {
-        return PreferenceManager::getForCurrent(PdoDatabase::getDatabaseConnection('acc'))->getPreference(PreferenceManager::PREF_SKIN);
-    }
-
-    /**
-     * @param $skin string
-     * @deprecated
-     */
-    public function setSkin($skin)
-    {
-        PreferenceManager::getForCurrent(PdoDatabase::getDatabaseConnection('acc'))->setGlobalPreference(PreferenceManager::PREF_SKIN, $skin);
     }
 
     #endregion

--- a/includes/DataObjects/User.php
+++ b/includes/DataObjects/User.php
@@ -32,7 +32,6 @@ class User extends DataObject
     private $email;
     private $status = self::STATUS_NEW;
     private $onwikiname;
-    private $welcome_sig = "";
     private $lastactive = "0000-00-00 00:00:00";
     private $forcelogout = 0;
     private $forceidentified = null;
@@ -176,11 +175,11 @@ class User extends DataObject
             // insert
             $statement = $this->dbObject->prepare(<<<SQL
 				INSERT INTO `user` ( 
-					username, email, status, onwikiname, welcome_sig, 
+					username, email, status, onwikiname, 
 					lastactive, forcelogout, forceidentified,
 					welcome_template, abortpref, confirmationdiff, emailsig, creationmode, skin
 				) VALUES (
-					:username, :email, :status, :onwikiname, :welcome_sig,
+					:username, :email, :status, :onwikiname,
 					:lastactive, :forcelogout, :forceidentified,
 					:welcome_template, :abortpref, :confirmationdiff, :emailsig, :creationmode, :skin
 				);
@@ -190,7 +189,6 @@ SQL
             $statement->bindValue(":email", $this->email);
             $statement->bindValue(":status", $this->status);
             $statement->bindValue(":onwikiname", $this->onwikiname);
-            $statement->bindValue(":welcome_sig", $this->welcome_sig);
             $statement->bindValue(":lastactive", $this->lastactive);
             $statement->bindValue(":forcelogout", $this->forcelogout);
             $statement->bindValue(":forceidentified", $this->forceidentified);
@@ -214,7 +212,7 @@ SQL
 				UPDATE `user` SET 
 					username = :username, email = :email, 
 					status = :status,
-					onwikiname = :onwikiname, welcome_sig = :welcome_sig, 
+					onwikiname = :onwikiname, 
 					lastactive = :lastactive, forcelogout = :forcelogout, 
 					forceidentified = :forceidentified,
 					welcome_template = :welcome_template, abortpref = :abortpref, 
@@ -233,7 +231,6 @@ SQL
             $statement->bindValue(':email', $this->email);
             $statement->bindValue(':status', $this->status);
             $statement->bindValue(':onwikiname', $this->onwikiname);
-            $statement->bindValue(':welcome_sig', $this->welcome_sig);
             $statement->bindValue(':lastactive', $this->lastactive);
             $statement->bindValue(':forcelogout', $this->forcelogout);
             $statement->bindValue(':forceidentified', $this->forceidentified);
@@ -337,25 +334,6 @@ SQL
     public function setOnWikiName($onWikiName)
     {
         $this->onwikiname = $onWikiName;
-    }
-
-    /**
-     * Gets the welcome signature
-     * @return string
-     */
-    public function getWelcomeSig()
-    {
-        return $this->welcome_sig;
-    }
-
-    /**
-     * Sets the welcome signature
-     *
-     * @param string $welcomeSig
-     */
-    public function setWelcomeSig($welcomeSig)
-    {
-        $this->welcome_sig = $welcomeSig;
     }
 
     /**

--- a/includes/DataObjects/UserPreference.php
+++ b/includes/DataObjects/UserPreference.php
@@ -1,0 +1,180 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\DataObjects;
+
+use Exception;
+use Waca\DataObject;
+use Waca\Exceptions\OptimisticLockFailedException;
+use Waca\PdoDatabase;
+
+class UserPreference extends DataObject
+{
+
+    /** @var int */
+    private $user;
+
+    /** @var ?int */
+    private $domain;
+
+    /** @var string */
+    private $preference;
+
+    /** @var ?mixed */
+    private $value;
+
+    public static function getLocalPreference(PdoDatabase $database, int $user, string $preference, int $domain) {
+        $statement = $database->prepare('SELECT * FROM userpreference WHERE preference = :preference AND USER = :user AND domain = :domain');
+        $statement->execute([
+            ':user' => $user,
+            ':preference' => $preference,
+            ':domain' => $domain
+        ]);
+
+        $resultObject = $statement->fetchObject(get_called_class());
+
+        if ($resultObject !== false) {
+            $resultObject->setDatabase($database);
+        }
+
+        return $resultObject;
+    }
+
+    public static function getGlobalPreference(PdoDatabase $database, int $user, string $preference) {
+        $statement = $database->prepare('SELECT * FROM userpreference WHERE preference = :preference AND USER = :user AND domain IS NULL');
+        $statement->execute([
+            ':user' => $user,
+            ':preference' => $preference
+        ]);
+
+        $resultObject = $statement->fetchObject(get_called_class());
+
+        if ($resultObject !== false) {
+            $resultObject->setDatabase($database);
+        }
+
+        return $resultObject;
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exception
+     */
+    public function save()
+    {
+        if($this->isNew()) {
+            // insert
+            $statement = $this->dbObject->prepare(<<<SQL
+                INSERT INTO `userpreference` (
+                    user, domain, preference, value
+                ) VALUES (
+                    :user, :domain, :preference, :value
+                );
+SQL
+            );
+            $statement->bindValue(":user", $this->user);
+            $statement->bindValue(":domain", $this->domain);
+            $statement->bindValue(":preference", $this->preference);
+            $statement->bindValue(":value", $this->value);
+
+            if ($statement->execute()) {
+                $this->id = (int)$this->dbObject->lastInsertId();
+            }
+            else {
+                throw new Exception($statement->errorInfo());
+            }
+        }else{
+            // update
+            $statement = $this->dbObject->prepare(<<<SQL
+                UPDATE `userpreference` SET 
+                    value = :value,
+                    updateversion = updateversion + 1
+                WHERE id = :id AND updateversion = :updateversion;
+SQL
+            );
+            $statement->bindValue(":value", $this->value);
+
+            $statement->bindValue(':id', $this->id);
+            $statement->bindValue(':updateversion', $this->updateversion);
+
+            if (!$statement->execute()) {
+                throw new Exception($statement->errorInfo());
+            }
+
+            if ($statement->rowCount() !== 1) {
+                throw new OptimisticLockFailedException();
+            }
+
+            $this->updateversion++;
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getUser(): int
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param int $user
+     */
+    public function setUser(int $user): void
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * @return ?int
+     */
+    public function getDomain(): ?int
+    {
+        return $this->domain;
+    }
+
+    /**
+     * @param ?int $domain
+     */
+    public function setDomain(?int $domain): void
+    {
+        $this->domain = $domain;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPreference(): string
+    {
+        return $this->preference;
+    }
+
+    /**
+     * @param string $preference
+     */
+    public function setPreference(string $preference): void
+    {
+        $this->preference = $preference;
+    }
+
+    /**
+     * @return mixed|null
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param mixed|null $value
+     */
+    public function setValue($value): void
+    {
+        $this->value = $value;
+    }
+}

--- a/includes/DataObjects/WelcomeTemplate.php
+++ b/includes/DataObjects/WelcomeTemplate.php
@@ -166,7 +166,7 @@ SQL
             return;
         }
 
-        $deleteQuery = "UPDATE welcometemplate SET deleted = 1 WHERE id = :id AND updateversion = :updateversion;";
+        $deleteQuery = "UPDATE welcometemplate SET deleted = 1, updateversion = updateversion + 1 WHERE id = :id AND updateversion = :updateversion;";
         $statement = $this->dbObject->prepare($deleteQuery);
 
         $statement->bindValue(":id", $this->id);

--- a/includes/DataObjects/WelcomeTemplate.php
+++ b/includes/DataObjects/WelcomeTemplate.php
@@ -12,6 +12,7 @@ use Exception;
 use PDO;
 use Waca\DataObject;
 use Waca\Exceptions\OptimisticLockFailedException;
+use Waca\Helpers\PreferenceManager;
 use Waca\PdoDatabase;
 
 /**
@@ -135,9 +136,12 @@ SQL
     public function getUsersUsingTemplate()
     {
         if ($this->usageCache === null) {
-            $statement = $this->dbObject->prepare("SELECT * FROM user WHERE welcome_template = :id;");
+            $statement = $this->dbObject->prepare("SELECT * FROM user WHERE id IN (SELECT DISTINCT user FROM userpreference WHERE preference = :pref AND value = :id);");
 
-            $statement->execute(array(":id" => $this->id));
+            $statement->execute([
+                ':id' => $this->id,
+                ':pref' => PreferenceManager::PREF_WELCOMETEMPLATE
+            ]);
 
             $result = array();
             /** @var WelcomeTemplate $v */

--- a/includes/Exceptions/AccessDeniedException.php
+++ b/includes/Exceptions/AccessDeniedException.php
@@ -12,6 +12,7 @@ use Waca\DataObjects\Domain;
 use Waca\DataObjects\Log;
 use Waca\DataObjects\User;
 use Waca\Fragments\NavigationMenuAccessControl;
+use Waca\Helpers\PreferenceManager;
 use Waca\Helpers\SearchHelpers\LogSearchHelper;
 use Waca\PdoDatabase;
 use Waca\Security\DomainAccessManager;
@@ -56,6 +57,7 @@ class AccessDeniedException extends ReadableException
         // uck. We should still be able to access the database in this situation though.
         $database = PdoDatabase::getDatabaseConnection('acc');
         $currentUser = User::getCurrent($database);
+        $this->assign('skin', PreferenceManager::getForCurrent($database)->getPreference(PreferenceManager::PREF_SKIN));
         $this->assign('currentUser', $currentUser);
         $this->assign('currentDomain', Domain::getCurrent($database));
 

--- a/includes/Exceptions/NotIdentifiedException.php
+++ b/includes/Exceptions/NotIdentifiedException.php
@@ -11,6 +11,7 @@ namespace Waca\Exceptions;
 use Waca\DataObjects\Domain;
 use Waca\DataObjects\User;
 use Waca\Fragments\NavigationMenuAccessControl;
+use Waca\Helpers\PreferenceManager;
 use Waca\PdoDatabase;
 use Waca\Security\DomainAccessManager;
 use Waca\Security\SecurityManager;
@@ -51,6 +52,7 @@ class NotIdentifiedException extends ReadableException
         // uck. We should still be able to access the database in this situation though.
         $database = PdoDatabase::getDatabaseConnection('acc');
         $currentUser = User::getCurrent($database);
+        $this->assign('skin', PreferenceManager::getForCurrent($database)->getPreference(PreferenceManager::PREF_SKIN));
         $this->assign('currentUser', $currentUser);
         $this->assign('currentDomain', Domain::getCurrent($database));
 

--- a/includes/Fragments/TemplateOutput.php
+++ b/includes/Fragments/TemplateOutput.php
@@ -45,6 +45,7 @@ trait TemplateOutput
         $this->smarty->addPluginsDir($this->getSiteConfiguration()->getFilePath() . '/smarty-plugins');
 
         $this->assign('currentUser', User::getCommunity());
+        $this->assign('skin', 'main');
         $this->assign('currentDomain', null);
         $this->assign('loggedIn', false);
         $this->assign('baseurl', $this->getSiteConfiguration()->getBaseUrl());

--- a/includes/Helpers/PreferenceManager.php
+++ b/includes/Helpers/PreferenceManager.php
@@ -1,0 +1,211 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\Helpers;
+
+use PDO;
+use Waca\DataObjects\User;
+use Waca\DataObjects\UserPreference;
+use Waca\Exceptions\OptimisticLockFailedException;
+use Waca\PdoDatabase;
+use Waca\WebRequest;
+
+class PreferenceManager
+{
+    const PREF_WELCOMETEMPLATE = 'welcomeTemplate';
+    const PREF_SKIP_JS_ABORT = 'skipJsAbort';
+    const PREF_EMAIL_SIGNATURE = 'emailSignature';
+    const PREF_CREATION_MODE = 'creationMode';
+    const PREF_SKIN = 'skin';
+    const CREATION_MANUAL = 0;
+    const CREATION_OAUTH = 1;
+    const CREATION_BOT = 2;
+    /** @var PdoDatabase */
+    private $database;
+    /** @var int */
+    private $user;
+    /** @var ?int */
+    private $domain;
+    /** @var PreferenceManager|null */
+    private static $currentUser = null;
+    private $cachedPreferences = null;
+
+    public function __construct(PdoDatabase $database, int $user, ?int $domain)
+    {
+        $this->database = $database;
+        $this->user = $user;
+        $this->domain = $domain;
+    }
+
+    public static function getForCurrent(PdoDatabase $database): PreferenceManager
+    {
+        if (self::$currentUser === null) {
+            $user = User::getCurrent($database)->getId();
+            $domain = WebRequest::getSessionDomain();
+
+            self::$currentUser = new self($database, $user, $domain);
+        }
+
+        return self::$currentUser;
+    }
+
+    public function setLocalPreference(string $preference, $value): void
+    {
+        if ($this->cachedPreferences === null) {
+            $this->loadPreferences();
+        }
+
+        if ($this->cachedPreferences[$preference]['value'] == $value
+            && $this->cachedPreferences[$preference]['global'] === false) {
+            return;
+        }
+
+        $localPreference = UserPreference::getLocalPreference($this->database, $this->user, $preference, $this->domain);
+        if ($localPreference === false) {
+            $localPreference = new UserPreference();
+            $localPreference->setDatabase($this->database);
+            $localPreference->setDomain($this->domain);
+            $localPreference->setUser($this->user);
+            $localPreference->setPreference($preference);
+        }
+
+        $localPreference->setValue($value);
+        $localPreference->save();
+
+        $this->cachedPreferences[$preference] = [
+            'value'  => $value,
+            'global' => false,
+        ];
+    }
+
+    public function setGlobalPreference(string $preference, $value): void
+    {
+        if ($this->cachedPreferences === null) {
+            $this->loadPreferences();
+        }
+
+        if ($this->cachedPreferences[$preference]['value'] == $value
+            && $this->cachedPreferences[$preference]['global'] === true) {
+            return;
+        }
+
+        $this->deleteLocalPreference($preference);
+
+        $globalPreference = UserPreference::getGlobalPreference($this->database, $this->user, $preference);
+        if ($globalPreference === false) {
+            $globalPreference = new UserPreference();
+            $globalPreference->setDatabase($this->database);
+            $globalPreference->setDomain(null);
+            $globalPreference->setUser($this->user);
+            $globalPreference->setPreference($preference);
+        }
+
+        $globalPreference->setValue($value);
+        $globalPreference->save();
+
+        $this->cachedPreferences[$preference] = [
+            'value'  => $value,
+            'global' => true,
+        ];
+    }
+
+    public function getPreference(string $preference)
+    {
+        if ($this->cachedPreferences === null) {
+            $this->loadPreferences();
+        }
+
+        if (!isset($this->cachedPreferences[$preference])) {
+            return null;
+        }
+
+        return $this->cachedPreferences[$preference]['value'];
+    }
+
+    public function isGlobalPreference(string $preference) : ?bool
+    {
+        if ($this->cachedPreferences === null) {
+            $this->loadPreferences();
+        }
+
+        if (!isset($this->cachedPreferences[$preference])) {
+            return null;
+        }
+
+        return $this->cachedPreferences[$preference]['global'];
+    }
+
+    protected function deleteLocalPreference(string $preference): void
+    {
+        $getStatement = $this->database->prepare('SELECT * FROM userpreference WHERE preference = :preference AND USER = :user AND domain = :domain');
+        $getStatement->execute([
+            ':user'       => $this->user,
+            ':preference' => $preference,
+            ':domain'     => $this->domain
+        ]);
+
+        $localPreference = $getStatement->fetchObject(UserPreference::class);
+        if ($localPreference !== false) {
+            $localPreference->setDatabase($this->database);
+            $localPreference->delete();
+        }
+    }
+
+    protected function loadPreferences(): void
+    {
+        /**
+         * OK, this is a bit of a complicated query.
+         * It's designed to get all the preferences defined for a user in a specified domain, falling back to globally
+         * defined preferences if a local preference isn't set. As such, this query is the *heart* of how global
+         * preferences work.
+         *
+         * Starting with the WHERE, we filter rows:
+         *   a) where the row's domain is the domain we're looking for
+         *   b) where the row's domain is null, thus it's a global setting
+         *   c) if we don't have a domain we're looking for, fall back to global only
+         *
+         * The MAX(...) OVER(...) is a window function, *not* an aggregate. It basically takes the max of all selected
+         * rows' domain columns, grouped by the preference column. Since any number N < null, this highlights all the
+         * correct settings (local has precedence over global) such that prefpart == domain.
+         *
+         * -1 is used to represent null in the COALESCE() calls, since domain.id is an unsigned int hence -1 is an
+         * impossible value
+         */
+        $sql = /** @lang SQL */
+            <<<'EOF'
+WITH allprefs AS (
+    SELECT up.domain, up.preference, MAX(up.domain) OVER (PARTITION BY up.preference) AS prefpart, up.value, CASE WHEN up.domain IS NULL THEN 1 END AS isglobal
+    FROM userpreference up
+    WHERE COALESCE(up.domain, :domainc, -1) = COALESCE(:domain, -1)
+      AND up.user = :user
+)
+SELECT p.preference, p.value, coalesce(p.isglobal, 0) as isglobal
+FROM allprefs p
+WHERE COALESCE(p.prefpart, -1) = COALESCE(p.domain, -1);
+EOF;
+        $statement = $this->database->prepare($sql);
+
+        $statement->execute([
+            ':domain'  => $this->domain,
+            ':domainc' => $this->domain,
+            ':user'    => $this->user,
+        ]);
+
+        $rawPrefs = $statement->fetchAll(PDO::FETCH_ASSOC);
+        $prefs = [];
+
+        foreach ($rawPrefs as $p) {
+            $prefs[$p['preference']] = [
+                'value'  => $p['value'],
+                'global' => $p['isglobal'] == 1,
+            ];
+        }
+
+        $this->cachedPreferences = $prefs;
+    }
+}

--- a/includes/Helpers/PreferenceManager.php
+++ b/includes/Helpers/PreferenceManager.php
@@ -22,6 +22,7 @@ class PreferenceManager
     const PREF_EMAIL_SIGNATURE = 'emailSignature';
     const PREF_CREATION_MODE = 'creationMode';
     const PREF_SKIN = 'skin';
+    const PREF_DEFAULT_DOMAIN = 'defaultDomain';
     const CREATION_MANUAL = 0;
     const CREATION_OAUTH = 1;
     const CREATION_BOT = 2;

--- a/includes/Helpers/RequestEmailHelper.php
+++ b/includes/Helpers/RequestEmailHelper.php
@@ -33,14 +33,14 @@ class RequestEmailHelper
     /**
      * @param Request $request
      * @param string  $mailText
-     * @param User    $currentUser
+     * @param User    $sendingUser      The user sending the email
      * @param boolean $ccMailingList
      */
-    public function sendMail(Request $request, $mailText, User $currentUser, $ccMailingList)
+    public function sendMail(Request $request, $mailText, User $sendingUser, $ccMailingList)
     {
         $headers = array(
             'X-ACC-Request' => $request->getId(),
-            'X-ACC-UserID'  => $currentUser->getId(),
+            'X-ACC-UserID'  => $sendingUser->getId(),
         );
 
         // FIXME: domains!
@@ -53,7 +53,10 @@ class RequestEmailHelper
 
         $helper = $this->emailHelper;
 
-        $emailSig = $currentUser->getEmailSig();
+        // FIXME: domains
+        $preferenceManager = new PreferenceManager($request->getDatabase(), $sendingUser->getId(), 1);
+
+        $emailSig = $preferenceManager->getPreference(PreferenceManager::PREF_EMAIL_SIGNATURE);
         if ($emailSig !== '' || $emailSig !== null) {
             $emailSig = "\n\n" . $emailSig;
         }

--- a/includes/Offline.php
+++ b/includes/Offline.php
@@ -68,6 +68,7 @@ class Offline
             $smarty->assign("dontUseDbReason", $message);
             $smarty->assign("alerts", array());
             $smarty->assign('currentUser', User::getCommunity());
+            $smarty->assign('skin', 'main');
             $smarty->assign('currentDomain', null);
 
             return $smarty->fetch("offline/internal.tpl");

--- a/includes/Pages/PageQueueManagement.php
+++ b/includes/Pages/PageQueueManagement.php
@@ -122,8 +122,15 @@ class PageQueueManagement extends InternalPageBase
     {
         $database = $this->getDatabase();
 
+        $id = WebRequest::getInt('queue');
+        if ($id === null) {
+            $this->redirect('queueManagement');
+
+            return;
+        }
+
         /** @var RequestQueue $queue */
-        $queue = RequestQueue::getById(WebRequest::getInt('queue'), $database);
+        $queue = RequestQueue::getById($id, $database);
 
         if (WebRequest::wasPosted()) {
             $this->validateCSRFToken();

--- a/includes/Pages/PageUserManagement.php
+++ b/includes/Pages/PageUserManagement.php
@@ -502,7 +502,6 @@ class PageUserManagement extends InternalPageBase
                 }
 
                 $user->setOnWikiName($newOnWikiName);
-                $user->setWelcomeSig(WebRequest::postString('sig'));
             }
 
             $user->setEmail($newEmail);

--- a/includes/Pages/PageUserManagement.php
+++ b/includes/Pages/PageUserManagement.php
@@ -116,7 +116,7 @@ class PageUserManagement extends InternalPageBase
         /** @var User $user */
         $user = User::getById($userId, $database);
 
-        if ($user === false) {
+        if ($user === false || $user->isCommunityUser()) {
             throw new ApplicationLogicException('Sorry, the user you are trying to edit could not be found.');
         }
 
@@ -215,7 +215,7 @@ class PageUserManagement extends InternalPageBase
         /** @var User $user */
         $user = User::getById($userId, $database);
 
-        if ($user === false) {
+        if ($user === false || $user->isCommunityUser()) {
             throw new ApplicationLogicException('Sorry, the user you are trying to suspend could not be found.');
         }
 
@@ -280,7 +280,7 @@ class PageUserManagement extends InternalPageBase
         $userId = WebRequest::getInt('user');
         $user = User::getById($userId, $database);
 
-        if ($user === false) {
+        if ($user === false || $user->isCommunityUser()) {
             throw new ApplicationLogicException('Sorry, the user you are trying to decline could not be found.');
         }
 
@@ -341,7 +341,7 @@ class PageUserManagement extends InternalPageBase
         $userId = WebRequest::getInt('user');
         $user = User::getById($userId, $database);
 
-        if ($user === false) {
+        if ($user === false || $user->isCommunityUser()) {
             throw new ApplicationLogicException('Sorry, the user you are trying to approve could not be found.');
         }
 
@@ -400,7 +400,7 @@ class PageUserManagement extends InternalPageBase
         $userId = WebRequest::getInt('user');
         $user = User::getById($userId, $database);
 
-        if ($user === false) {
+        if ($user === false || $user->isCommunityUser()) {
             throw new ApplicationLogicException('Sorry, the user you are trying to rename could not be found.');
         }
 
@@ -479,7 +479,7 @@ class PageUserManagement extends InternalPageBase
         $user = User::getById($userId, $database);
         $oauth = new OAuthUserHelper($user, $database, $this->getOAuthProtocolHelper(), $this->getSiteConfiguration());
 
-        if ($user === false) {
+        if ($user === false || $user->isCommunityUser()) {
             throw new ApplicationLogicException('Sorry, the user you are trying to edit could not be found.');
         }
 

--- a/includes/Pages/PageWelcomeTemplateManagement.php
+++ b/includes/Pages/PageWelcomeTemplateManagement.php
@@ -225,9 +225,8 @@ class PageWelcomeTemplateManagement extends InternalPageBase
 
     protected function delete()
     {
-        $this->redirect('welcomeTemplates');
-
         if (!WebRequest::wasPosted()) {
+            $this->redirect('welcomeTemplates');
             return;
         }
 
@@ -258,6 +257,8 @@ class PageWelcomeTemplateManagement extends InternalPageBase
         Logger::welcomeTemplateDeleted($database, $template);
 
         $template->delete();
+
+        $this->redirect('welcomeTemplates');
 
         SessionAlert::success(
             "Template deleted. Any users who were using this template have had automatic welcoming disabled.");

--- a/includes/Pages/PageWelcomeTemplateManagement.php
+++ b/includes/Pages/PageWelcomeTemplateManagement.php
@@ -15,6 +15,7 @@ use Waca\Exceptions\ApplicationLogicException;
 use Waca\Helpers\Logger;
 use Waca\Helpers\MediaWikiHelper;
 use Waca\Helpers\OAuthUserHelper;
+use Waca\Helpers\PreferenceManager;
 use Waca\SessionAlert;
 use Waca\Tasks\InternalPageBase;
 use Waca\WebRequest;
@@ -244,8 +245,11 @@ class PageWelcomeTemplateManagement extends InternalPageBase
         $template->setUpdateVersion($updateVersion);
 
         $database
-            ->prepare("UPDATE user SET welcome_template = NULL WHERE welcome_template = :id;")
-            ->execute(array(":id" => $templateId));
+            ->prepare("UPDATE userpreference SET value = NULL, updateversion = updateversion + 1 WHERE preference = :pref and value = :id;")
+            ->execute([
+                ':id'   => $templateId,
+                ':pref' => PreferenceManager::PREF_WELCOMETEMPLATE
+            ]);
 
         Logger::welcomeTemplateDeleted($database, $template);
 

--- a/includes/Pages/RequestAction/PageCloseRequest.php
+++ b/includes/Pages/RequestAction/PageCloseRequest.php
@@ -16,6 +16,7 @@ use Waca\DataObjects\User;
 use Waca\Exceptions\ApplicationLogicException;
 use Waca\Helpers\Logger;
 use Waca\Helpers\OAuthUserHelper;
+use Waca\Helpers\PreferenceManager;
 use Waca\Helpers\RequestEmailHelper;
 use Waca\PdoDatabase;
 use Waca\RequestStatus;
@@ -246,12 +247,13 @@ class PageCloseRequest extends RequestActionBase
     {
         $database = $this->getDatabase();
         $currentUser = User::getCurrent($database);
+        $preferencesManager = PreferenceManager::getForCurrent($database);
 
         if ($action !== EmailTemplate::ACTION_CREATED) {
             return;
         }
 
-        if ($currentUser->getWelcomeTemplate() === null) {
+        if ($preferencesManager->getPreference(PreferenceManager::PREF_WELCOMETEMPLATE) === null) {
             return;
         }
 

--- a/includes/Pages/UserAuth/PagePreferences.php
+++ b/includes/Pages/UserAuth/PagePreferences.php
@@ -32,7 +32,6 @@ class PagePreferences extends InternalPageBase
         // Dual mode
         if (WebRequest::wasPosted()) {
             $this->validateCSRFToken();
-            $user->setWelcomeSig(WebRequest::postString('sig'));
             $user->setEmailSig(WebRequest::postString('emailsig'));
             $user->setAbortPref(WebRequest::postBoolean('abortpref') ? 1 : 0);
             $this->setCreationMode($user);

--- a/includes/Pages/UserAuth/PagePreferences.php
+++ b/includes/Pages/UserAuth/PagePreferences.php
@@ -53,7 +53,12 @@ class PagePreferences extends InternalPageBase
             $user->save();
             SessionAlert::success("Preferences updated!");
 
-            $this->redirect('');
+            if ($this->barrierTest(RoleConfiguration::MAIN, $user, PageMain::class)) {
+                $this->redirect('');
+            }
+            else {
+                $this->redirect('preferences');
+            }
         }
         else {
             $this->assignCSRFToken();

--- a/includes/Pages/UserAuth/PagePreferences.php
+++ b/includes/Pages/UserAuth/PagePreferences.php
@@ -41,6 +41,7 @@ class PagePreferences extends InternalPageBase
             $this->setPreferenceWithValue($preferencesManager,PreferenceManager::PREF_SKIP_JS_ABORT, 'skipJsAbort', WebRequest::postBoolean('skipJsAbort') ? 1 : 0);
             $this->setCreationMode($user, $preferencesManager);
             $this->setSkin($preferencesManager);
+            $preferencesManager->setGlobalPreference(PreferenceManager::PREF_DEFAULT_DOMAIN, WebRequest::postInt('defaultDomain'));
 
             $email = WebRequest::postEmail('email');
             if ($email !== null) {
@@ -72,6 +73,7 @@ class PagePreferences extends InternalPageBase
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_CREATION_MODE, 'creationMode', false);
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_SKIN, 'skin', true);
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_SKIP_JS_ABORT, 'skipJsAbort', false);
+            $this->assignPreference($preferencesManager, PreferenceManager::PREF_DEFAULT_DOMAIN, 'defaultDomain', true);
 
             $this->assign('canManualCreate',
                 $this->barrierTest(PreferenceManager::CREATION_MANUAL, $user, 'RequestCreation'));

--- a/includes/Security/RoleConfiguration.php
+++ b/includes/Security/RoleConfiguration.php
@@ -8,7 +8,7 @@
 
 namespace Waca\Security;
 
-use Waca\DataObjects\User;
+use Waca\Helpers\PreferenceManager;
 use Waca\Pages\PageBan;
 use Waca\Pages\PageDomainManagement;
 use Waca\Pages\PageDomainSwitch;
@@ -240,8 +240,8 @@ class RoleConfiguration
                 'preview'  => self::ACCESS_ALLOW,
             ),
             'RequestCreation'                    => array(
-                User::CREATION_MANUAL => self::ACCESS_ALLOW,
-                User::CREATION_OAUTH  => self::ACCESS_ALLOW,
+                PreferenceManager::CREATION_MANUAL => self::ACCESS_ALLOW,
+                PreferenceManager::CREATION_OAUTH  => self::ACCESS_ALLOW,
             ),
             'GlobalInfo'                         => array(
                 'viewSiteNotice' => self::ACCESS_ALLOW,
@@ -353,7 +353,7 @@ class RoleConfiguration
             '_editableBy'     => array('admin', 'toolRoot'),
             '_childRoles'     => array(),
             'RequestCreation' => array(
-                User::CREATION_BOT => self::ACCESS_ALLOW,
+                PreferenceManager::CREATION_BOT => self::ACCESS_ALLOW,
             ),
         ),
 

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -19,7 +19,7 @@ class SiteConfiguration
 {
     private $baseUrl;
     private $filePath;
-    private $schemaVersion = 42;
+    private $schemaVersion = 43;
     private $debuggingTraceEnabled;
     private $debuggingCssBreakpointsEnabled;
     private $dataClearIp = '127.0.0.1';

--- a/includes/Tasks/PageBase.php
+++ b/includes/Tasks/PageBase.php
@@ -16,6 +16,7 @@ use Waca\ExceptionHandler;
 use Waca\Exceptions\ApplicationLogicException;
 use Waca\Exceptions\OptimisticLockFailedException;
 use Waca\Fragments\TemplateOutput;
+use Waca\Helpers\PreferenceManager;
 use Waca\Security\ContentSecurityPolicyManager;
 use Waca\Security\TokenManager;
 use Waca\SessionAlert;
@@ -79,9 +80,11 @@ abstract class PageBase extends TaskBase implements IRoutedTask
     {
         $this->setUpSmarty();
 
-        $currentUser = User::getCurrent($this->getDatabase());
+        $database = $this->getDatabase();
+        $currentUser = User::getCurrent($database);
         $this->assign('currentUser', $currentUser);
-        $this->assign('currentDomain', Domain::getCurrent($this->getDatabase()));
+        $this->assign('skin', PreferenceManager::getForCurrent($database)->getPreference(PreferenceManager::PREF_SKIN));
+        $this->assign('currentDomain', Domain::getCurrent($database));
         $this->assign('loggedIn', (!$currentUser->isCommunityUser()));
     }
 

--- a/resources/scss/_common.scss
+++ b/resources/scss/_common.scss
@@ -107,3 +107,7 @@ iframe.preview-frame {
         height: 30vh;
     }
 }
+
+.form-control.uneditable-input {
+    @extend .form-control[readonly]
+}

--- a/resources/scss/bootstrap-alt.scss
+++ b/resources/scss/bootstrap-alt.scss
@@ -61,6 +61,9 @@ $card-bg: lighten($gray-900, 3%);
 
 $popover-bg: $gray-800;
 
+$modal-content-bg: $gray-800;
+$modal-backdrop-opacity: .65;
+
 $alert-bg-level: 6;
 $alert-border-level: 2;
 $alert-color-level: -10;
@@ -69,6 +72,8 @@ $progress-bg: $gray-800;
 
 $sortabletable-marker: $gray-500;
 $sortabletable-hover: $gray-800;
+
+$close-color: $white;
 
 @import "common";
 

--- a/sql/patches/patch43-preferencesrefactor.sql
+++ b/sql/patches/patch43-preferencesrefactor.sql
@@ -1,0 +1,91 @@
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
+DELIMITER ';;'
+CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
+    -- -------------------------------------------------------------------------
+    -- Developers - set the number of the schema patch here!
+    -- -------------------------------------------------------------------------
+    DECLARE patchversion INT DEFAULT 43;
+    -- -------------------------------------------------------------------------
+    -- working variables
+    DECLARE currentschemaversion INT DEFAULT 0;
+    DECLARE lastversion INT;
+	
+    -- check the schema has a version table
+    IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'schemaversion' AND table_schema = DATABASE()) THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please ensure patches are run in order! This database does not have a schemaversion table.';
+    END IF;
+    
+    -- get the current version
+    SELECT version INTO currentschemaversion FROM schemaversion;
+    
+    -- check schema is not ahead of this patch
+    IF currentschemaversion >= patchversion THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'This patch has already been applied!';
+    END IF;
+    
+    -- check schema is up-to-date
+    SET lastversion = patchversion - 1;
+    IF currentschemaversion != lastversion THEN
+		SET @message_text = CONCAT('Please ensure patches are run in order! This patch upgrades to version ', patchversion, ', but the database is not version ', lastversion);
+        SIGNAL SQLSTATE '45000' SET message_text = @message_text;
+    END IF;
+
+    -- -------------------------------------------------------------------------
+    -- Developers - put your upgrade statements here!
+    -- -------------------------------------------------------------------------
+
+    -- unused column
+    # noinspection SqlResolve
+    ALTER TABLE user
+        DROP welcome_sig;
+
+    CREATE TABLE userpreference
+    (
+        id            INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        user          INT UNSIGNED   NOT NULL,
+        domain        INT UNSIGNED   NULL COMMENT 'The domain this specific preference is for',
+        preference    VARCHAR(255)   NOT NULL,
+        value         VARBINARY(255) NULL,
+        global        TINYINT UNSIGNED AS (CASE WHEN domain IS NULL THEN 1 END) COMMENT 'Is this globally-defined?',
+        updateversion INT UNSIGNED NOT NULL DEFAULT 0,
+        CONSTRAINT userpreference_user_id_fk FOREIGN KEY (user) REFERENCES user (id),
+        CONSTRAINT userpreference_domain_id_fk FOREIGN KEY (domain) REFERENCES domain (id)
+    ) ENGINE = InnoDB COMMENT 'Holds user preferences';
+
+    ALTER TABLE userpreference
+        ADD CONSTRAINT userpreference_userglobal_uniq UNIQUE (user, preference, global),
+        ADD CONSTRAINT userpreference_userdomain_uniq UNIQUE (user, preference, domain);
+
+    # noinspection SqlResolve
+    INSERT INTO userpreference (user, domain, preference, value)
+    SELECT u.id as user, 1 as domain, 'welcomeTemplate' as preference, u.welcome_template as value FROM user u WHERE u.welcome_template IS NOT NULL
+    UNION ALL
+    SELECT u.id, 1, 'skipJsAbort', u.abortpref FROM user u -- NN column
+    UNION ALL
+    SELECT u.id, 1, 'emailSignature', u.emailsig FROM user u WHERE u.emailsig IS NOT NULL
+    UNION ALL
+    SELECT u.id, 1, 'creationMode', u.creationmode FROM user u -- NN column
+    UNION ALL
+    SELECT u.id, null, 'skin', u.skin FROM user u -- NN column, global setting
+    ;
+
+    COMMIT;
+
+    # noinspection SqlResolve
+    ALTER TABLE user
+        DROP CONSTRAINT user_welcometemplate_id_fk,
+        DROP welcome_template,
+        DROP abortpref,
+        DROP emailsig,
+        DROP creationmode,
+        DROP skin
+    ;
+
+    -- -------------------------------------------------------------------------
+    -- finally, update the schema version to indicate success
+    # noinspection SqlWithoutWhere
+    UPDATE schemaversion SET version = patchversion;
+END;;
+DELIMITER ';'
+CALL SCHEMA_UPGRADE_SCRIPT();
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;

--- a/templates/base.tpl
+++ b/templates/base.tpl
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- bootstrap styles -->
-    <link href="{$baseurl}/resources/generated/bootstrap-{$currentUser->getSkin()|escape|default:'main'}.css?{$resourceCacheEpoch}" rel="stylesheet"/>
+    <link href="{$baseurl}/resources/generated/bootstrap-{$skin|escape|default:'main'}.css?{$resourceCacheEpoch}" rel="stylesheet"/>
 
     <!-- fontawesome -->
     <link href="{$baseurl}/vendor/fortawesome/font-awesome/css/all.min.css" rel="stylesheet"/>

--- a/templates/custom-close.tpl
+++ b/templates/custom-close.tpl
@@ -41,16 +41,16 @@
                     <option value="" {if $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_NONE}selected="selected"{/if}>(please select)</option>
                     <option value="mail" {if $preloadAction == "mail"}selected="selected"{/if}>Only send the email</option>
                     <optgroup label="Send email and close request...">
-                        <option value="created" {if $preloadAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED && $currentUser->getCreationMode() == 0)}selected="selected"{/if}>
+                        <option value="created" {if $preloadAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED && $preferredCreationMode == 0)}selected="selected"{/if}>
                             Close request as created
                         </option>
                         {if $canOauthCreate}
-                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH}"  {if $preloadAction == Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED && $currentUser->getCreationMode() == 1)}selected="selected"{/if}>
+                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH}"  {if $preloadAction == Waca\Pages\RequestAction\PageCustomClose::CREATE_OAUTH || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED && $preferredCreationMode == 1)}selected="selected"{/if}>
                                 Create account (Wikimedia account) & close request as created
                             </option>
                         {/if}
                         {if $canBotCreate}
-                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT}"  {if $preloadAction == Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED && $currentUser->getCreationMode() == 2)}selected="selected"{/if}>
+                            <option value="{Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT}"  {if $preloadAction == Waca\Pages\RequestAction\PageCustomClose::CREATE_BOT || ($preloadAction === null && $defaultAction == Waca\DataObjects\EmailTemplate::ACTION_CREATED && $preferredCreationMode == 2)}selected="selected"{/if}>
                                 Create account (via bot) & close request as created
                             </option>
                         {/if}

--- a/templates/preferences/globalcheck.tpl
+++ b/templates/preferences/globalcheck.tpl
@@ -1,0 +1,10 @@
+{if count($nav__domainList) > 1}
+    <div class="col-md-2 col-lg-2 col-xl-1 {$offset|default:''} d-none d-md-block">
+        <div class="custom-control custom-switch" data-toggle="tooltip" data-html="true" title="Define this setting across all domains. This only has an effect if your account has access to multiple domains.{if !$settingAvailable && $settingState}<br /><br /><strong>This option is only configurable at a global level</strong>{/if}{if !$settingAvailable && !$settingState}<br /><br /><strong>This option is only configurable at the local level</strong>{/if}">
+            <input type="checkbox" class="custom-control-input" id="{$settingName}Global" name="{$settingName}Global" {if $settingState}checked{/if} {if !$settingAvailable}disabled{/if}>
+            <label class="custom-control-label" for="{$settingName}Global">Global</label>
+        </div>
+    </div>
+{else}
+    <input type="hidden" name="{$settingName}Global" value="{if $settingState}on{else}off{/if}">
+{/if}

--- a/templates/preferences/globalhelp.tpl
+++ b/templates/preferences/globalhelp.tpl
@@ -1,0 +1,29 @@
+<div class="modal fade" id="modalGlobalSettings" tabindex="-1" aria-labelledby="modalGlobalSettingsLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalGlobalSettingsLabel">Help on global settings</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>
+                    Some preferences can be set either globally for all domains, or locally for this domain ({$currentDomain->getLongName()|escape}).
+                </p>
+                <p>
+                    If you want a setting to apply globally, you can mark the preference as a "global" setting.
+                    If you want a setting to apply only to {$currentDomain->getLongName()|escape}, you can remove the global mark.
+                </p>
+
+                <p>
+                    If a domain has no local setting, the global setting will apply.
+                    When you mark a setting as global, the local setting will be deleted, and the global setting set to the provided value.
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/preferences/prefs.tpl
+++ b/templates/preferences/prefs.tpl
@@ -15,50 +15,57 @@
                 <fieldset>
                     <legend>General settings</legend>
 
-                    <div class="form-group row">
+                    <div class="form-group row mb-5">
                         <div class="col-md-2 col-lg-3">
                             <label for="inputEmail" class="col-form-label">Your Email address</label>
                         </div>
-                        <div class="col-md-10 col-lg-8 col-xl-6">
+                        <div class="col-md-8 col-lg-7 col-xl-6">
                             <input class="form-control" type="email" id="inputEmail" name="email" required="required" value="{$currentUser->getEmail()|escape}"/>
                             <small class="form-text text-muted">This is used to send you automatic notifications about events involving your account in the tool, including sending password reset emails.</small>
                         </div>
+                        {include file="preferences/globalcheck.tpl" settingName="email" settingState=true settingAvailable=false}
                     </div>
 
-                    <div class="form-group row">
+                    <div class="form-group row mb-5">
                         <div class="col-md-2 col-lg-3">
-                            <label for="inputEmailsig" class="col-form-label">Email signature</label>
+                            <label for="emailSignature" class="col-form-label">Email signature</label>
                         </div>
-                        <div class="col-md-10 col-lg-8 col-xl-6">
-                            <textarea class="form-control" id="inputEmailsig" rows="4" name="emailsig">{$emailSignature|escape}</textarea>
+                        <div class="col-md-8 col-lg-7 col-xl-6">
+                            <textarea class="form-control" id="emailSignature" rows="5" name="emailSignature">{$emailSignature|escape}</textarea>
                             <small class="form-text text-muted">This will show up at the end of any Email you send through the interface.</small>
                         </div>
+                        {include file="preferences/globalcheck.tpl" settingName="emailSignature" settingState=$emailSignatureGlobal settingAvailable=true}
                     </div>
 
-                    <div class="form-group row">
-                        <div class="offset-md-2 offset-lg-3 col-md-10 col-lg-8 col-xl-6">
+                    <div class="form-group row mb-5">
+
+                        <div class="col-md-2 col-lg-3">
+                            <span class="col-form-label">Request closure</span>
+                        </div>
+                        <div class="col-md-8 col-lg-7 col-xl-6">
                             <div class="custom-control custom-switch">
-                                <input class="custom-control-input" type="checkbox" id="inputAbortpref" name="abortpref"{if $skipJsAbort} checked{/if}>
-                                <label class="custom-control-label" for="inputAbortpref">Skip double-check prompt before closing requests</label>
+                                <input class="custom-control-input" type="checkbox" id="skipJsAbort" name="skipJsAbort"{if $skipJsAbort} checked{/if}>
+                                <label class="custom-control-label" for="skipJsAbort">Skip double-check prompt before closing requests</label>
                             </div>
                         </div>
+                        {include file="preferences/globalcheck.tpl" settingName="skipJsAbort" settingState=$skipJsAbortGlobal settingAvailable=true}
                     </div>
 
-                    <div class="form-group row">
+                    <div class="form-group row mb-5">
                         <div class="col-md-2 col-lg-3">
                             <label class="col-form-label">Account Creation Mode</label>
                         </div>
-                        <div class="col-md-10 col-lg-8 col-xl-6">
+                        <div class="col-md-8 col-lg-7 col-xl-6">
 
                             <div class="custom-control custom-radio">
-                                <input type="radio" name="creationmode" value="0" class="custom-control-input" id="autocreateNone"
+                                <input type="radio" name="creationMode" value="0" class="custom-control-input" id="autocreateNone"
                                        {if $creationMode == 0}checked="checked"{/if}
                                        {if !$canManualCreate}disabled="disabled"{/if}/>
                                 <label class="custom-control-label" for="autocreateNone">Create accounts manually using Special:CreateAccount</label>
                             </div>
 
                             <div class="custom-control custom-radio">
-                                <input type="radio" name="creationmode" value="1" class="custom-control-input" id="autocreateOauth"
+                                <input type="radio" name="creationMode" value="1" class="custom-control-input" id="autocreateOauth"
                                        {if $creationMode == 1}checked="checked"{/if}
                                        {if !$canOauthCreate}disabled="disabled"{/if}/>
                                 <label class="custom-control-label" for="autocreateOauth">Use my Wikimedia account to create the accounts on my behalf where possible</label>
@@ -68,7 +75,7 @@
                             </div>
 
                             <div class="custom-control custom-radio">
-                                <input type="radio" name="creationmode" value="2" class="custom-control-input" id="autocreateBot"
+                                <input type="radio" name="creationMode" value="2" class="custom-control-input" id="autocreateBot"
                                        {if $creationMode == 2}checked="checked"{/if}
                                        {if !$canBotCreate}disabled="disabled"{/if}/>
                                 <label class="custom-control-label" for="autocreateBot">Use a bot to create the accounts on my behalf where possible</label>
@@ -76,14 +83,16 @@
 
                             <small class="form-text text-muted">Please refer to the Guide for a full explanation of these options.</small>
                         </div>
+                        {include file="preferences/globalcheck.tpl" settingName="creationMode" settingState=false settingAvailable=false}
+
                     </div>
 
-                    <div class="form-group row">
+                    <div class="form-group row mb-5">
                         <div class="col-md-2 col-lg-3">
-                            <label class="col-form-label" for="inputSkinType">Tool theme:</label>
+                            <label class="col-form-label" for="skin">Tool theme</label>
                         </div>
                         <div class="col-md-6 col-lg-5 col-xl-4">
-                            <select class="form-control" id="inputSkinType" name="skintype">
+                            <select class="form-control" id="skin" name="skin">
                                 <option value="auto" {if $skin === 'auto'}selected="selected"{/if}>
                                     Use browser default
                                 </option>
@@ -95,12 +104,18 @@
                                 </option>
                             </select>
                         </div>
+                        {include file="preferences/globalcheck.tpl" settingName="skin" settingState=$skinGlobal settingAvailable=true offset="offset-md-2 offset-lg-2 offset-xl-2"}
                     </div>
 
                     <div class="form-group row">
                         <div class="offset-md-2 offset-lg-3 col-md-4 col-lg-3">
                             <button type="submit" class="btn btn-primary btn-block">Save preferences</button>
                         </div>
+                        {if count($nav__domainList) > 1}
+                            <div class="offset-md-4 offset-lg-4 offset-xl-3 col-md-2 col-lg-1 d-none d-md-block">
+                                <a href="#modalGlobalSettings" data-toggle="modal" class="btn btn-outline-info btn-block">Help</a>
+                            </div>
+                        {/if}
                     </div>
 
                 </fieldset>
@@ -274,4 +289,8 @@
 
         {/if}
     </fieldset>
+
+    {if count($nav__domainList) > 1}
+        {include file="preferences/globalhelp.tpl"}
+    {/if}
 {/block}

--- a/templates/preferences/prefs.tpl
+++ b/templates/preferences/prefs.tpl
@@ -14,19 +14,6 @@
                 {include file="security/csrf.tpl"}
                 <fieldset>
                     <legend>General settings</legend>
-                    {if !$oauth->isFullyLinked() }
-                    <div class="form-group row">
-                        <div class="col-md-2 col-lg-3">
-                            <label for="inputSig" class="col-form-label">Your signature (wikicode)</label>
-                        </div>
-                        <div class="col-md-10 col-lg-8 col-xl-6">
-                            <input class="form-control" type="text" id="inputSig" name="sig" value="{$currentUser->getWelcomeSig()|escape}"/>
-                            <small class="form-text text-muted">This would be the same as ~~~ on-wiki. No date, please.</small>
-                        </div>
-                    </div>
-                    {else}
-                        <input type="hidden" name="sig" value=""/>
-                    {/if}
 
                     <div class="form-group row">
                         <div class="col-md-2 col-lg-3">

--- a/templates/preferences/prefs.tpl
+++ b/templates/preferences/prefs.tpl
@@ -107,6 +107,29 @@
                         {include file="preferences/globalcheck.tpl" settingName="skin" settingState=$skinGlobal settingAvailable=true offset="offset-md-2 offset-lg-2 offset-xl-2"}
                     </div>
 
+                    {if count($nav__domainList) > 1}
+                    <div class="form-group row mb-5">
+                        <div class="col-md-2 col-lg-3">
+                            <label class="col-form-label" for="defaultDomain">Default domain</label>
+                        </div>
+                        <div class="col-md-6 col-lg-5 col-xl-4">
+                            <select class="form-control" id="defaultDomain" name="defaultDomain">
+                                {foreach from=$nav__domainList item=domain}
+                                    <option value="{$domain->getId()}" {if $defaultDomain == $domain->getId()}selected="selected"{/if}>
+                                        {$domain->getLongName()|escape}
+                                    </option>
+                                {/foreach}
+                            </select>
+                            <small class="form-text text-muted">This is used to choose the domain which is selected by default on login.</small>
+
+                        </div>
+                        {include file="preferences/globalcheck.tpl" settingName="defaultDomain" settingState=true settingAvailable=false offset="offset-md-2 offset-lg-2 offset-xl-2"}
+
+                    </div>
+                    {else}
+                        <input type="hidden" name="defaultDomain" value="">
+                    {/if}
+
                     <div class="form-group row">
                         <div class="offset-md-2 offset-lg-3 col-md-4 col-lg-3">
                             <button type="submit" class="btn btn-primary btn-block">Save preferences</button>

--- a/templates/preferences/prefs.tpl
+++ b/templates/preferences/prefs.tpl
@@ -30,7 +30,7 @@
                             <label for="inputEmailsig" class="col-form-label">Email signature</label>
                         </div>
                         <div class="col-md-10 col-lg-8 col-xl-6">
-                            <textarea class="form-control" id="inputEmailsig" rows="4" name="emailsig">{$currentUser->getEmailSig()|escape}</textarea>
+                            <textarea class="form-control" id="inputEmailsig" rows="4" name="emailsig">{$emailSignature|escape}</textarea>
                             <small class="form-text text-muted">This will show up at the end of any Email you send through the interface.</small>
                         </div>
                     </div>
@@ -38,7 +38,7 @@
                     <div class="form-group row">
                         <div class="offset-md-2 offset-lg-3 col-md-10 col-lg-8 col-xl-6">
                             <div class="custom-control custom-switch">
-                                <input class="custom-control-input" type="checkbox" id="inputAbortpref" name="abortpref"{if $currentUser->getAbortPref()} checked{/if}>
+                                <input class="custom-control-input" type="checkbox" id="inputAbortpref" name="abortpref"{if $skipJsAbort} checked{/if}>
                                 <label class="custom-control-label" for="inputAbortpref">Skip double-check prompt before closing requests</label>
                             </div>
                         </div>
@@ -52,14 +52,14 @@
 
                             <div class="custom-control custom-radio">
                                 <input type="radio" name="creationmode" value="0" class="custom-control-input" id="autocreateNone"
-                                       {if $currentUser->getCreationMode() == 0}checked="checked"{/if}
+                                       {if $creationMode == 0}checked="checked"{/if}
                                        {if !$canManualCreate}disabled="disabled"{/if}/>
                                 <label class="custom-control-label" for="autocreateNone">Create accounts manually using Special:CreateAccount</label>
                             </div>
 
                             <div class="custom-control custom-radio">
                                 <input type="radio" name="creationmode" value="1" class="custom-control-input" id="autocreateOauth"
-                                       {if $currentUser->getCreationMode() == 1}checked="checked"{/if}
+                                       {if $creationMode == 1}checked="checked"{/if}
                                        {if !$canOauthCreate}disabled="disabled"{/if}/>
                                 <label class="custom-control-label" for="autocreateOauth">Use my Wikimedia account to create the accounts on my behalf where possible</label>
                                 {if $canOauthCreate && !$oauth->canCreateAccount()}
@@ -69,7 +69,7 @@
 
                             <div class="custom-control custom-radio">
                                 <input type="radio" name="creationmode" value="2" class="custom-control-input" id="autocreateBot"
-                                       {if $currentUser->getCreationMode() == 2}checked="checked"{/if}
+                                       {if $creationMode == 2}checked="checked"{/if}
                                        {if !$canBotCreate}disabled="disabled"{/if}/>
                                 <label class="custom-control-label" for="autocreateBot">Use a bot to create the accounts on my behalf where possible</label>
                             </div>
@@ -84,13 +84,13 @@
                         </div>
                         <div class="col-md-6 col-lg-5 col-xl-4">
                             <select class="form-control" id="inputSkinType" name="skintype">
-                                <option value="auto" {if $currentUser->getSkin() === 'auto'}selected="selected"{/if}>
+                                <option value="auto" {if $skin === 'auto'}selected="selected"{/if}>
                                     Use browser default
                                 </option>
-                                <option value="main" {if $currentUser->getSkin() === 'main'}selected="selected"{/if}>
+                                <option value="main" {if $skin === 'main'}selected="selected"{/if}>
                                     Light theme
                                 </option>
-                                <option value="alt" {if $currentUser->getSkin() === 'alt'}selected="selected"{/if}>
+                                <option value="alt" {if $skin === 'alt'}selected="selected"{/if}>
                                     Dark theme
                                 </option>
                             </select>

--- a/templates/statistics/welcome-template-usage.tpl
+++ b/templates/statistics/welcome-template-usage.tpl
@@ -1,19 +1,19 @@
 {extends file="statistics/base.tpl"}
 {block name="statisticsContent"}
-    <table class="table table-striped table-hover table-sm">
+    <table class="table table-striped table-hover table-sm table-nonfluid">
         <thead>
+        <tr><th rowspan="2">Template</th><th colspan="2">Users using this template</th></tr>
         <tr>
-            <th>Template</th>
-            <th>Active users using this template</th>
-            <th>All users using this template</th>
+            <th>Active users</th>
+            <th>All users</th>
         </tr>
         </thead>
         <tbody>
         {foreach from=$dataTable item=row}
             <tr>
                 <td><a href="{$baseurl}/internal.php/welcomeTemplates/view?template={$row.templateid}">{$row.usercode|escape}</a></td>
-                <td>{$row.activecount|escape}</td>
-                <td>{$row.usercount|escape}</td>
+                <td class="text-right">{$row.activecount|escape}</td>
+                <td class="text-right">{$row.usercount|escape}</td>
             </tr>
         {/foreach}
         </tbody>

--- a/templates/usermanagement/edituser.tpl
+++ b/templates/usermanagement/edituser.tpl
@@ -62,7 +62,7 @@
                 <label for="inputEmailsig" class="col-form-label">Email signature</label>
             </div>
             <div class="col-md-9 col-lg-7 col-xl-6">
-                <div class="form-control prewrap minh-5">{$emailSignature|escape}</div>
+                <div class="form-control prewrap minh-5 uneditable-input">{$emailSignature|escape}</div>
             </div>
         </div>
 

--- a/templates/usermanagement/edituser.tpl
+++ b/templates/usermanagement/edituser.tpl
@@ -62,7 +62,7 @@
                 <label for="inputEmailsig" class="col-form-label">Email signature</label>
             </div>
             <div class="col-md-9 col-lg-7 col-xl-6">
-                <div class="form-control prewrap minh-5">{$user->getEmailSig()|escape}</div>
+                <div class="form-control prewrap minh-5">{$emailSignature|escape}</div>
             </div>
         </div>
 
@@ -76,7 +76,7 @@
                 </div>
                 <div class="custom-control custom-radio">
                     <input type="radio" name="creationmode" value="0" class="custom-control-input" id="autocreateNone"
-                           {if $user->getCreationMode() == 0}checked="checked"{/if} />
+                           {if $preferredCreationMode == 0}checked="checked"{/if} />
                     <label class="custom-control-label" for="autocreateNone">
                         {if !$canManualCreate}<span class="badge badge-danger">Not authorised</span>{/if}
                         Create accounts manually using Special:CreateAccount
@@ -85,7 +85,7 @@
 
                 <div class="custom-control custom-radio">
                     <input type="radio" name="creationmode" value="1" class="custom-control-input" id="autocreateOauth"
-                           {if $user->getCreationMode() == 1}checked="checked"{/if} />
+                           {if $preferredCreationMode == 1}checked="checked"{/if} />
                     <label class="custom-control-label" for="autocreateOauth">
                         {if !$canOauthCreate}<span class="badge badge-danger">Not authorised</span>{/if}
                         Use my Wikimedia account to create the accounts on my behalf where possible
@@ -94,7 +94,7 @@
 
                 <div class="custom-control custom-radio">
                     <input type="radio" name="creationmode" value="2" class="custom-control-input" id="autocreateBot"
-                           {if $user->getCreationMode() == 2}checked="checked"{/if} />
+                           {if $preferredCreationMode == 2}checked="checked"{/if} />
                     <label class="custom-control-label" for="autocreateBot">
                         {if !$canBotCreate}<span class="badge badge-danger">Not authorised</span>{/if}
                         Use a bot to create the accounts on my behalf where possible

--- a/templates/usermanagement/edituser.tpl
+++ b/templates/usermanagement/edituser.tpl
@@ -55,15 +55,6 @@
                            value="{$user->getOnWikiName()|escape}" required="required"/>
                 </div>
             </div>
-
-            <div class="form-group row">
-                <div class="offset-lg-2 col-md-3 col-lg-2">
-                    <label for="inputSig" class="col-form-label">Signature (wikicode)</label>
-                </div>
-                <div class="col-md-8 col-lg-6 col-xl-4">
-                    <input class="form-control" type="text" id="inputSig" name="sig" value="{$currentUser->getWelcomeSig()|escape}"/>
-                </div>
-            </div>
         {/if}
 
         <div class="form-group row">

--- a/templates/view-request/createbuttons/auto.tpl
+++ b/templates/view-request/createbuttons/auto.tpl
@@ -3,7 +3,7 @@
     {if !empty($createReasons)}
         <div class="dropright btn-group btn-block">
             <button class="btn btn-success col jsconfirm" type="submit" name="template" value="{$createdId}"
-                    {if !$currentUser->getAbortPref() && $createdHasJsQuestion}
+                    {if !$skipJsAborts && $createdHasJsQuestion}
                 data-template="{$createdId}"
                     {/if}>
                 Create and close as {$createdName|escape}
@@ -17,7 +17,7 @@
                 {foreach $createReasons as $reason}
                     <li>
                         <button class="btn-link dropdown-item jsconfirm" name="template" value="{$reason->getId()}" type="submit"
-                            {if !$currentUser->getAbortPref() && $reason->getJsquestion() != ''}
+                            {if !$skipJsAborts && $reason->getJsquestion() != ''}
                             data-template="{$reason->getId()}"
                             {/if}>
                             {$reason->getName()|escape}
@@ -28,7 +28,7 @@
         </div>
     {else}
         <button class="btn btn-success btn-block jsconfirm" type="submit" name="template" value="{$createdId}"
-                {if !$currentUser->getAbortPref() && $createdHasJsQuestion}
+                {if !$skipJsAborts && $createdHasJsQuestion}
             data-template="{$createdId}"
                 {/if}>
             {$createdName|escape}

--- a/templates/view-request/createbuttons/manual.tpl
+++ b/templates/view-request/createbuttons/manual.tpl
@@ -3,7 +3,7 @@
     <div class="col-md-6">
         <a class="btn btn-primary btn-block jsconfirm" target="_blank"
            href="{$mediawikiScriptPath}?title=Special:UserLogin/signup&amp;wpName={$requestName|escape:'url'}&amp;email={$requestEmail|escape:'url'}&amp;reason={$createAccountReason|escape:'url'}{$requestId}&amp;wpCreateaccountMail=true"
-                {if !$currentUser->getAbortPref() && $createdHasJsQuestion}
+                {if !$skipJsAborts && $createdHasJsQuestion}
                     data-template="{$createdId}"
                 {/if}>
             Create account
@@ -24,7 +24,7 @@
                     {foreach $createReasons as $reason}
                         <li>
                             <button class="btn-link dropdown-item jsconfirm" name="template" value="{$reason->getId()}" type="submit"
-                                    {if !$currentUser->getAbortPref() && $reason->getJsquestion() != ''}
+                                    {if !$skipJsAborts && $reason->getJsquestion() != ''}
                                         data-template="{$reason->getId()}"
                                     {/if}>
                                 {$reason->getName()|escape}

--- a/templates/view-request/decline-button.tpl
+++ b/templates/view-request/decline-button.tpl
@@ -7,7 +7,7 @@
         <div class="dropdown-menu">
             {foreach $declineReasons as $reason}
                 <button class="btn-link dropdown-item jsconfirm" name="template" value="{$reason->getId()}" type="submit"
-                        {if !$currentUser->getAbortPref() && $reason->getJsquestion() != ''}
+                        {if !$skipJsAborts && $reason->getJsquestion() != ''}
                             data-template="{$reason->getId()}"
                         {/if}>
                     {$reason->getName()|escape}

--- a/templates/view-request/main.tpl
+++ b/templates/view-request/main.tpl
@@ -24,25 +24,25 @@
                             <div class="creationOptions">
                                 <div class="creationTypeOptions">
                                     {if $canManualCreate}
-										<div class="custom-control-inline custom-radio">
+                                        <div class="custom-control-inline custom-radio">
                                             <input type="radio" name="createMode" id="createModeManual" value="manual" class="custom-control-input"
-                                                   {if $currentUser->getCreationMode() == 0}checked="checked"{/if} />
+                                                   {if $preferredCreationMode == 0}checked="checked"{/if} />
                                             <label for="createModeManual" class="custom-control-label">Manual</label>
-										</div>
+                                        </div>
                                     {/if}
                                     {if $canOauthCreate}
-									    <div class="custom-control-inline custom-radio">
+                                        <div class="custom-control-inline custom-radio">
                                             <input type="radio" name="createMode" id="createModeOauth" value="oauth" class="custom-control-input"
-                                                   {if $currentUser->getCreationMode() == 1}checked="checked"{/if}>
+                                                   {if $preferredCreationMode == 1}checked="checked"{/if}>
                                             <label for="createModeOauth" class="custom-control-label">Use my Wikimedia account</label>
-										</div>
+                                        </div>
                                     {/if}
                                     {if $canBotCreate}
-									    <div class="custom-control-inline custom-radio">
+                                        <div class="custom-control-inline custom-radio">
                                             <input type="radio" name="createMode" id="createModeBot" value="bot" class="custom-control-input"
-                                                   {if $currentUser->getCreationMode() == 2}checked="checked"{/if}>
+                                                   {if $preferredCreationMode == 2}checked="checked"{/if}>
                                             <label for="createModeBot" class="custom-control-label">Use the bot</label>
-										</div>
+                                        </div>
                                     {/if}
                                 </div>
                             </div>
@@ -52,12 +52,12 @@
                             <div class="row">
                                 {if $requestIsReservedByMe && !$requestIsClosed}
                                     {if $canManualCreate}
-                                        <div class="col-md-12 create-button-row {if $currentUser->getCreationMode() !== 0}d-none{/if}" id="createManual">
+                                        <div class="col-md-12 create-button-row {if $preferredCreationMode !== 0}d-none{/if}" id="createManual">
                                             {block name="manualcreationbutton"}{/block}
                                         </div>
                                     {/if}
                                     {if $canOauthCreate}
-                                        <div class="col-md-12 create-button-row {if $currentUser->getCreationMode() !== 1}d-none{/if}" id="createOauth">
+                                        <div class="col-md-12 create-button-row {if $preferredCreationMode !== 1}d-none{/if}" id="createOauth">
                                             {if $requestEmailSent}
                                                 <div class="alert alert-warning mb-0">This request has already had an email sent to the requester. Please do a custom close or fall back to manual creation.</div>
                                             {elseif $oauthProblem}
@@ -75,15 +75,15 @@
                                     {/if}
                                     {if $canBotCreate}
                                         {if $requestEmailSent}
-                                            <div class="col-md-12 create-button-row {if $currentUser->getCreationMode() !== 2}d-none{/if}" id="createBot">
+                                            <div class="col-md-12 create-button-row {if $preferredCreationMode !== 2}d-none{/if}" id="createBot">
                                                 <div class="alert alert-warning mb-0">This request has already had an email sent to the requester. Please do a custom close or fall back to manual creation.</div>
                                             </div>
                                         {elseif $botProblem}
-                                            <div class="col-md-12 create-button-row {if $currentUser->getCreationMode() !== 2}d-none{/if}" id="createBot">
+                                            <div class="col-md-12 create-button-row {if $preferredCreationMode !== 2}d-none{/if}" id="createBot">
                                                 <div class="alert alert-warning mb-0">There's an issue with the tool configuration. Please choose a different creation type above.</div>
                                             </div>
                                         {else}
-                                            <div class="col-md-12 create-button-row {if $currentUser->getCreationMode() !== 2}d-none{/if}" id="createBot">
+                                            <div class="col-md-12 create-button-row {if $preferredCreationMode !== 2}d-none{/if}" id="createBot">
                                                 {include file="view-request/createbuttons/auto.tpl" creationMode="bot"}
                                             </div>
                                         {/if}

--- a/templates/welcome-template/list.tpl
+++ b/templates/welcome-template/list.tpl
@@ -37,13 +37,13 @@
                 </thead>
                 {if $canSelect}
                     <tfoot>
-                        <tr {if $currentUser->getWelcomeTemplate() == null}class="table-success"{/if}>
+                        <tr {if $currentTemplate == null}class="table-success"{/if}>
                             <th colspan="2">Disable automatic welcoming</th>
                             {if $canEdit}
                                 <th class="d-none d-lg-block"><!-- count --></th>
                             {/if}
                             <td class="table-button-cell">
-                                {if $currentUser->getWelcomeTemplate() !== null}
+                                {if $currentTemplate !== null}
                                     <form method="post" action="{$baseurl}/internal.php/welcomeTemplates/select">
                                         {include file="security/csrf.tpl"}
                                         <input type="hidden" name="disable" value="true"/>
@@ -60,7 +60,7 @@
                 {/if}
                 <tbody>
                 {foreach from=$templateList item="t" name="templateloop"}
-                    <tr {if $currentUser->getWelcomeTemplate() == $t->getId()}class="table-success"{/if}>
+                    <tr {if $currentTemplate == $t->getId()}class="table-success"{/if}>
                         <td>
                             {$t->getUserCode()|escape}
                         </td>
@@ -96,7 +96,7 @@
                                     </button>
                                 </form>
                             {/if}
-                            {if $currentUser->getWelcomeTemplate() != $t->getId()}
+                            {if $currentTemplate != $t->getId()}
                                 {if $canSelect}
                                     <form method="post" action="{$baseurl}/internal.php/welcomeTemplates/select" class="d-inline-block">
                                         {include file="security/csrf.tpl"}


### PR DESCRIPTION
Due to a number of our preferences being specific to a single wiki (welcome template, email signature) or at a point where you may want to configure it differently per-wiki (abortpref, creation mode), we need a way of setting these preferences per-domain.

This patch does several things:
* Changes preferences to not be hard-wired into database columns, allowing for the addition of new preferences without a schema change (#675)
* Introduces the concept of "global" preferences, which preferences fall back to if no local preference is set (#594)
* Adds a flag to determine which (if any) domain a specific preference is for, allowing us to differentiate between preferences for a user across different domains
* Removes the unused "welcome signature" preference, unused since OAuth-based welcoming was introduced
* Adds a "default domain" preference

Two other issues were fixed as part of this overhaul:
* Don't redirect to the main page on preferences save if the user has no access to see the main page
* In dark mode, change the colours of modal dialogs to be light text on dark background, rather than light text on light background.

Worthy of note:
* There's a generated column on the new `userpreference` table called `global`. This exists purely to work around that `null <> null` in a database context, such that a unique constraint on a nullable column **can** have multiple nulls in it. This column is solely used in the context of unique constraints in the database, so it's not pulled into the application on purpose.
* The core of the global preferences system is one SQL query in `PreferenceManager::loadPreferences`.