### PR TITLE
Bump PHP/MariaDB versions to reflect production migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: php
 
 php:
-  - 7.3
+  - 7.4
 
 addons:
-  mariadb: '10.2'
+  mariadb: '10.5'
 
 os: linux
-dist: bionic
+dist: focal
 
 before_install:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,18 @@ addons:
 os: linux
 dist: focal
 
-before_install:
-  - composer install
-
 git:
   submodules: true
 
 env:
-  - MYSQL_HOST=localhost MYSQL_USER=root MYSQL_SCHEMA=testdb
+  - MYSQL_HOST=localhost MYSQL_USER=root MYSQL_SCHEMA=testdb MYSQL_PASSWORD=travis
+
+install:
+  - pecl install runkit7-4.0.0a6
+  - sudo mysql -e "SET Password=PASSWORD('travis')"
 
 before_script:
-  - pecl install runkit7-4.0.0a6
+  - composer install
   - phpenv config-add .travis.php.ini
   - cd sql
   - bash test_db.sh 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ git:
   submodules: true
 
 env:
-  - MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_SCHEMA=testdb
+  - MYSQL_HOST=localhost MYSQL_USER=root MYSQL_SCHEMA=testdb
 
 before_script:
   - pecl install runkit7-4.0.0a6

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   - MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_SCHEMA=testdb
 
 before_script:
-  - pecl install runkit7-3.0.0
+  - pecl install runkit7-4.0.0a6
   - phpenv config-add .travis.php.ini
   - cd sql
   - bash test_db.sh 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-apache-buster
+FROM php:7.4-apache-bullseye
 
 ENV DEBIAN_FRONTEND="noninteractive"
 

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -3,14 +3,14 @@ This is a brief installation guide for developers/testers etc to get this system
 # Prerequisites
 
 * Web server
-* MariaDB 10.3.22+ (or equivalent)
-* PHP 7.3+
+* MariaDB 10.5.15+ (or equivalent)
+* PHP 7.4+
 
 The webserver must be configured to pre-process *.php files through the PHP engine before sending them to a client.
 
 You must also have a database which you can use with the tool.
 
-Note: MariaDB 10.2.1 is likely sufficient, but compatibility cannot be guaranteed as Production runs on 10.3.22.
+Note: MariaDB 10.2.1 is likely sufficient, but compatibility cannot be guaranteed as Production runs on 10.5.15.
 
 ## PHP configuration
 You'll also need some PHP extensions:
@@ -37,10 +37,10 @@ Note that runkit is a pain[1] to get working on Windows, and is only used by som
 
 ### Production
 
-* MariaDB 10.1.37
-* PHP 7.3.14
-* Apache 2.4.38 (Debian)
-* Debian Buster (Wikimedia Cloud VPS)
+* MariaDB 10.5.15
+* PHP 7.4.30
+* Apache 2.4.54 (Debian)
+* Debian Bullseye (Wikimedia Cloud VPS)
 
 # Basic information
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - msgbroker
       - mailsink
   database:
-    image: mariadb:10.3
+    image: mariadb:10.5
     ports:
       - "3306:3306"
     environment:
@@ -26,7 +26,7 @@ services:
       - ./docker/database.sh:/docker-entrypoint-initdb.d/init.sh
       - ./sql:/wacadb
   msgbroker:
-    image: rabbitmq:3.10-management-alpine
+    image: rabbitmq:3.8-management-alpine
     ports:
       - "5672:5672" # Actual message broker port.
       - "15672:15672" # Management web interface port. Plain HTTP, username guest, password guest.


### PR DESCRIPTION
NOTE: this migration has already happened in Production, so this is just an update to CI/Docker/documentation.