### PR TITLE
Update RabbitMQ Docker config for 3.10 -> 3.8

### DIFF
--- a/docker/rabbitmq-definitions.json
+++ b/docker/rabbitmq-definitions.json
@@ -1,16 +1,14 @@
 {
-    "rabbit_version": "3.10.7",
-    "rabbitmq_version": "3.10.7",
+    "rabbit_version": "3.8.34",
+    "rabbitmq_version": "3.8.34",
     "product_name": "RabbitMQ",
-    "product_version": "3.10.7",
+    "product_version": "3.8.34",
     "users": [
         {
             "name": "guest",
-            "password_hash": "Qc1Q8iTLO1z51lpulvLJBdICCl0XWo9p32z2tOaszlgRJlcW",
+            "password_hash": "fbA7sbl2kHV5ljv5wymNQugTE6IdxEUcFZOpl+oUkmU4Hs8O",
             "hashing_algorithm": "rabbit_password_hashing_sha256",
-            "tags": [
-                "administrator"
-            ],
+            "tags": "administrator",
             "limits": {}
         }
     ],
@@ -33,7 +31,7 @@
     "global_parameters": [
         {
             "name": "internal_cluster_id",
-            "value": "rabbitmq-cluster-id-wb6Nr3IIqXpuiOTPpBz6oA"
+            "value": "rabbitmq-cluster-id-9zDTywHuD9k6q_wRQioN1A"
         }
     ],
     "policies": [],

--- a/docker/rabbitmq.conf
+++ b/docker/rabbitmq.conf
@@ -1,1 +1,5 @@
 management.load_definitions = /etc/rabbitmq/definitions.json
+
+# Allow the "guest" user to be used for convenience in the Docker development environment. Not advised in prod for
+# obvious reasons.
+loopback_users = none


### PR DESCRIPTION
Updates RabbitMQ Docker config/definitions to reflect the change from 3.10 to 3.8 in PR #766. This is a repeat of #768, this time with feeling.

Tested locally to function as expected by creating a request, email confirming that request (using the Docker mailsink), and reserving the request through the internal interface and verifying that notifications were sent to RabbitMQ as expected.