### PR TITLE
Extract ID noticeboard wiki to variable, and add to config.inc.php

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -167,6 +167,9 @@ $jobQueueBatchSize = 10;
 
 $emailSender = 'accounts@wmflabs.org';
 
+$identificationNoticeboardPage = 'Access to nonpublic personal data policy/Noticeboard';
+$identificationNoticeboardApi = $metaWikimediaWebServiceEndpoint;
+
 /**************************************************************************
  **********                   IMPORTANT NOTICE                    **********
  ***************************************************************************
@@ -271,4 +274,6 @@ $siteConfiguration->setBaseUrl($baseurl)
     ->setBanMaxIpBlockRange($banMaxIpBlockRange)
     ->setJobQueueBatchSize($jobQueueBatchSize)
     ->setAmqpConfiguration($amqpConfiguration)
-    ->setEmailSender($emailSender);
+    ->setEmailSender($emailSender)
+    ->setIdentificationNoticeboardPage($identificationNoticeboardPage)
+    ->setIdentificationNoticeboardWebserviceEndpoint($identificationNoticeboardApi);

--- a/includes/IdentificationVerifier.php
+++ b/includes/IdentificationVerifier.php
@@ -187,7 +187,7 @@ SQL;
         $parameters['titles'] = $this->siteConfiguration->getIdentificationNoticeboardPage();
 
         try {
-            $endpoint = $this->siteConfiguration->getMetaWikimediaWebServiceEndpoint();
+            $endpoint = $this->siteConfiguration->getIdentificationNoticeboardWebserviceEndpoint();
             $response = $this->httpHelper->get($endpoint, $parameters);
             $response = json_decode($response, true);
         }

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -62,6 +62,7 @@ class SiteConfiguration
     private $yubicoApiKey = "";
     private $totpEncryptionKey = "1234";
     private $identificationNoticeboardPage = 'Access to nonpublic personal data policy/Noticeboard';
+    private $identificationNoticeboardWebserviceEndpoint = 'https://meta.wikimedia.org/w/api.php';
     private $registrationAllowed = true;
     private $cspReportUri = null;
     private $resourceCacheEpoch = 1;
@@ -831,6 +832,18 @@ class SiteConfiguration
         $this->identificationNoticeboardPage = $identificationNoticeboardPage;
 
         return $this;
+    }
+
+    public function setIdentificationNoticeboardWebserviceEndpoint(string $identificationNoticeboardWebserviceEndpoint
+    ): SiteConfiguration {
+        $this->identificationNoticeboardWebserviceEndpoint = $identificationNoticeboardWebserviceEndpoint;
+
+        return $this;
+    }
+
+    public function getIdentificationNoticeboardWebserviceEndpoint(): string
+    {
+        return $this->identificationNoticeboardWebserviceEndpoint;
     }
 
     public function isRegistrationAllowed(): bool


### PR DESCRIPTION
This patch makes the location of the ID noticeboard lookups fully configurable, in case the move to foundationwiki goes ahead.