### PR TITLE
Docker: Bump RabbitMQ 3.8 -> 3.10.8, update docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - ./docker/database.sh:/docker-entrypoint-initdb.d/init.sh
       - ./sql:/wacadb
   msgbroker:
-    image: rabbitmq:3.8-management-alpine
+    image: rabbitmq:3.10.8-management-alpine
     ports:
       - "5672:5672" # Actual message broker port.
       - "15672:15672" # Management web interface port. Plain HTTP, username guest, password guest.

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,8 +35,8 @@ Four Docker Compose services will be started, each within its own container:
 | Service name  | Container name       | Description                                                       |
 |---------------|----------------------|-------------------------------------------------------------------|
 | `application` | `waca-application-1` | Apache web server with PHP 7.4 hosting the actual ACC app.        |
-| `database`    | `waca-database-1`    | MariaDB 10.5 database server used by ACC.                         |
-| `msgbroker`   | `waca-msgbroker-1`   | RabbitMQ 3.8 message broker server used for notifications.        |
+| `database`    | `waca-database-1`    | MariaDB 10.11.3 database server used by ACC.                      |
+| `msgbroker`   | `waca-msgbroker-1`   | RabbitMQ 3.10.8 message broker server used for notifications.     |
 | `mailsink`    | `waca-mailsink-1`    | A simple mailsink running a dummy SMTP server which ACC will use. |
 
 If it doesn't already exist, a `config.local.inc.php` file will automatically be created in the repo root containing

--- a/docker/rabbitmq-definitions.json
+++ b/docker/rabbitmq-definitions.json
@@ -1,14 +1,16 @@
 {
-    "rabbit_version": "3.8.34",
-    "rabbitmq_version": "3.8.34",
+    "rabbit_version": "3.10.8",
+    "rabbitmq_version": "3.10.8",
     "product_name": "RabbitMQ",
-    "product_version": "3.8.34",
+    "product_version": "3.10.8",
     "users": [
         {
             "name": "guest",
             "password_hash": "fbA7sbl2kHV5ljv5wymNQugTE6IdxEUcFZOpl+oUkmU4Hs8O",
             "hashing_algorithm": "rabbit_password_hashing_sha256",
-            "tags": "administrator",
+            "tags": [
+                "administrator"
+            ],
             "limits": {}
         }
     ],


### PR DESCRIPTION
In preparation for upgrading the ACC appserver to the latest Debian, bumps RabbitMQ from 3.8 to 3.10.8 in `docker-compose.yml`, which is the version currently available in the package repos for Debian bookworm as of this PR. (See https://packages.debian.org/stable/rabbitmq-server)

Also updates the Docker README to reflect version bumps to MariaDB and RabbitMQ.

Tested locally by wiping out everything (`docker system prune -af --volumes && docker volume prune -af`) and rebuilding from scratch (`docker compose up --detach`), then making a request, email confirming it via the mailsink, confirming that RabbitMQ shows the IRC notification, and then logging into the interface to confirm the presence of the request.

For future reference: RabbitMQ 3.10.8 accepted the 3.8 `rabbitmq-definitions.json` file; after RabbitMQ was up, I simply visited http://localhost:15672/api/definitions to grab an updated version and that's what's included in this PR.