### PR TITLE
Add domain columns to relevant tables

### DIFF
--- a/includes/API/Actions/JsTemplateConfirmsAction.php
+++ b/includes/API/Actions/JsTemplateConfirmsAction.php
@@ -17,7 +17,8 @@ class JsTemplateConfirmsAction extends JsonApiPageBase implements IJsonApiAction
     public function executeApiAction()
     {
         /** @var EmailTemplate[] $templates */
-        $templates = EmailTemplate::getAllActiveTemplates(null, $this->getDatabase());
+        // FIXME: domains!
+        $templates = EmailTemplate::getAllActiveTemplates(null, $this->getDatabase(), 1);
 
         $dataset = [];
         foreach ($templates as $tpl) {

--- a/includes/API/Actions/StatusAction.php
+++ b/includes/API/Actions/StatusAction.php
@@ -47,7 +47,8 @@ SQL
         }
 
         // hospital queue
-        $search = RequestSearchHelper::get($this->getDatabase())->isHospitalised();
+        // FIXME: domains
+        $search = RequestSearchHelper::get($this->getDatabase(), 1)->isHospitalised();
 
         if ($this->getSiteConfiguration()->getEmailConfirmationEnabled()) {
             $search->withConfirmedEmail();
@@ -56,7 +57,8 @@ SQL
         $statusElement->setAttribute('x-hospital', $hospitalCount);
 
         // job queue
-        $search = RequestSearchHelper::get($this->getDatabase())
+        // FIXME: domains
+        $search = RequestSearchHelper::get($this->getDatabase(), 1)
             ->byStatus(RequestStatus::JOBQUEUE);
 
         if ($this->getSiteConfiguration()->getEmailConfirmationEnabled()) {

--- a/includes/Background/Task/WelcomeUserTask.php
+++ b/includes/Background/Task/WelcomeUserTask.php
@@ -9,30 +9,18 @@
 namespace Waca\Background\Task;
 
 use Waca\Background\BackgroundTaskBase;
-use Waca\DataObjects\JobQueue;
 use Waca\DataObjects\Request;
 use Waca\DataObjects\User;
 use Waca\DataObjects\WelcomeTemplate;
 use Waca\Helpers\MediaWikiHelper;
 use Waca\Helpers\OAuthUserHelper;
 use Waca\Helpers\PreferenceManager;
-use Waca\PdoDatabase;
 use Waca\RequestStatus;
 
 class WelcomeUserTask extends BackgroundTaskBase
 {
     /** @var Request */
     private $request;
-
-    public static function enqueue(User $triggerUser, Request $request, PdoDatabase $database)
-    {
-        $job = new JobQueue();
-        $job->setDatabase($database);
-        $job->setTask(WelcomeUserTask::class);
-        $job->setRequest($request->getId());
-        $job->setTriggerUserId($triggerUser->getId());
-        $job->save();
-    }
 
     public function execute()
     {

--- a/includes/DataObjects/Comment.php
+++ b/includes/DataObjects/Comment.php
@@ -73,10 +73,10 @@ SQL
         return $result;
     }
 
-    public static function getFlaggedComments(PdoDatabase $database)
+    public static function getFlaggedComments(PdoDatabase $database, int $domain)
     {
-        $statement = $database->prepare('SELECT * FROM comment WHERE flagged = 1;');
-        $statement->execute();
+        $statement = $database->prepare('SELECT c.* FROM comment c INNER JOIN request r ON c.request = r.id WHERE c.flagged = 1 AND r.domain = :domain;');
+        $statement->execute([':domain' => $domain]);
 
         $result = array();
         /** @var Comment $v */

--- a/includes/DataObjects/EmailTemplate.php
+++ b/includes/DataObjects/EmailTemplate.php
@@ -35,6 +35,8 @@ class EmailTemplate extends DataObject
     private $preloadonly = 0;
     private $defaultaction = self::ACTION_NOT_CREATED;
     private $queue;
+    /** @var int */
+    private $domain;
 
     /**
      * Gets active non-preload templates
@@ -171,8 +173,8 @@ SQL
         if ($this->isNew()) {
             // insert
             $statement = $this->dbObject->prepare(<<<SQL
-INSERT INTO `emailtemplate` (name, text, jsquestion, defaultaction, active, preloadonly, queue)
-VALUES (:name, :text, :jsquestion, :defaultaction, :active, :preloadonly, :queue);
+INSERT INTO `emailtemplate` (name, text, jsquestion, defaultaction, active, preloadonly, queue, domain)
+VALUES (:name, :text, :jsquestion, :defaultaction, :active, :preloadonly, :queue, :domain);
 SQL
             );
             $statement->bindValue(":name", $this->name);
@@ -182,6 +184,7 @@ SQL
             $statement->bindValue(":active", $this->active);
             $statement->bindValue(":preloadonly", $this->preloadonly);
             $statement->bindValue(":queue", $this->queue);
+            $statement->bindValue(":domain", $this->domain);
 
             if ($statement->execute()) {
                 $this->id = (int)$this->dbObject->lastInsertId();
@@ -365,5 +368,15 @@ SQL
     public function setQueue(?int $queue): void
     {
         $this->queue = $queue;
+    }
+
+    public function getDomain(): int
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(int $domain): void
+    {
+        $this->domain = $domain;
     }
 }

--- a/includes/DataObjects/JobQueue.php
+++ b/includes/DataObjects/JobQueue.php
@@ -61,6 +61,8 @@ class JobQueue extends DataObject
     private $acknowledged;
     /** @var int */
     private $parent;
+    /** @var int */
+    private $domain;
 
     /**
      * This feels like the least bad place to put this method.
@@ -85,8 +87,8 @@ class JobQueue extends DataObject
         if ($this->isNew()) {
             // insert
             $statement = $this->dbObject->prepare(<<<SQL
-                INSERT INTO jobqueue (task, user, request, emailtemplate, parameters, parent, status) 
-                VALUES (:task, :user, :request, :emailtemplate, :parameters, :parent, 'queued')
+                INSERT INTO jobqueue (task, user, request, emailtemplate, parameters, parent, status, domain) 
+                VALUES (:task, :user, :request, :emailtemplate, :parameters, :parent, 'queued', :domain)
 SQL
             );
             $statement->bindValue(":task", $this->task);
@@ -95,6 +97,7 @@ SQL
             $statement->bindValue(":emailtemplate", $this->emailtemplate);
             $statement->bindValue(":parameters", $this->parameters);
             $statement->bindValue(":parent", $this->parent);
+            $statement->bindValue(":domain", $this->domain);
 
             if ($statement->execute()) {
                 $this->id = (int)$this->dbObject->lastInsertId();
@@ -296,4 +299,13 @@ SQL
         $this->emailtemplate = $emailTemplate;
     }
     #endregion
+    public function getDomain(): int
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(int $domain): void
+    {
+        $this->domain = $domain;
+    }
 }

--- a/includes/DataObjects/Log.php
+++ b/includes/DataObjects/Log.php
@@ -28,6 +28,8 @@ class Log extends DataObject
     private $timestamp;
     /** @var string|null */
     private $comment;
+    /** @var int */
+    private $domain;
 
     /**
      * @throws Exception
@@ -36,8 +38,8 @@ class Log extends DataObject
     {
         if ($this->isNew()) {
             $statement = $this->dbObject->prepare(<<<SQL
-                INSERT INTO log (objectid, objecttype, user, action, timestamp, comment) 
-                VALUES (:id, :type, :user, :action, CURRENT_TIMESTAMP(), :comment);
+                INSERT INTO log (objectid, objecttype, user, action, timestamp, comment, domain) 
+                VALUES (:id, :type, :user, :action, CURRENT_TIMESTAMP(), :comment, :domain);
 SQL
             );
 
@@ -46,6 +48,7 @@ SQL
             $statement->bindValue(":user", $this->user);
             $statement->bindValue(":action", $this->action);
             $statement->bindValue(":comment", $this->comment);
+            $statement->bindValue(":domain", $this->domain);
 
             if ($statement->execute()) {
                 $this->id = (int)$this->dbObject->lastInsertId();
@@ -163,5 +166,15 @@ SQL
     public function setComment($comment)
     {
         $this->comment = $comment;
+    }
+
+    public function getDomain(): int
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(int $domain): void
+    {
+        $this->domain = $domain;
     }
 }

--- a/includes/DataObjects/Request.php
+++ b/includes/DataObjects/Request.php
@@ -38,6 +38,8 @@ class Request extends DataObject
     private $hasComments = false;
     private $hasCommentsResolved = false;
     private $originform;
+    /** @var int */
+    private $domain;
 
     /**
      * @throws Exception
@@ -51,11 +53,11 @@ class Request extends DataObject
 INSERT INTO `request` (
 	email, ip, name, status, date, emailsent,
 	emailconfirm, reserved, useragent, forwardedip,
-    queue, originform
+    queue, originform, domain
 ) VALUES (
 	:email, :ip, :name, :status, CURRENT_TIMESTAMP(), :emailsent,
 	:emailconfirm, :reserved, :useragent, :forwardedip,
-    :queue, :originform
+    :queue, :originform, :domain
 );
 SQL
             );
@@ -70,6 +72,7 @@ SQL
             $statement->bindValue(':forwardedip', $this->forwardedip);
             $statement->bindValue(':queue', $this->queue);
             $statement->bindValue(':originform', $this->originform);
+            $statement->bindValue(':domain', $this->domain);
 
             if ($statement->execute()) {
                 $this->id = (int)$this->dbObject->lastInsertId();
@@ -484,5 +487,15 @@ SQL
     public function setOriginForm(?int $originForm): void
     {
         $this->originform = $originForm;
+    }
+
+    public function getDomain(): int
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(int $domain): void
+    {
+        $this->domain = $domain;
     }
 }

--- a/includes/DataObjects/UserRole.php
+++ b/includes/DataObjects/UserRole.php
@@ -28,11 +28,12 @@ class UserRole extends DataObject
      *
      * @return UserRole[]
      */
-    public static function getForUser($userId, PdoDatabase $database)
+    public static function getForUser($userId, PdoDatabase $database, int $domainId)
     {
-        $sql = 'SELECT * FROM userrole WHERE user = :user';
+        $sql = 'SELECT * FROM userrole WHERE user = :user AND domain = :domain';
         $statement = $database->prepare($sql);
         $statement->bindValue(':user', $userId);
+        $statement->bindValue(':domain', $domainId);
 
         $statement->execute();
 

--- a/includes/DataObjects/UserRole.php
+++ b/includes/DataObjects/UserRole.php
@@ -23,17 +23,18 @@ class UserRole extends DataObject
     private $domain;
 
     /**
-     * @param int         $userId
+     * @param int         $user
      * @param PdoDatabase $database
+     * @param int         $domain
      *
      * @return UserRole[]
      */
-    public static function getForUser($userId, PdoDatabase $database, int $domainId)
+    public static function getForUser(int $user, PdoDatabase $database, int $domain)
     {
         $sql = 'SELECT * FROM userrole WHERE user = :user AND domain = :domain';
         $statement = $database->prepare($sql);
-        $statement->bindValue(':user', $userId);
-        $statement->bindValue(':domain', $domainId);
+        $statement->bindValue(':user', $user);
+        $statement->bindValue(':domain', $domain);
 
         $statement->execute();
 

--- a/includes/DataObjects/UserRole.php
+++ b/includes/DataObjects/UserRole.php
@@ -19,6 +19,8 @@ class UserRole extends DataObject
     private $user;
     /** @var string */
     private $role;
+    /** @var int */
+    private $domain;
 
     /**
      * @param int         $userId
@@ -54,10 +56,11 @@ class UserRole extends DataObject
     {
         if ($this->isNew()) {
             // insert
-            $statement = $this->dbObject->prepare('INSERT INTO `userrole` (user, role) VALUES (:user, :role);'
+            $statement = $this->dbObject->prepare('INSERT INTO `userrole` (user, role, domain) VALUES (:user, :role, :domain);'
             );
             $statement->bindValue(":user", $this->user);
             $statement->bindValue(":role", $this->role);
+            $statement->bindValue(":domain", $this->domain);
 
             if ($statement->execute()) {
                 $this->id = (int)$this->dbObject->lastInsertId();
@@ -71,8 +74,6 @@ class UserRole extends DataObject
             throw new Exception('Updating roles is not available');
         }
     }
-
-    #region Properties
 
     /**
      * @return int
@@ -105,5 +106,14 @@ class UserRole extends DataObject
     {
         $this->role = $role;
     }
-    #endregion
+
+    public function getDomain(): int
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(int $domain): void
+    {
+        $this->domain = $domain;
+    }
 }

--- a/includes/DataObjects/WelcomeTemplate.php
+++ b/includes/DataObjects/WelcomeTemplate.php
@@ -36,11 +36,11 @@ class WelcomeTemplate extends DataObject
      *
      * @return WelcomeTemplate[]
      */
-    public static function getAll(PdoDatabase $database)
+    public static function getAll(PdoDatabase $database, int $domain)
     {
-        $statement = $database->prepare("SELECT * FROM welcometemplate WHERE deleted = 0;");
+        $statement = $database->prepare("SELECT * FROM welcometemplate WHERE deleted = 0 AND domain = :domain;");
 
-        $statement->execute();
+        $statement->execute([':domain' => $domain]);
 
         $result = array();
         /** @var WelcomeTemplate $v */

--- a/includes/DataObjects/WelcomeTemplate.php
+++ b/includes/DataObjects/WelcomeTemplate.php
@@ -26,6 +26,8 @@ class WelcomeTemplate extends DataObject
     private $botcode;
     private $usageCache;
     private $deleted = 0;
+    /** @var int */
+    private $domain;
 
     /**
      * Summary of getAll
@@ -58,11 +60,12 @@ class WelcomeTemplate extends DataObject
         if ($this->isNew()) {
             // insert
             $statement = $this->dbObject->prepare(<<<SQL
-INSERT INTO welcometemplate (usercode, botcode) VALUES (:usercode, :botcode);
+INSERT INTO welcometemplate (usercode, botcode, domain) VALUES (:usercode, :botcode, :domain);
 SQL
             );
             $statement->bindValue(":usercode", $this->usercode);
             $statement->bindValue(":botcode", $this->botcode);
+            $statement->bindValue(":domain", $this->domain);
 
             if ($statement->execute()) {
                 $this->id = (int)$this->dbObject->lastInsertId();
@@ -206,5 +209,15 @@ SQL
         $templateText = str_replace('$username', $creator, $templateText);
 
         return $templateText;
+    }
+
+    public function getDomain(): int
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(int $domain): void
+    {
+        $this->domain = $domain;
     }
 }

--- a/includes/Exceptions/AccessDeniedException.php
+++ b/includes/Exceptions/AccessDeniedException.php
@@ -98,7 +98,7 @@ class AccessDeniedException extends ReadableException
     private function getLogEntry($action, User $user, PdoDatabase $database)
     {
         /** @var Log[] $logs */
-        $logs = LogSearchHelper::get($database)
+        $logs = LogSearchHelper::get($database, null)
             ->byAction($action)
             ->byObjectType('User')
             ->byObjectId($user->getId())

--- a/includes/Fragments/NavigationMenuAccessControl.php
+++ b/includes/Fragments/NavigationMenuAccessControl.php
@@ -122,7 +122,7 @@ trait NavigationMenuAccessControl
         // Count of flagged comments:
         if($this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageListFlaggedComments::class)) {
             // We want all flagged comments that haven't been acknowledged if we can visit the page.
-            $countOfFlagged = sizeof(Comment::getFlaggedComments($database));
+            $countOfFlagged = sizeof(Comment::getFlaggedComments($database, 1)); // FIXME: domains
         }
 
         // Count of failed job queue changes:

--- a/includes/Fragments/NavigationMenuAccessControl.php
+++ b/includes/Fragments/NavigationMenuAccessControl.php
@@ -128,7 +128,7 @@ trait NavigationMenuAccessControl
         // Count of failed job queue changes:
         if($this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageJobQueue::class)) {
             // We want all failed jobs that haven't been acknowledged if we can visit the page.
-            JobQueueSearchHelper::get($database)
+            JobQueueSearchHelper::get($database, 1) // FIXME: domains
                 ->statusIn([JobQueue::STATUS_FAILED])
                 ->notAcknowledged()
                 ->getRecordCount($countOfJobQueue);

--- a/includes/Fragments/RequestData.php
+++ b/includes/Fragments/RequestData.php
@@ -215,7 +215,8 @@ trait RequestData
     {
         $this->assign('canSeeRelatedRequests', true);
 
-        $relatedEmailRequests = RequestSearchHelper::get($database)
+        // TODO: Do we want to return results from other domains?
+        $relatedEmailRequests = RequestSearchHelper::get($database, null)
             ->byEmailAddress($request->getEmail())
             ->withConfirmedEmail()
             ->excludingPurgedData($configuration)
@@ -226,7 +227,9 @@ trait RequestData
         $this->assign('requestRelatedEmailRequests', $relatedEmailRequests);
 
         $trustedIp = $this->getXffTrustProvider()->getTrustedClientIp($request->getIp(), $request->getForwardedIp());
-        $relatedIpRequests = RequestSearchHelper::get($database)
+
+        // TODO: Do we want to return results from other domains?
+        $relatedIpRequests = RequestSearchHelper::get($database, null)
             ->byIp($trustedIp)
             ->withConfirmedEmail()
             ->excludingPurgedData($configuration)

--- a/includes/Fragments/RequestListData.php
+++ b/includes/Fragments/RequestListData.php
@@ -58,14 +58,15 @@ trait RequestListData
                 $request->getForwardedIp()
             );
 
-            RequestSearchHelper::get($this->getDatabase())
+            // TODO: Do we really want to return results from other domains?
+            RequestSearchHelper::get($this->getDatabase(), null)
                 ->byIp($trustedIp)
                 ->withConfirmedEmail()
                 ->excludingPurgedData($this->getSiteConfiguration())
                 ->excludingRequest($request->getId())
                 ->getRecordCount($ipCount);
 
-            RequestSearchHelper::get($this->getDatabase())
+            RequestSearchHelper::get($this->getDatabase(), null)
                 ->byEmailAddress($request->getEmail())
                 ->withConfirmedEmail()
                 ->excludingPurgedData($this->getSiteConfiguration())

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -41,7 +41,8 @@ class LogHelper
      */
     public static function getRequestLogsWithComments($requestId, PdoDatabase $db, SecurityManager $securityManager)
     {
-        $logs = LogSearchHelper::get($db)->byObjectType('Request')->byObjectId($requestId)->fetch();
+        // FIXME: domains
+        $logs = LogSearchHelper::get($db, 1)->byObjectType('Request')->byObjectId($requestId)->fetch();
 
         $currentUser = User::getCurrent($db);
         $showRestrictedComments = $securityManager->allows('RequestData', 'seeRestrictedComments', $currentUser) === SecurityManager::ALLOWED;

--- a/includes/Helpers/Logger.php
+++ b/includes/Helpers/Logger.php
@@ -69,6 +69,12 @@ class Logger
         }
 
         $log = new Log();
+
+        if (method_exists($object, 'getDomain'))
+        {
+            $log->setDomain($object->getDomain());
+        }
+
         $log->setDatabase($database);
         $log->setAction($logAction);
         $log->setObjectId($object->getId());

--- a/includes/Helpers/Logger.php
+++ b/includes/Helpers/Logger.php
@@ -162,8 +162,11 @@ class Logger
      * @param string      $reason
      * @param array       $added
      * @param array       $removed
+     * @param int         $domain
+     *
+     * @throws Exception
      */
-    public static function userRolesEdited(PdoDatabase $database, User $object, $reason, $added, $removed)
+    public static function userRolesEdited(PdoDatabase $database, User $object, $reason, $added, $removed, int $domain)
     {
         $logData = serialize(array(
             'added'   => $added,
@@ -171,7 +174,7 @@ class Logger
             'reason'  => $reason,
         ));
 
-        self::createLogEntry($database, $object, "RoleChange", $logData);
+        self::createLogEntry($database, $object, "RoleChange", $logData, null, $domain);
     }
 
     #endregion

--- a/includes/Helpers/Logger.php
+++ b/includes/Helpers/Logger.php
@@ -48,7 +48,8 @@ class Logger
      * @param DataObject  $object
      * @param string      $logAction
      * @param null|string $comment
-     * @param User        $user
+     * @param User|null   $user
+     * @param int|null    $domain
      *
      * @throws Exception
      */
@@ -57,7 +58,8 @@ class Logger
         DataObject $object,
         $logAction,
         $comment = null,
-        $user = null
+        $user = null,
+        ?int $domain = null
     ) {
         if ($user == null) {
             $user = User::getCurrent($database);
@@ -70,8 +72,10 @@ class Logger
 
         $log = new Log();
 
-        if (method_exists($object, 'getDomain'))
-        {
+        if ($domain !== null) {
+            $log->setDomain($domain);
+        }
+        elseif (method_exists($object, 'getDomain')) {
             $log->setDomain($object->getDomain());
         }
 
@@ -313,25 +317,25 @@ class Logger
     public static function editComment(PdoDatabase $database, Comment $object, Request $request)
     {
         self::createLogEntry($database, $request, "EditComment-r");
-        self::createLogEntry($database, $object, "EditComment-c");
+        self::createLogEntry($database, $object, "EditComment-c", null, null, $request->getDomain());
     }
 
     /**
      * @param PdoDatabase $database
      * @param Comment     $object
      */
-    public static function flaggedComment(PdoDatabase $database, Comment $object)
+    public static function flaggedComment(PdoDatabase $database, Comment $object, int $domain)
     {
-        self::createLogEntry($database, $object, "FlaggedComment");
+        self::createLogEntry($database, $object, "FlaggedComment", null, null, $domain);
     }
 
     /**
      * @param PdoDatabase $database
      * @param Comment     $object
      */
-    public static function unflaggedComment(PdoDatabase $database, Comment $object)
+    public static function unflaggedComment(PdoDatabase $database, Comment $object, int $domain)
     {
-        self::createLogEntry($database, $object, "UnflaggedComment");
+        self::createLogEntry($database, $object, "UnflaggedComment", null, null, $domain);
     }
 
     /**

--- a/includes/Helpers/RequestQueueHelper.php
+++ b/includes/Helpers/RequestQueueHelper.php
@@ -47,6 +47,8 @@ class RequestQueueHelper
     }
 
     /**
+     * Returns true if the specified queue is a target of an enabled email template with a defer action.
+     *
      * @param RequestQueue $queue
      * @param PdoDatabase  $database
      *

--- a/includes/Helpers/RequestQueueHelper.php
+++ b/includes/Helpers/RequestQueueHelper.php
@@ -56,7 +56,7 @@ class RequestQueueHelper
     {
         $isTarget = false;
         /** @var EmailTemplate[] $deferralTemplates */
-        $deferralTemplates = EmailTemplate::getAllActiveTemplates('defer', $database);
+        $deferralTemplates = EmailTemplate::getAllActiveTemplates(EmailTemplate::ACTION_DEFER, $database, $queue->getDomain());
         foreach ($deferralTemplates as $t) {
             if ($t->getQueue() === $queue->getId()) {
                 $isTarget = true;

--- a/includes/Helpers/SearchHelpers/JobQueueSearchHelper.php
+++ b/includes/Helpers/SearchHelpers/JobQueueSearchHelper.php
@@ -20,12 +20,17 @@ class JobQueueSearchHelper extends SearchHelperBase
 
     /**
      * @param PdoDatabase $database
+     * @param int         $domain
      *
      * @return JobQueueSearchHelper
      */
-    public static function get(PdoDatabase $database)
+    public static function get(PdoDatabase $database, int $domain)
     {
         $helper = new JobQueueSearchHelper($database);
+
+        $helper->whereClause .= ' AND domain = ?';
+        $helper->parameterList[] = $domain;
+
         return $helper;
     }
 

--- a/includes/Helpers/SearchHelpers/LogSearchHelper.php
+++ b/includes/Helpers/SearchHelpers/LogSearchHelper.php
@@ -24,15 +24,26 @@ class LogSearchHelper extends SearchHelperBase
     }
 
     /**
-     * Initiates a search for requests
+     * Initiates a search for logs
      *
      * @param PdoDatabase $database
+     * @param int|null $domain The domain to search for. This will retrieve both logs for the specified domain and
+     *                         global logs if a value is specified. If null, only global logs are returned.
      *
      * @return LogSearchHelper
      */
-    public static function get(PdoDatabase $database)
+    public static function get(PdoDatabase $database, ?int $domain)
     {
         $helper = new LogSearchHelper($database);
+
+        if ($domain === null) {
+            $helper->whereClause .= ' AND domain IS NULL';
+        }
+        else {
+            $helper->whereClause .= ' AND coalesce(domain, ?) = ?';
+            $helper->parameterList[] = $domain;
+            $helper->parameterList[] = $domain;
+        }
 
         return $helper;
     }

--- a/includes/Helpers/SearchHelpers/RequestSearchHelper.php
+++ b/includes/Helpers/SearchHelpers/RequestSearchHelper.php
@@ -29,12 +29,18 @@ class RequestSearchHelper extends SearchHelperBase
      * Initiates a search for requests
      *
      * @param PdoDatabase $database
+     * @param int|null    $domain
      *
      * @return RequestSearchHelper
      */
-    public static function get(PdoDatabase $database)
+    public static function get(PdoDatabase $database, ?int $domain)
     {
         $helper = new RequestSearchHelper($database);
+
+        if ($domain !== null) {
+            $helper->whereClause .= ' AND domain = ?';
+            $helper->parameterList[] = $domain;
+        }
 
         return $helper;
     }

--- a/includes/Pages/PageDomainManagement.php
+++ b/includes/Pages/PageDomainManagement.php
@@ -150,7 +150,11 @@ class PageDomainManagement extends InternalPageBase
         else {
             $this->assignCSRFToken();
 
-            $templates = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_CREATED, $database, $domain->getId());
+            $templates = EmailTemplate::getActiveNonpreloadTemplates(
+                EmailTemplate::ACTION_CREATED,
+                $database,
+                $domain->getId());
+
             $this->assign('closeTemplates', $templates);
 
             $this->assign('shortName', $domain->getShortName());

--- a/includes/Pages/PageDomainManagement.php
+++ b/includes/Pages/PageDomainManagement.php
@@ -122,9 +122,10 @@ class PageDomainManagement extends InternalPageBase
             $domain->setDefaultLanguage(WebRequest::postString('defaultLanguage'));
             $domain->setLocalDocumentation(WebRequest::postString('localDocumentation'));
 
-            /** @var EmailTemplate $template */
+            /** @var EmailTemplate|false $template */
             $template = EmailTemplate::getById(WebRequest::postInt('defaultClose'), $database);
-            if ($template->getActive()
+            if ($template !== false
+                && $template->getActive()
                 && $template->getPreloadOnly() === false
                 && $template->getDefaultAction() === EmailTemplate::ACTION_CREATED) {
                 $domain->setDefaultClose(WebRequest::postInt('defaultClose'));
@@ -149,7 +150,7 @@ class PageDomainManagement extends InternalPageBase
         else {
             $this->assignCSRFToken();
 
-            $templates = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_CREATED, $database);
+            $templates = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_CREATED, $database, $domain->getId());
             $this->assign('closeTemplates', $templates);
 
             $this->assign('shortName', $domain->getShortName());

--- a/includes/Pages/PageEmailManagement.php
+++ b/includes/Pages/PageEmailManagement.php
@@ -30,8 +30,9 @@ class PageEmailManagement extends InternalPageBase
         $this->setHtmlTitle('Close Emails');
 
         // Get all active email templates
-        $activeTemplates = EmailTemplate::getAllActiveTemplates(null, $this->getDatabase());
-        $inactiveTemplates = EmailTemplate::getAllInactiveTemplates($this->getDatabase());
+        // FIXME: domains!
+        $activeTemplates = EmailTemplate::getAllActiveTemplates(null, $this->getDatabase(), 1);
+        $inactiveTemplates = EmailTemplate::getAllInactiveTemplates($this->getDatabase(), 1);
 
         $this->assign('activeTemplates', $activeTemplates);
         $this->assign('inactiveTemplates', $inactiveTemplates);
@@ -101,7 +102,7 @@ class PageEmailManagement extends InternalPageBase
 
             $this->modifyTemplateData($template);
 
-            $other = EmailTemplate::getByName($template->getName(), $database);
+            $other = EmailTemplate::getByName($template->getName(), $database, $domain->getId());
             if ($other !== false && $other->getId() !== $template->getId()) {
                 throw new ApplicationLogicException('A template with this name already exists');
             }
@@ -192,9 +193,12 @@ class PageEmailManagement extends InternalPageBase
             $template = new EmailTemplate();
             $template->setDatabase($database);
 
+            // FIXME: domains!
+            $template->setDomain(1);
+
             $this->modifyTemplateData($template);
 
-            $other = EmailTemplate::getByName($template->getName(), $database);
+            $other = EmailTemplate::getByName($template->getName(), $database, $template->getDomain());
             if ($other !== false) {
                 throw new ApplicationLogicException('A template with this name already exists');
             }

--- a/includes/Pages/PageExpandedRequestList.php
+++ b/includes/Pages/PageExpandedRequestList.php
@@ -49,7 +49,8 @@ class PageExpandedRequestList extends InternalPageBase
 
         $this->assign('queuehelp', $queue->getHelp());
 
-        $search = RequestSearchHelper::get($database);
+        // FIXME: domains
+        $search = RequestSearchHelper::get($database, 1);
         $search->byStatus(RequestStatus::OPEN);
 
         list($defaultSort, $defaultSortDirection) = WebRequest::requestListDefaultSort();

--- a/includes/Pages/PageFlagComment.php
+++ b/includes/Pages/PageFlagComment.php
@@ -9,6 +9,7 @@
 namespace Waca\Pages;
 
 use Waca\DataObjects\Comment;
+use Waca\DataObjects\Request;
 use Waca\DataObjects\User;
 use Waca\Exceptions\AccessDeniedException;
 use Waca\Exceptions\ApplicationLogicException;
@@ -54,11 +55,14 @@ class PageFlagComment extends InternalPageBase
         $comment->setUpdateVersion($updateVersion);
         $comment->save();
 
+        /** @var Request $request */
+        $request = Request::getById($comment->getRequest(), $database);
+
         if ($flagState === 1) {
-            Logger::flaggedComment($database, $comment);
+            Logger::flaggedComment($database, $comment, $request->getDomain());
         }
         else {
-            Logger::unflaggedComment($database, $comment);
+            Logger::unflaggedComment($database, $comment, $request->getDomain());
         }
 
         if (WebRequest::postString('return') == 'list') {

--- a/includes/Pages/PageJobQueue.php
+++ b/includes/Pages/PageJobQueue.php
@@ -41,8 +41,15 @@ class PageJobQueue extends PagedInternalPageBase
         $database = $this->getDatabase();
 
         /** @var JobQueue[] $jobList */
-        $jobList = JobQueueSearchHelper::get($database)
-            ->statusIn(array('queued', 'ready', 'waiting', 'running', 'failed'))
+        // FIXME: domains
+        $jobList = JobQueueSearchHelper::get($database, 1)
+            ->statusIn([
+                JobQueue::STATUS_QUEUED,
+                JobQueue::STATUS_READY,
+                JobQueue::STATUS_WAITING,
+                JobQueue::STATUS_RUNNING,
+                JobQueue::STATUS_FAILED,
+            ])
             ->notAcknowledged()
             ->fetch();
 
@@ -73,7 +80,8 @@ class PageJobQueue extends PagedInternalPageBase
 
         $database = $this->getDatabase();
 
-        $searchHelper = JobQueueSearchHelper::get($database);
+        // FIXME: domains
+        $searchHelper = JobQueueSearchHelper::get($database, 1);
         $this->setSearchHelper($searchHelper);
         $this->setupLimits();
 

--- a/includes/Pages/PageJobQueue.php
+++ b/includes/Pages/PageJobQueue.php
@@ -172,7 +172,8 @@ class PageJobQueue extends PagedInternalPageBase
         $this->assign('parent', JobQueue::getById($job->getParent(), $database));
 
         /** @var Log[] $logs */
-        $logs = LogSearchHelper::get($database)->byObjectType('JobQueue')
+        // FIXME: domains
+        $logs = LogSearchHelper::get($database, 1)->byObjectType('JobQueue')
             ->byObjectId($job->getId())->getRecordCount($logCount)->fetch();
         if ($logCount === 0) {
             $this->assign('log', array());

--- a/includes/Pages/PageJobQueue.php
+++ b/includes/Pages/PageJobQueue.php
@@ -66,7 +66,8 @@ class PageJobQueue extends PagedInternalPageBase
         $this->assign('canSeeAll', $this->barrierTest('all', User::getCurrent($database)));
 
         $this->assign('users', UserSearchHelper::get($database)->inIds($userIds)->fetchMap('username'));
-        $this->assign('requests', RequestSearchHelper::get($database)->inIds($requestIds)->fetchMap('name'));
+        // FIXME: domains
+        $this->assign('requests', RequestSearchHelper::get($database, 1)->inIds($requestIds)->fetchMap('name'));
 
         $this->assign('joblist', $jobList);
         $this->setTemplate('jobqueue/main.tpl');
@@ -137,7 +138,8 @@ class PageJobQueue extends PagedInternalPageBase
         });
 
         $this->assign('users', UserSearchHelper::get($database)->inIds($userIds)->fetchMap('username'));
-        $this->assign('requests', RequestSearchHelper::get($database)->inIds($requestIds)->fetchMap('name'));
+        // FIXME: domains!
+        $this->assign('requests', RequestSearchHelper::get($database, 1)->inIds($requestIds)->fetchMap('name'));
 
         $this->assign('joblist', $jobList);
 

--- a/includes/Pages/PageListFlaggedComments.php
+++ b/includes/Pages/PageListFlaggedComments.php
@@ -29,7 +29,7 @@ class PageListFlaggedComments extends InternalPageBase
         $this->assignCSRFToken();
 
         /** @var Comment[] $commentObjects */
-        $commentObjects = Comment::getFlaggedComments($database);
+        $commentObjects = Comment::getFlaggedComments($database, 1); // FIXME: domains
         $comments = [];
 
         $currentUser = User::getCurrent($database);

--- a/includes/Pages/PageLog.php
+++ b/includes/Pages/PageLog.php
@@ -37,7 +37,8 @@ class PageLog extends PagedInternalPageBase
 
         $this->addJs("/api.php?action=users&all=true&targetVariable=typeaheaddata");
 
-        $logSearch = LogSearchHelper::get($database);
+        // FIXME: domains
+        $logSearch = LogSearchHelper::get($database, 1);
 
         if ($filterUser !== null) {
             $userObj = User::getByUsername($filterUser, $database);

--- a/includes/Pages/PageMain.php
+++ b/includes/Pages/PageMain.php
@@ -102,7 +102,8 @@ SQL;
         SiteConfiguration $config,
         &$requestSectionData
     ) {
-        $search = RequestSearchHelper::get($database)
+        // FIXME: domains!
+        $search = RequestSearchHelper::get($database, 1)
             ->limit($config->getMiserModeLimit())
             ->excludingStatus('Closed')
             ->isHospitalised();
@@ -137,7 +138,8 @@ SQL;
         SiteConfiguration $config,
         &$requestSectionData
     ) {
-        $search = RequestSearchHelper::get($database)
+        // FIXME: domains!
+        $search = RequestSearchHelper::get($database, 1)
             ->limit($config->getMiserModeLimit())
             ->byStatus(RequestStatus::JOBQUEUE);
 
@@ -171,7 +173,8 @@ SQL;
         SiteConfiguration $config,
         &$requestSectionData
     ) {
-        $search = RequestSearchHelper::get($database)->limit($config->getMiserModeLimit());
+        // FIXME: domains!
+        $search = RequestSearchHelper::get($database, 1)->limit($config->getMiserModeLimit());
         $search->byStatus(RequestStatus::OPEN);
 
         if ($config->getEmailConfirmationEnabled()) {

--- a/includes/Pages/PageSearch.php
+++ b/includes/Pages/PageSearch.php
@@ -59,7 +59,8 @@ class PageSearch extends PagedInternalPageBase
                 $formParameters['excludeNonConfirmed'] = true;
             }
 
-            $requestSearch = RequestSearchHelper::get($database);
+            // FIXME: domains
+            $requestSearch = RequestSearchHelper::get($database, 1);
             $this->setSearchHelper($requestSearch);
             $this->setupLimits();
 

--- a/includes/Pages/PageUserManagement.php
+++ b/includes/Pages/PageUserManagement.php
@@ -120,7 +120,7 @@ class PageUserManagement extends InternalPageBase
             throw new ApplicationLogicException('Sorry, the user you are trying to edit could not be found.');
         }
 
-        $roleData = $this->getRoleData(UserRole::getForUser($user->getId(), $database));
+        $roleData = $this->getRoleData(UserRole::getForUser($user->getId(), $database, 1)); // FIXME: domains
 
         // Dual-mode action
         if (WebRequest::wasPosted()) {
@@ -174,11 +174,12 @@ class PageUserManagement extends InternalPageBase
                 $a = new UserRole();
                 $a->setUser($user->getId());
                 $a->setRole($x);
+                $a->setDomain(1); // FIXME: domains
                 $a->setDatabase($database);
                 $a->save();
             }
 
-            Logger::userRolesEdited($database, $user, $reason, $add, $removed);
+            Logger::userRolesEdited($database, $user, $reason, $add, $removed, 1); // FIXME: domains
 
             // dummy save for optimistic locking. If this fails, the entire txn will roll back.
             $user->setUpdateVersion(WebRequest::postInt('updateversion'));

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -187,16 +187,16 @@ class PageViewRequest extends InternalPageBase
         $this->assign('skipJsAborts', $skipJsAborts);
         $this->assign('preferredCreationMode', $preferredCreationMode);
 
-        $createReasons = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_CREATED, $database, $domain->getDefaultClose());
+        $createReasons = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_CREATED, $database, $domain->getId(), $domain->getDefaultClose());
         $this->assign("createReasons", $createReasons);
-        $declineReasons = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_NOT_CREATED, $database);
+        $declineReasons = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_NOT_CREATED, $database, $domain->getId());
         $this->assign("declineReasons", $declineReasons);
 
-        $allCreateReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::ACTION_CREATED, $database);
+        $allCreateReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::ACTION_CREATED, $database, $domain->getId());
         $this->assign("allCreateReasons", $allCreateReasons);
-        $allDeclineReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::ACTION_NOT_CREATED, $database);
+        $allDeclineReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::ACTION_NOT_CREATED, $database, $domain->getId());
         $this->assign("allDeclineReasons", $allDeclineReasons);
-        $allOtherReasons = EmailTemplate::getAllActiveTemplates(false, $database);
+        $allOtherReasons = EmailTemplate::getAllActiveTemplates(false, $database, $domain->getId());
         $this->assign("allOtherReasons", $allOtherReasons);
     }
 

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -33,6 +33,7 @@ use Waca\WebRequest;
 class PageViewRequest extends InternalPageBase
 {
     use RequestData;
+
     const STATUS_SYMBOL_OPEN = '&#927';
     const STATUS_SYMBOL_ACCEPTED = '&#x2611';
     const STATUS_SYMBOL_REJECTED = '&#x2612';
@@ -113,12 +114,12 @@ class PageViewRequest extends InternalPageBase
         }
 
         $this->assign('canCreateLocalAccount', $this->barrierTest('createLocalAccount', $currentUser, 'RequestData'));
-            
+
         $closureDate = $request->getClosureDate();
         $date = new DateTime();
         $date->modify("-7 days");
         if ($request->getStatus() == "Closed" && $closureDate < $date) {
-                $this->assign('isOldRequest', true);
+            $this->assign('isOldRequest', true);
         }
         $this->assign('canResetOldRequest', $this->barrierTest('reopenOldRequest', $currentUser, 'RequestData'));
         $this->assign('canResetPurgedRequest', $this->barrierTest('reopenClearedRequest', $currentUser, 'RequestData'));
@@ -187,16 +188,35 @@ class PageViewRequest extends InternalPageBase
         $this->assign('skipJsAborts', $skipJsAborts);
         $this->assign('preferredCreationMode', $preferredCreationMode);
 
-        $createReasons = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_CREATED, $database, $domain->getId(), $domain->getDefaultClose());
+        $createReasons = EmailTemplate::getActiveNonpreloadTemplates(
+            EmailTemplate::ACTION_CREATED,
+            $database,
+            $domain->getId(),
+            $domain->getDefaultClose());
         $this->assign("createReasons", $createReasons);
-        $declineReasons = EmailTemplate::getActiveNonpreloadTemplates(EmailTemplate::ACTION_NOT_CREATED, $database, $domain->getId());
+
+        $declineReasons = EmailTemplate::getActiveNonpreloadTemplates(
+            EmailTemplate::ACTION_NOT_CREATED,
+            $database,
+            $domain->getId());
         $this->assign("declineReasons", $declineReasons);
 
-        $allCreateReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::ACTION_CREATED, $database, $domain->getId());
+        $allCreateReasons = EmailTemplate::getAllActiveTemplates(
+            EmailTemplate::ACTION_CREATED,
+            $database,
+            $domain->getId());
         $this->assign("allCreateReasons", $allCreateReasons);
-        $allDeclineReasons = EmailTemplate::getAllActiveTemplates(EmailTemplate::ACTION_NOT_CREATED, $database, $domain->getId());
+
+        $allDeclineReasons = EmailTemplate::getAllActiveTemplates(
+            EmailTemplate::ACTION_NOT_CREATED,
+            $database,
+            $domain->getId());
         $this->assign("allDeclineReasons", $allDeclineReasons);
-        $allOtherReasons = EmailTemplate::getAllActiveTemplates(false, $database, $domain->getId());
+
+        $allOtherReasons = EmailTemplate::getAllActiveTemplates(
+            false,
+            $database,
+            $domain->getId());
         $this->assign("allOtherReasons", $allOtherReasons);
     }
 

--- a/includes/Pages/PageWelcomeTemplateManagement.php
+++ b/includes/Pages/PageWelcomeTemplateManagement.php
@@ -29,7 +29,7 @@ class PageWelcomeTemplateManagement extends InternalPageBase
     protected function main()
     {
         $database = $this->getDatabase();
-        $templateList = WelcomeTemplate::getAll($database);
+        $templateList = WelcomeTemplate::getAll($database, 1); // FIXME: domains
         $preferenceManager = PreferenceManager::getForCurrent($database);
 
         $this->setHtmlTitle('Welcome Templates');
@@ -156,6 +156,7 @@ class PageWelcomeTemplateManagement extends InternalPageBase
             $template->setDatabase($database);
             $template->setUserCode($userCode);
             $template->setBotCode($botCode);
+            $template->setDomain(1); // FIXME: domains!
             $template->save();
 
             Logger::welcomeTemplateCreated($database, $template);

--- a/includes/Pages/Registration/PageRegisterBase.php
+++ b/includes/Pages/Registration/PageRegisterBase.php
@@ -228,11 +228,12 @@ abstract class PageRegisterBase extends InternalPageBase
         $role->setDatabase($database);
         $role->setUser($user->getId());
         $role->setRole($defaultRole);
+        $role->setDomain($domainObject->getId()); // FIXME: domains
         $role->save();
 
         // Log now to get the signup date.
         Logger::newUser($database, $user);
-        Logger::userRolesEdited($database, $user, 'Registration', array($defaultRole), array());
+        Logger::userRolesEdited($database, $user, 'Registration', array($defaultRole), array(), $domainObject->getId());
 
         $userDomain = new UserDomain();
         $userDomain->setDatabase($database);

--- a/includes/Pages/Request/PageRequestAccount.php
+++ b/includes/Pages/Request/PageRequestAccount.php
@@ -114,6 +114,7 @@ class PageRequestAccount extends PublicInterfacePageBase
 
         $request->setQueue(RequestQueue::getDefaultQueue($database, $domain)->getId());
         $request->setDatabase($database);
+        $request->setDomain($domain);
 
         $request->setName(trim(WebRequest::postString('name')));
         $request->setEmail(WebRequest::postEmail('email'));

--- a/includes/Pages/RequestAction/PageCreateRequest.php
+++ b/includes/Pages/RequestAction/PageCreateRequest.php
@@ -174,6 +174,7 @@ class PageCreateRequest extends RequestActionBase
         }
 
         $creationTask = new JobQueue();
+        $creationTask->setDomain(1); // FIXME: domains!
         $creationTask->setTask($creationTaskClass);
         $creationTask->setRequest($request->getId());
         $creationTask->setEmailTemplate($template->getId());

--- a/includes/Pages/RequestAction/PageCustomClose.php
+++ b/includes/Pages/RequestAction/PageCustomClose.php
@@ -409,6 +409,7 @@ class PageCustomClose extends PageCloseRequest
         ];
 
         $creationTask = new JobQueue();
+        $creationTask->setDomain(1); // FIXME: domains!
         $creationTask->setTask($creationTaskClass);
         $creationTask->setRequest($request->getId());
         $creationTask->setTriggerUserId($currentUser->getId());

--- a/includes/Pages/RequestAction/PageDeferRequest.php
+++ b/includes/Pages/RequestAction/PageDeferRequest.php
@@ -68,11 +68,15 @@ class PageDeferRequest extends RequestActionBase
 
         if ($request->getStatus() === RequestStatus::JOBQUEUE) {
             /** @var JobQueue[] $pendingJobs */
-            $pendingJobs = JobQueueSearchHelper::get($database)->byRequest($request->getId())->statusIn([
-                JobQueue::STATUS_QUEUED,
-                JobQueue::STATUS_READY,
-                JobQueue::STATUS_WAITING,
-            ])->fetch();
+            // FIXME: domains
+            $pendingJobs = JobQueueSearchHelper::get($database, 1)
+                ->byRequest($request->getId())
+                ->statusIn([
+                    JobQueue::STATUS_QUEUED,
+                    JobQueue::STATUS_READY,
+                    JobQueue::STATUS_WAITING,
+                ])
+                ->fetch();
 
             foreach ($pendingJobs as $job) {
                 $job->setStatus(JobQueue::STATUS_CANCELLED);

--- a/includes/Pages/RequestAction/RequestActionBase.php
+++ b/includes/Pages/RequestAction/RequestActionBase.php
@@ -62,6 +62,7 @@ abstract class RequestActionBase extends InternalPageBase
     protected function enqueueWelcomeTask(Request $request, $parentTaskId, User $user, PdoDatabase $database)
     {
         $welcomeTask = new JobQueue();
+        $welcomeTask->setDomain(1); // FIXME: domains!
         $welcomeTask->setTask(WelcomeUserTask::class);
         $welcomeTask->setRequest($request->getId());
         $welcomeTask->setParent($parentTaskId);

--- a/includes/Pages/Statistics/StatsUsers.php
+++ b/includes/Pages/Statistics/StatsUsers.php
@@ -121,7 +121,7 @@ SQL
         $this->assign("notcreated", $usersNotCreated);
 
         /** @var Log[] $logs */
-        $logs = LogSearchHelper::get($database)
+        $logs = LogSearchHelper::get($database, null)
             ->byObjectType('User')
             ->byObjectId($user->getId())
             ->getRecordCount($logCount)

--- a/includes/Security/SecurityManager.php
+++ b/includes/Security/SecurityManager.php
@@ -179,7 +179,7 @@ final class SecurityManager
             $userRoles[] = 'loggedIn';
 
             if ($user->isActive()) {
-                $ur = UserRole::getForUser($user->getId(), $user->getDatabase());
+                $ur = UserRole::getForUser($user->getId(), $user->getDatabase(), 1); // FIXME: domains
 
                 // NOTE: public is still in this array.
                 foreach ($ur as $r) {

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -19,7 +19,7 @@ class SiteConfiguration
 {
     private $baseUrl;
     private $filePath;
-    private $schemaVersion = 44;
+    private $schemaVersion = 45;
     private $debuggingTraceEnabled;
     private $debuggingCssBreakpointsEnabled;
     private $dataClearIp = '127.0.0.1';

--- a/sql/patches/patch45-domain-columns.sql
+++ b/sql/patches/patch45-domain-columns.sql
@@ -1,0 +1,92 @@
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
+DELIMITER ';;'
+CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
+    -- -------------------------------------------------------------------------
+    -- Developers - set the number of the schema patch here!
+    -- -------------------------------------------------------------------------
+    DECLARE patchversion INT DEFAULT 45;
+    -- -------------------------------------------------------------------------
+    -- working variables
+    DECLARE currentschemaversion INT DEFAULT 0;
+    DECLARE lastversion INT;
+
+    -- check the schema has a version table
+    IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'schemaversion' AND table_schema = DATABASE()) THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please ensure patches are run in order! This database does not have a schemaversion table.';
+    END IF;
+
+    -- get the current version
+    SELECT version INTO currentschemaversion FROM schemaversion;
+
+    -- check schema is not ahead of this patch
+    IF currentschemaversion >= patchversion THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'This patch has already been applied!';
+    END IF;
+
+    -- check schema is up-to-date
+    SET lastversion = patchversion - 1;
+    IF currentschemaversion != lastversion THEN
+        SET @message_text = CONCAT('Please ensure patches are run in order! This patch upgrades to version ', patchversion, ', but the database is not version ', lastversion);
+        SIGNAL SQLSTATE '45000' SET message_text = @message_text;
+    END IF;
+
+    -- -------------------------------------------------------------------------
+    -- Developers - put your upgrade statements here!
+    -- -------------------------------------------------------------------------
+
+    -- Add new column and foreign keys
+    ALTER TABLE request
+        ADD COLUMN domain INT UNSIGNED NULL,
+        ADD CONSTRAINT request_fk_domain_domain FOREIGN KEY (domain) REFERENCES domain (id) ON DELETE CASCADE;
+    ALTER TABLE emailtemplate
+        ADD COLUMN domain INT UNSIGNED NULL,
+        ADD CONSTRAINT emailtemplate_fk_domain_domain FOREIGN KEY (domain) REFERENCES domain (id) ON DELETE CASCADE;
+    ALTER TABLE welcometemplate
+        ADD COLUMN domain INT UNSIGNED NULL,
+        ADD CONSTRAINT welcometemplate_fk_domain_domain FOREIGN KEY (domain) REFERENCES domain (id) ON DELETE CASCADE;
+    ALTER TABLE userrole
+        ADD COLUMN domain INT UNSIGNED NULL,
+        ADD CONSTRAINT userrole_fk_domain_domain FOREIGN KEY (domain) REFERENCES domain (id) ON DELETE CASCADE;
+    ALTER TABLE log
+        ADD COLUMN domain INT UNSIGNED NULL,
+        ADD CONSTRAINT log_fk_domain_domain FOREIGN KEY (domain) REFERENCES domain (id) ON DELETE CASCADE;
+    ALTER TABLE jobqueue
+        ADD COLUMN domain INT UNSIGNED NULL,
+        ADD CONSTRAINT jobqueue_fk_domain_domain FOREIGN KEY (domain) REFERENCES domain (id) ON DELETE CASCADE;
+
+    -- Update unique indexes
+    ALTER TABLE emailtemplate
+        DROP KEY name,
+        ADD CONSTRAINT emailtemplate_uidx_domain_name UNIQUE (domain, name);
+    ALTER TABLE userrole
+        DROP KEY userrole_user_role_uindex,
+        ADD CONSTRAINT userrole_uidx_user_role_domain UNIQUE (user, role, domain);
+
+    -- Populate column
+    UPDATE request SET domain = 1;
+    UPDATE emailtemplate SET domain = 1;
+    UPDATE welcometemplate SET domain = 1;
+    UPDATE userrole SET domain = 1;
+    UPDATE log SET domain = 1
+        WHERE objecttype IN (
+            'Comment', 'EmailTemplate', 'JobQueue', 'Request', 'RequestForm', 'RequestQueue', 'WelcomeTemplate'
+        );
+    UPDATE log SET domain = 1 WHERE action = 'RoleChange' AND objecttype = 'User';
+    UPDATE jobqueue SET domain = 1;
+
+    -- Mark as not nullable
+    ALTER TABLE request MODIFY COLUMN domain INT UNSIGNED NOT NULL;
+    ALTER TABLE emailtemplate MODIFY COLUMN domain INT UNSIGNED NOT NULL;
+    ALTER TABLE welcometemplate MODIFY COLUMN domain INT UNSIGNED NOT NULL;
+    ALTER TABLE userrole MODIFY COLUMN domain INT UNSIGNED NOT NULL;
+    -- Skip log table; some rows can have a null domain for globally-relevant log entries.
+    ALTER TABLE jobqueue MODIFY COLUMN domain INT UNSIGNED NOT NULL;
+
+    -- -------------------------------------------------------------------------
+    -- finally, update the schema version to indicate success
+    # noinspection SqlWithoutWhere
+    UPDATE schemaversion SET version = patchversion;
+END;;
+DELIMITER ';'
+CALL SCHEMA_UPGRADE_SCRIPT();
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;


### PR DESCRIPTION
For proper segregation of the different domains, we need to be able to mark which domain certain database rows belong to.

For the time being, this means:
* `requestqueue` (column already present from #590 and #601)
* `requestform` (column already present from #590 and #604)
* `userpreference` (column already present from #594)
* `emailtemplate`
* `welcometemplate`
* `log`
* `userrole`
* `jobqueue`
* `request`
* `requestdata` (not done as request data are strongly linked to a request, which is domain-filtered)
* `comment` (not done as comments are strongly linked to a request, which is domain-filtered)
* `sitenotice` (this needs a major overhaul; too much for this PR)
* `userdomain` (column already present from #590)

<details>
<summary>Tables not included</summary>

The `domain` parent table itself

The `ban` table, since bans should probably act globally such that a user can't just go to a different wiki's domain and request an account there.

Various cache tables:
* `antispoofcache`
* `geolocation`
* `idcache`
* `rdnscache`
* `tornodecache`
* `xfftrustcache`

User data tables (bound to domains via `userdomain` and `userrole`):
* `user`
* `oauthidentity`
* `oauthtoken`
* `credential`

Read-only lookups and internal tables
* `applicationlog` (debug logging table)
* `netmask` (IP CIDR lookup table)
* `schemaversion` (database version detection)
</details>

There's two parts to this change; adding the column, then making use of the column by populating it and including it in searches.

For the most part, we're still hard-coding domain ID 1 everywhere. This is intentional, and will be resolved by #600 

Fixes #599