### PR TITLE
Docker updates: Debian bookworm, PHP 8.2, and DB, plus MariaDB improvement in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,15 @@ jobs:
         mysql database: 'waca'
         mysql user: 'waca'
         mysql password: ${{ secrets.DatabasePassword }}
+
+    - name: Wait for MariaDB
+      run: |
+        while ! mysqladmin ping -h127.0.0.1 --silent; do
+          sleep 1
+        done
     
     - name: Test database build
       run: |
-        sleep 5
         sql/test_db.sh --ci
       env:
         MYSQL_HOST: 127.0.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache-bullseye
+FROM php:8.2-apache-bookworm
 
 ENV DEBIAN_FRONTEND="noninteractive"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
+      # - composer-vendor:/var/www/html/vendor  # Uncomment if experiencing font-awesome issues. See docker/README.md.
       - .:/var/www/html/
     ports:
       - "8080:80"
@@ -41,5 +42,6 @@ services:
       - "8081:8080" # HTTP web interface to view received emails
 
 volumes:
+  # composer-vendor:  # Uncomment if experiencing font-awesome issues. See docker/README.md.
   mysql-data:
   rabbitmq-data:

--- a/docker/README.md
+++ b/docker/README.md
@@ -89,15 +89,15 @@ images are re-downloaded and an Internet connection will be required.
 Sometimes, when the application container starts, the Composer install step will fail with a cryptic error message about
 being unable to delete files, usually in relation to the Font-Awesome package. This is due to a timeout; the package
 contains _lots and lots_ of tiny files. While using a shared Docker volume for the application is convenient (this is
-what allows changes to be made to the local repo to be immediately reflected in the container and vice-versa), there is
-a large performance penalty, especially on Windows and macOS.
+what allows changes made to the local repo to be immediately reflected in the container and vice-versa), there is a 
+large performance penalty, especially on Windows and macOS.
 
 You should try simply restarting the service, but if that doesn't work, here are a couple ways this can be resolved:
 
 1. If you can install a matching version of PHP locally, you can also install Composer and run `composer install` in
    your local repo before running `docker compose up`. The container will detect the pre-installed dependencies and not
    need to install them again.
-2. In `docker-compose.yml`, uncomment the `- composer-vendor:/var/www/html/vendor` line under
+2. In `/docker-compose.yml`, uncomment the `- composer-vendor:/var/www/html/vendor` line under
    `services.application.volumes` **and** the corresponding volume line near the bottom of the file. This will prevent
    the container from using the shared volume for the vendor directory, which will speed up Composer installs within the
    container. However, the Composer packages installed in the container will not be made available to the local repo, so

--- a/docker/database.sh
+++ b/docker/database.sh
@@ -1,4 +1,10 @@
 #!/bin/bash -x
 
-cd /wacadb
-./test_db.sh 1 localhost ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD}
+cd /wacadb || { echo "Failed to cd to /wacadb"; exit 1; }
+
+# Set env vars needed by the test_db.sh script. Note that the MYSQL_USER and MYSQL_PASSWORD env vars are set by the
+# docker-compose.yml file and passed through to test_db.sh.
+export MYSQL_HOST="localhost"
+export MYSQL_SCHEMA="${MYSQL_DATABASE}"  # Compatibility shim
+
+./test_db.sh --ci --create


### PR DESCRIPTION
## Description
Makes the following updates to the Docker configuration:
- Updates Debian to bookworm
- Updates PHP to version 8.2
- Updates the database seed script for the new test_db.sh parameters

In addition, adds some notes to the Docker README for what to do if you run into font-awesome installation issues (which I did a couple of times).

Also adds a step to the GitHub Actions CI to wait for MariaDB to become available before continuing, as opposed to a somewhat-unreliable `sleep 5`.

Resolves #827.

## Testing
- Blew away local Docker and ran `docker compose up` from scratch as-committed (i.e., with the `composer-vendor` workaround commented out)
    - Confirmed that database seeds correctly
    - Confirmed that `package-lock.json` no longer gets changed
    - Confirmed that able to submit new requests and log in to ACC
    - Emails are delivered to the mailsink as expected, and messages are delivered to RabbitMQ as expected
    - Remote debugging with XDebug works as expected
- Blew away lock Docker and re-ran with the `composer-vendor` volume workaround uncommented
    - Able to log in to ACC
    - Confirmed that installed dependencies persist through restarts, even when using `docker compose down`, as long as the named volume isn't deleted
    - Also confirmed that this is much more performant so it is a viable workaround if needed