### PR TITLE
In-tool documentation tweaks about passwords

### DIFF
--- a/includes/Pages/UserAuth/MultiFactor/PageMultiFactor.php
+++ b/includes/Pages/UserAuth/MultiFactor/PageMultiFactor.php
@@ -216,7 +216,7 @@ class PageMultiFactor extends InternalPageBase
 
             $this->assignCSRFToken();
 
-            $this->assign('alertmessage', 'To enable your multi-factor credentials, please prove you are who you say you are by providing the information below.');
+            $this->assign('alertmessage', 'To enable your multi-factor credentials, please prove you are who you say you are by providing your tool password below.');
             $this->assign('alertheader', 'Provide credentials');
             $this->assign('continueText', 'Verify password');
             $this->setTemplate('mfa/enableAuth.tpl');
@@ -267,7 +267,7 @@ class PageMultiFactor extends InternalPageBase
         else {
             $this->assignCSRFToken();
 
-            $this->assign('alertmessage', 'To regenerate your emergency scratch tokens, please prove you are who you say you are by providing the information below. Note that continuing will invalidate all remaining scratch tokens, and provide a set of new ones.');
+            $this->assign('alertmessage', 'To regenerate your emergency scratch tokens, please prove you are who you say you are by providing your tool password below. Note that continuing will invalidate all remaining scratch tokens, and provide a set of new ones.');
             $this->assign('alertheader', 'Re-generate scratch tokens');
             $this->assign('continueText', 'Regenerate Scratch Tokens');
 

--- a/templates/mfa/disableOtp.tpl
+++ b/templates/mfa/disableOtp.tpl
@@ -13,7 +13,7 @@
                 <div class="card-body p-4">
                     <form method="post">
                         {include file="security/csrf.tpl"}
-                        {include file="alert.tpl" alertblock="true" alerttype="alert-danger" alertclosable=false alertheader="Provide credentials" alertmessage="To disable your {$otpType|escape} multi-factor credentials, please prove you are who you say you are by providing the information below."}
+                        {include file="alert.tpl" alertblock="true" alerttype="alert-danger" alertclosable=false alertheader="Provide credentials" alertmessage="To disable your {$otpType|escape} multi-factor credentials, please prove you are who you say you are by providing your tool password below."}
                         <div class="form-group row">
                             <div class="col">
                                 <label class="sr-only" for="password">Password</label>

--- a/templates/mfa/enableYubikey.tpl
+++ b/templates/mfa/enableYubikey.tpl
@@ -14,7 +14,7 @@
                 <div class="card-body p-4">
                     <form method="post">
                         {include file="security/csrf.tpl"}
-                        {include file="alert.tpl" alertblock="true" alerttype="alert-info" alertclosable=false alertheader="Provide credentials" alertmessage="To enable your YubiKey OTP multi-factor credentials, please prove you are who you say you are by providing the information below."}
+                        {include file="alert.tpl" alertblock="true" alerttype="alert-info" alertclosable=false alertheader="Provide credentials" alertmessage="To enable your YubiKey OTP multi-factor credentials, please prove you are who you say you are by providing your tool password below."}
                         <div class="form-group row">
                             <div class="col">
                                 <label class="sr-only" for="password">Password</label>

--- a/templates/preferences/changePassword.tpl
+++ b/templates/preferences/changePassword.tpl
@@ -8,41 +8,40 @@
         </div>
     </div>
 
-    <form method="post" class="password-form">
-        {include file="security/csrf.tpl"}
+    <div class="row">
+        <div class="col-xl-4 offset-xl-4 col-lg-6 offset-lg-3 col-md-8 offset-md-2">
+            <div class="card mb-5" id="loginCredentialForm">
+                <div class="card-body p-4">
+                    <h4>Change password</h4>
+                    <p>To change your password, please enter your current password and desired new password below.</p>
+                    {include file="alert.tpl" alertblock="true" alerttype="alert-warning" alertclosable=false alertheader="" alertmessage="Use of your Wikimedia credentials is highly discouraged in this tool. You should use a different password for your account than you would on projects like Wikipedia, Wikimedia Commons, etc."}
 
-        <div class="form-group row">
-            <div class="col-md-3 col-lg-2">
-                <label class="col-form-label" for="inputOldpassword">Your old password</label>
-            </div>
-            <div class="col-md-6 col-lg-4 col-xl-3">
-                <input class="form-control" type="password" id="inputOldpassword" name="oldpassword" required="required" autocomplete="password"/>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 col-lg-2">
-                <label class="col-form-label" for="inputNewpassword">Your new password</label>
-            </div>
-            <div class="col-md-6 col-lg-4 col-xl-3">
-                <input class="form-control password-strength" type="password" id="inputNewpassword" name="newpassword" required="required" autocomplete="new-password"/>
-                <div class="progress password-strength-progress">
-                    <div class="progress-bar" id="password-strength-bar"></div>
+                    <form method="post" class="password-form">
+                        {include file="security/csrf.tpl"}
+
+                        <div class="form-group">
+                            <label class="col-form-label" for="inputOldpassword">Your old password</label>
+                            <input class="form-control" type="password" id="inputOldpassword" name="oldpassword" required="required" autocomplete="password"/>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-form-label" for="inputNewpassword">Your new password</label>
+                            <input class="form-control password-strength" type="password" id="inputNewpassword" name="newpassword" required="required" autocomplete="new-password"/>
+                            <div class="progress password-strength-progress">
+                                <div class="progress-bar" id="password-strength-bar"></div>
+                            </div>
+                            <span class="form-text text-danger" id="password-strength-warning"></span>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-form-label" for="inputNewpasswordconfirm">Confirm new password</label>
+                            <input class="form-control" type="password" id="inputNewpasswordconfirm" name="newpasswordconfirm" required="required" autocomplete="new-password"/>
+                        </div>
+                        <div class="form-group">
+                            <button type="submit" class="btn btn-block btn-primary">Update password</button>
+                        </div>
+                    </form>
+
                 </div>
-                <span class="form-text text-danger" id="password-strength-warning"></span>
             </div>
         </div>
-        <div class="form-group row">
-            <div class="col-md-3 col-lg-2">
-                <label class="col-form-label" for="inputNewpasswordconfirm">Confirm new password</label>
-            </div>
-            <div class="col-md-6 col-lg-4 col-xl-3">
-                <input class="form-control" type="password" id="inputNewpasswordconfirm" name="newpasswordconfirm" required="required" autocomplete="new-password"/>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="offset-md-3 offset-lg-2 col-md-6 col-lg-4 col-xl-3">
-                <button type="submit" class="btn btn-block btn-primary">Update password</button>
-            </div>
-        </div>
-    </form>
+    </div>
 {/block}

--- a/templates/registration/register.tpl
+++ b/templates/registration/register.tpl
@@ -48,9 +48,7 @@
                             <div class="progress-bar" id="password-strength-bar"></div>
                         </div>
                         <span class="form-text text-danger" id="password-strength-warning"></span>
-                        <small id="passHelp" class="form-text text-muted">
-                            Please <strong>do not</strong> use the same password you use on Wikipedia!
-                        </small>
+                        {include file="alert.tpl" alerttype="alert-warning mt-2" alertclosable=false alertheader="" alertmessage="Use of your Wikimedia credentials is highly discouraged in this tool. You should use a different password for your account than you would on projects like Wikipedia, Wikimedia Commons, etc."}
                     </div>
                 </div>
 


### PR DESCRIPTION
* Clarifies that authentication prompts surrounding enabling/disabling MFA ask for your tool password
* Change the styling of the password change page to better match other auth-type pages
* Add big notices to registration and password change reminding people to not use their WM passwords