### PR TITLE
Fix missing parameter on function call

### DIFF
--- a/includes/Pages/PageEditComment.php
+++ b/includes/Pages/PageEditComment.php
@@ -105,7 +105,7 @@ class PageEditComment extends InternalPageBase
 
             Logger::editComment($database, $comment, $request);
             if (WebRequest::postBoolean('unflag') && $canUnflag) {
-                Logger::unflaggedComment($database, $comment);
+                Logger::unflaggedComment($database, $comment, $request->getDomain());
             }
             $this->getNotificationHelper()->commentEdited($comment, $request);
             SessionAlert::success("Comment has been saved successfully");


### PR DESCRIPTION
Fixes call to `Logger::unflaggedComment(...)` introduced in [023e464c](https://github.com/enwikipedia-acc/waca/commit/023e464c869b18b3d6dae62f84b5ef00c025b2f9#diff-ab0b1a2e5ce308825251eca14f41898aaff27d5a431ba8237342419108c59f1aL331-L336)