### PR TITLE
Edit comment QoL tweaks

### DIFF
--- a/includes/ConsoleTasks/ClearOldDataTask.php
+++ b/includes/ConsoleTasks/ClearOldDataTask.php
@@ -16,8 +16,9 @@ class ClearOldDataTask extends ConsoleTaskBase
     public function execute()
     {
         $dataClearInterval = $this->getSiteConfiguration()->getDataClearInterval();
+        $database = $this->getDatabase();
 
-        $query = $this->getDatabase()->prepare(<<<SQL
+        $query = $database->prepare(<<<SQL
 UPDATE request
 SET ip = :ip, forwardedip = null, email = :mail, useragent = ''
 WHERE date < DATE_SUB(curdate(), INTERVAL {$dataClearInterval})
@@ -34,7 +35,7 @@ SQL
             throw new Exception("Error in transaction 1: Could not clear data.");
         }
 
-        $dataQuery = $this->getDatabase()->prepare(<<<SQL
+        $dataQuery = $database->prepare(<<<SQL
 DELETE rd
 FROM requestdata rd
 INNER JOIN request r ON r.id = rd.request
@@ -48,5 +49,14 @@ SQL
         if (!$success) {
             throw new Exception("Error in transaction 2: Could not clear data.");
         }
+
+        // FIXME: domains!
+        $flaggedCommentsQuery = $database->query(<<<SQL
+SELECT COUNT(1) FROM comment c INNER JOIN request r ON c.request = r.id WHERE c.flagged = 1 AND r.status = 'Closed'
+SQL
+        );
+
+        $flaggedCommentsCount = $flaggedCommentsQuery->fetchColumn();
+        $this->getNotificationHelper()->alertFlaggedComments($flaggedCommentsCount);
     }
 }

--- a/includes/Helpers/IrcNotificationHelper.php
+++ b/includes/Helpers/IrcNotificationHelper.php
@@ -486,6 +486,11 @@ TAG
         );
     }
 
+    public function alertFlaggedComments(int $count)
+    {
+        $this->send("There are ${count} flagged comments on closed requests currently awaiting redaction.");
+    }
+
     #endregion
 
     #region email management (close reasons)

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -435,7 +435,12 @@ HTML;
                 $formName = htmlentities($queue->getName(), ENT_COMPAT, 'UTF-8');
 
                 return "<a href=\"{$baseurl}/internal.php/requestFormManagement/edit?form={$objectId}\">{$formName}</a>";
+            case 'Comment':
+                /** @var Comment $comment */
+                $comment = Comment::getById($objectId, $database);
+                $requestName = htmlentities(Request::getById($comment->getRequest(), $database)->getName(), ENT_COMPAT, 'UTF-8');
 
+                return "<a href=\"{$baseurl}/internal.php/editComment?id={$objectId}\">Comment {$objectId}</a> on request <a href=\"{$baseurl}/internal.php/viewRequest?id={$comment->getRequest()}#comment-{$objectId}\">#{$comment->getRequest()} ({$requestName})</a>";
             default:
                 return '[' . $objectType . " " . $objectId . ']';
         }

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -438,7 +438,9 @@ HTML;
             case 'Comment':
                 /** @var Comment $comment */
                 $comment = Comment::getById($objectId, $database);
-                $requestName = htmlentities(Request::getById($comment->getRequest(), $database)->getName(), ENT_COMPAT, 'UTF-8');
+                /** @var Request $request */
+                $request = Request::getById($comment->getRequest(), $database);
+                $requestName = htmlentities($request->getName(), ENT_COMPAT, 'UTF-8');
 
                 return "<a href=\"{$baseurl}/internal.php/editComment?id={$objectId}\">Comment {$objectId}</a> on request <a href=\"{$baseurl}/internal.php/viewRequest?id={$comment->getRequest()}#comment-{$objectId}\">#{$comment->getRequest()} ({$requestName})</a>";
             default:

--- a/includes/Pages/PageEditComment.php
+++ b/includes/Pages/PageEditComment.php
@@ -60,8 +60,8 @@ class PageEditComment extends InternalPageBase
             $visibility = WebRequest::postString('visibility');
             $doUnflag = WebRequest::postBoolean('unflag');
 
-            if ($newComment === null || $newComment === "") {
-                throw new ApplicationLogicException("Comment cannot be empty!");
+            if ($newComment === null || $newComment === '') {
+                throw new ApplicationLogicException('Comment cannot be empty!');
             }
 
             $commentDataUnchanged = $newComment === $comment->getComment()
@@ -71,6 +71,7 @@ class PageEditComment extends InternalPageBase
             if ($commentDataUnchanged && $flagStatusUnchanged) {
                 // No change was made; redirect back.
                 $this->redirectBack($comment->getRequest());
+
                 return;
             }
 
@@ -98,7 +99,7 @@ class PageEditComment extends InternalPageBase
                 Logger::unflaggedComment($database, $comment, $request->getDomain());
             }
 
-            SessionAlert::success("Comment has been saved successfully");
+            SessionAlert::success('Comment has been saved successfully');
             $this->redirectBack($comment->getRequest());
         }
         else {
@@ -112,13 +113,9 @@ class PageEditComment extends InternalPageBase
     }
 
     /**
-     * @param $comment
-     * @param $currentUser
-     *
-     * @return void
      * @throws AccessDeniedException
      */
-    protected function checkCommentAccess($comment, $currentUser): void
+    private function checkCommentAccess(Comment $comment, User $currentUser): void
     {
         if ($comment->getUser() !== $currentUser->getId() && !$this->barrierTest('editOthers', $currentUser)) {
             throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
@@ -152,13 +149,9 @@ class PageEditComment extends InternalPageBase
     }
 
     /**
-     * @param             $comment
-     * @param string|null $visibility
-     * @param             $newComment
-     *
      * @throws ApplicationLogicException
      */
-    protected function updateCommentData(Comment $comment, ?string $visibility, string $newComment): void
+    private function updateCommentData(Comment $comment, ?string $visibility, string $newComment): void
     {
         if ($comment->getVisibility() !== 'requester') {
             if ($visibility !== 'user' && $visibility !== 'admin' && $visibility !== 'checkuser') {
@@ -172,13 +165,14 @@ class PageEditComment extends InternalPageBase
         $comment->touchEdited();
     }
 
-    protected function redirectBack(int $requestId): void
+    private function redirectBack(int $requestId): void
     {
-        $source = WebRequest::getString("from");
+        $source = WebRequest::getString('from');
 
-        if ($source == "flagged") {
+        if ($source == 'flagged') {
             $this->redirect('flaggedComments');
-        } else {
+        }
+        else {
             $this->redirect('viewRequest', null, array('id' => $requestId));
         }
     }

--- a/includes/Pages/PageListFlaggedComments.php
+++ b/includes/Pages/PageListFlaggedComments.php
@@ -79,10 +79,13 @@ class PageListFlaggedComments extends InternalPageBase
 
     protected function copyCommentData(Comment $object, array &$data, PdoDatabase $database): void
     {
+        $request = Request::getById($object->getRequest(), $database);
+
         $data['comment'] = $object->getComment();
         $data['time'] = $object->getTime();
         $data['requestid'] = $object->getRequest();
-        $data['request'] = Request::getById($object->getRequest(), $database)->getName();
+        $data['request'] = $request->getName();
+        $data['requeststatus'] = $request->getStatus();
         $data['userid'] = $object->getUser();
         $data['user'] = User::getById($object->getUser(), $database)->getUsername();
     }

--- a/resources/scss/_viewRequest.scss
+++ b/resources/scss/_viewRequest.scss
@@ -74,6 +74,11 @@ $zoom-section-spacer: 1.45rem;
         #commentSaveButton {
             min-width: 5rem;
         }
+
+        table tbody tr:target {
+            border: $secondary 2px solid !important;
+            border-left: $secondary 0.6rem solid !important;
+        }
     }
 
     .linkWrapSection .btn {

--- a/resources/scss/bootstrap-alt.scss
+++ b/resources/scss/bootstrap-alt.scss
@@ -88,3 +88,8 @@ $close-color: $white;
     color: $white;
   }
 }
+
+// override .table-secondary.text-muted to have better contrast
+.table-secondary .text-muted {
+  color: $gray-500 !important;
+}

--- a/templates/edit-comment.tpl
+++ b/templates/edit-comment.tpl
@@ -14,7 +14,18 @@
                 <label class="col-form-label" for="request">Request</label>
             </div>
             <div class="col-md-8 col-lg-4">
-                <a class="form-control" id="request" href="{$baseurl}/internal.php/viewRequest?id={$comment->getRequest()}">{$request->getName()|escape}</a>
+                <div class="form-control"> 
+                    <a id="request" href="{$baseurl}/internal.php/viewRequest?id={$comment->getRequest()}">
+                        {$request->getName()|escape}
+                    </a>
+                    {if $request->getStatus() == Waca\RequestStatus::CLOSED}
+                        <span class="badge badge-danger">Closed</span>
+                    {elseif $request->getStatus() == Waca\RequestStatus::OPEN}
+                        <span class="badge badge-success">Open</span>
+                    {else}
+                        <span class="badge badge-warning">{$request->getStatus()|escape}</span>
+                    {/if}
+                </div>
             </div>
         </div>
 
@@ -85,6 +96,19 @@
                 <div class="form-control prewrap" id="oldtext">{$comment->getComment()|escape}</div>
             </div>
         </div>
+
+        {if $request->getStatus() !== Waca\RequestStatus::CLOSED && $comment->getFlagged()}
+            <div class="form-group row">
+                <div class="offset-md-4 col-md-8 offset-lg-2 col-lg-10">
+                {include file="alert.tpl"
+                    alerttype="alert-warning mb-0"
+                    alertmessage="Please consider if any redactable information in this comment will be useful for handling this request, and whether a redaction can wait until the request is closed."
+                }
+                </div>
+            </div>
+
+            
+        {/if}
 
         <div class="form-group row">
             <div class="col-md-4 col-lg-2">

--- a/templates/flagged-comments.tpl
+++ b/templates/flagged-comments.tpl
@@ -78,12 +78,16 @@
                             <td data-value="{$data.time|date}" data-dateformat="YYYY-MM-DD hh:mm:ss" class="text-nowrap">
                                 {$data.time|date}&nbsp;<span class="text-muted">{$data.time|relativedate}</span>
                             </td>
-                            <td>{$data.comment|escape}</td>
+                            {if $data.unreserved}
+                                <td class="text-muted"><del>(redacted)</del></td>
+                            {else}
+                                <td>{$data.comment|escape}</td>
+                            {/if}
                             <td class="table-button-cell text-right">
-                                {if $editComments && ($editOthersComments || $data.userid == $currentUser->getId())}
+                                {if $editComments && !$data.unreserved && ($editOthersComments || $data.userid == $currentUser->getId())}
                                     <a href="{$baseurl}/internal.php/editComment?id={$data.id}&from=flagged" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i>&nbsp;Edit</a>
                                 {/if}
-                                {if $canUnflag}
+                                {if $canUnflag && !$data.unreserved}
                                 <form action="{$baseurl}/internal.php/flagComment" method="post" class="d-inline-block">
                                     {include file="security/csrf.tpl"}
                                     <input type="hidden" name="comment" value="{$data.id}" />

--- a/templates/flagged-comments.tpl
+++ b/templates/flagged-comments.tpl
@@ -6,6 +6,11 @@
                 <h1 class="h2">Flagged comments</h1>
             </div>
             <p>This page lists all comments which have been flagged for review. Please check each carefully and edit out any private data as required.</p>
+            <p>
+                If a request is still open, please be aware that the comment may contain information relevant to the 
+                handling of the request. It may be prudent to wait for a request to be closed before redacting the
+                comments for that request.
+            </p>
         </div>
     </div>
 
@@ -60,7 +65,16 @@
                             <td></td>
                         {else}
                             <td>{if $data.userid !== null}<a href="{$baseurl}/internal.php/statistics/users/detail?user={$data.userid|escape}">{$data.user|escape}</a>{/if}</td>
-                            <td><a href="{$baseurl}/internal.php/viewRequest?id={$data.requestid|escape}">{$data.request|escape}</a></td>
+                            <td>
+                                <a href="{$baseurl}/internal.php/viewRequest?id={$data.requestid|escape}">{$data.request|escape}</a>
+                                {if $data.requeststatus == Waca\RequestStatus::CLOSED}
+                                    <span class="badge badge-danger">Closed</span>
+                                {elseif $data.requeststatus == Waca\RequestStatus::OPEN}
+                                    <span class="badge badge-success">Open</span>
+                                {else}
+                                    <span class="badge badge-warning">{$data.requeststatus|escape}</span>
+                                {/if}
+                            </td>
                             <td data-value="{$data.time|date}" data-dateformat="YYYY-MM-DD hh:mm:ss" class="text-nowrap">
                                 {$data.time|date}&nbsp;<span class="text-muted">{$data.time|relativedate}</span>
                             </td>

--- a/templates/flagged-comments.tpl
+++ b/templates/flagged-comments.tpl
@@ -81,7 +81,7 @@
                             <td>{$data.comment|escape}</td>
                             <td class="table-button-cell text-right">
                                 {if $editComments && ($editOthersComments || $data.userid == $currentUser->getId())}
-                                    <a href="{$baseurl}/internal.php/editComment?id={$data.id}" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i>&nbsp;Edit</a>
+                                    <a href="{$baseurl}/internal.php/editComment?id={$data.id}&from=flagged" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i>&nbsp;Edit</a>
                                 {/if}
                                 {if $canUnflag}
                                 <form action="{$baseurl}/internal.php/flagComment" method="post" class="d-inline-block">

--- a/templates/flagged-comments.tpl
+++ b/templates/flagged-comments.tpl
@@ -78,16 +78,16 @@
                             <td data-value="{$data.time|date}" data-dateformat="YYYY-MM-DD hh:mm:ss" class="text-nowrap">
                                 {$data.time|date}&nbsp;<span class="text-muted">{$data.time|relativedate}</span>
                             </td>
-                            {if $data.unreserved}
+                            {if $data.hiddenText}
                                 <td class="text-muted"><del>(redacted)</del></td>
                             {else}
                                 <td>{$data.comment|escape}</td>
                             {/if}
                             <td class="table-button-cell text-right">
-                                {if $editComments && !$data.unreserved && ($editOthersComments || $data.userid == $currentUser->getId())}
+                                {if $editComments && !$data.hiddenText && ($editOthersComments || $data.userid == $currentUser->getId())}
                                     <a href="{$baseurl}/internal.php/editComment?id={$data.id}&from=flagged" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i>&nbsp;Edit</a>
                                 {/if}
-                                {if $canUnflag && !$data.unreserved}
+                                {if $canUnflag && !$data.hiddenText}
                                 <form action="{$baseurl}/internal.php/flagComment" method="post" class="d-inline-block">
                                     {include file="security/csrf.tpl"}
                                     <input type="hidden" name="comment" value="{$data.id}" />

--- a/templates/view-request/request-log.tpl
+++ b/templates/view-request/request-log.tpl
@@ -9,7 +9,7 @@
         <tbody>
         {if $requestLogs}
             {foreach from=$requestLogs item=zoomrow name=logloop}
-                    <tr class="{if $zoomrow.security == "admin"}table-danger{elseif $zoomrow.security == "checkuser"}table-visited{/if}" id="{if $zoomrow.type == "comment"}comment{else}log{/if}-{$zoomrow.id}">
+                    <tr class="{if $zoomrow.security == "admin"}table-danger{elseif $zoomrow.security == "checkuser"}table-visited{elseif $zoomrow.hidden}table-secondary{/if}" id="{if $zoomrow.type == "comment"}comment{else}log{/if}-{$zoomrow.id}">
                     <td class="text-nowrap">
                         {if $zoomrow.userid != null}
                             <a href='{$baseurl}/internal.php/statistics/users/detail?user={$zoomrow.userid}'>{$zoomrow.user|escape}</a>
@@ -70,7 +70,12 @@
                                 </a>
                             {/if}
 
-                            <div class="prewrap">{$zoomrow.comment|escape}</div>
+                            {if $zoomrow.hidden}
+                                <span class="text-muted">This comment has been hidden. Reserve the request to view it.</span>
+                            {else}
+                                <div class="prewrap">{$zoomrow.comment|escape}</div>
+                            {/if}
+
                         {/if}
                     </td>
                     <td class="text-nowrap">

--- a/templates/view-request/request-log.tpl
+++ b/templates/view-request/request-log.tpl
@@ -9,7 +9,7 @@
         <tbody>
         {if $requestLogs}
             {foreach from=$requestLogs item=zoomrow name=logloop}
-                    <tr class="{if $zoomrow.security == "admin"}table-danger{elseif $zoomrow.security == "checkuser"}table-visited{/if}">
+                    <tr class="{if $zoomrow.security == "admin"}table-danger{elseif $zoomrow.security == "checkuser"}table-visited{/if}" id="{if $zoomrow.type == "comment"}comment{else}log{/if}-{$zoomrow.id}">
                     <td class="text-nowrap">
                         {if $zoomrow.userid != null}
                             <a href='{$baseurl}/internal.php/statistics/users/detail?user={$zoomrow.userid}'>{$zoomrow.user|escape}</a>


### PR DESCRIPTION
* Show request status on edit comment
* Show a warning when editing a flagged comment on a non-closed request
* Show link to edit comment and the comment in-situ on the request from the log page.
* Fix issue where it was impossible to only unflag a comment via the edit comment screen
* Edit comment screen now returns you to either the view request page or the flagged comments page, depending on which you used to edit the comment.
* Hides flagged comments from view when request is unreserved (#777)
* Handles some extra edge cases for when a user has access to the edit interfaces, but doesn't have `RequestData::alwaysSeePrivateData`
* Adds an IRC ping for outstanding flagged comments (#777)