### PR TITLE
Implement global roles

### DIFF
--- a/includes/DataObjects/UserRole.php
+++ b/includes/DataObjects/UserRole.php
@@ -20,7 +20,7 @@ class UserRole extends DataObject
     /** @var string */
     private $role;
     /** @var int */
-    private $domain;
+    private ?int $domain;
 
     /**
      * @param int         $user
@@ -31,7 +31,7 @@ class UserRole extends DataObject
      */
     public static function getForUser(int $user, PdoDatabase $database, int $domain)
     {
-        $sql = 'SELECT * FROM userrole WHERE user = :user AND domain = :domain';
+        $sql = 'SELECT * FROM userrole WHERE user = :user AND (domain IS NULL OR domain = :domain)';
         $statement = $database->prepare($sql);
         $statement->bindValue(':user', $user);
         $statement->bindValue(':domain', $domain);
@@ -109,12 +109,12 @@ class UserRole extends DataObject
         $this->role = $role;
     }
 
-    public function getDomain(): int
+    public function getDomain(): ?int
     {
         return $this->domain;
     }
 
-    public function setDomain(int $domain): void
+    public function setDomain(?int $domain): void
     {
         $this->domain = $domain;
     }

--- a/includes/DataObjects/UserRole.php
+++ b/includes/DataObjects/UserRole.php
@@ -19,7 +19,6 @@ class UserRole extends DataObject
     private $user;
     /** @var string */
     private $role;
-    /** @var int */
     private ?int $domain;
 
     /**

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -31,16 +31,15 @@ use Waca\SiteConfiguration;
 class LogHelper
 {
     /**
-     * Summary of getRequestLogsWithComments
-     *
      * @param int             $requestId
-     * @param PdoDatabase     $db
-     * @param SecurityManager $securityManager
      *
      * @return DataObject[]
      */
-    public static function getRequestLogsWithComments($requestId, PdoDatabase $db, SecurityManager $securityManager)
-    {
+    public static function getRequestLogsWithComments(
+        $requestId,
+        PdoDatabase $db,
+        SecurityManager $securityManager
+    ): array {
         // FIXME: domains
         $logs = LogSearchHelper::get($db, 1)->byObjectType('Request')->byObjectId($requestId)->fetch();
 
@@ -52,12 +51,7 @@ class LogHelper
 
         $items = array_merge($logs, $comments);
 
-        /**
-         * @param DataObject $item
-         *
-         * @return int
-         */
-        $sortKey = function(DataObject $item) {
+        $sortKey = function(DataObject $item): int {
             if ($item instanceof Log) {
                 return $item->getTimestamp()->getTimestamp();
             }
@@ -91,14 +85,7 @@ class LogHelper
         return $items;
     }
 
-    /**
-     * Summary of getLogDescription
-     *
-     * @param Log $entry
-     *
-     * @return string
-     */
-    public static function getLogDescription(Log $entry)
+    public static function getLogDescription(Log $entry): string
     {
         $text = "Deferred to ";
         if (substr($entry->getAction(), 0, strlen($text)) == $text) {
@@ -129,11 +116,11 @@ class LogHelper
         if (substr($entry->getAction(), 0, strlen($text)) == $text) {
             // Closed with a reason - do a lookup here.
             $id = substr($entry->getAction(), strlen($text));
-            /** @var EmailTemplate $template */
+            /** @var EmailTemplate|false $template */
             $template = EmailTemplate::getById((int)$id, $entry->getDatabase());
 
-            if ($template != false) {
-                return "closed (" . $template->getName() . ")";
+            if ($template !== false) {
+                return 'closed (' . $template->getName() . ')';
             }
         }
 
@@ -193,12 +180,7 @@ class LogHelper
         return "performed an unknown action ({$entry->getAction()})";
     }
 
-    /**
-     * @param PdoDatabase $database
-     *
-     * @return array
-     */
-    public static function getLogActions(PdoDatabase $database)
+    public static function getLogActions(PdoDatabase $database): array
     {
         $lookup = array(
             "Requests" => [
@@ -283,7 +265,7 @@ SQL
         return $lookup;
     }
 
-    public static function getObjectTypes()
+    public static function getObjectTypes(): array
     {
         return array(
             'Ban'             => 'Ban',
@@ -301,14 +283,11 @@ SQL
     }
 
     /**
-     * This returns a HTML
+     * This returns an HTML representation of the object
      *
-     * @param string            $objectId
+     * @param int               $objectId
      * @param string            $objectType
-     * @param PdoDatabase       $database
-     * @param SiteConfiguration $configuration
      *
-     * @return null|string
      * @category Security-Critical
      */
     private static function getObjectDescription(
@@ -316,7 +295,7 @@ SQL
         $objectType,
         PdoDatabase $database,
         SiteConfiguration $configuration
-    ) {
+    ): ?string {
         if ($objectType == '') {
             return null;
         }
@@ -453,14 +432,11 @@ HTML;
     }
 
     /**
-     * @param Log[]             $logs
-     * @param PdoDatabase       $database
-     * @param SiteConfiguration $configuration
+     * @param Log[] $logs
      *
-     * @return array
      * @throws Exception
      */
-    public static function prepareLogsForTemplate($logs, PdoDatabase $database, SiteConfiguration $configuration)
+    public static function prepareLogsForTemplate(array $logs, PdoDatabase $database, SiteConfiguration $configuration): array
     {
         $userIds = array();
 

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -146,6 +146,7 @@ class LogHelper
             'Approved'            => 'approved',
             'Suspended'           => 'suspended',
             'RoleChange'          => 'changed roles',
+            'GlobalRoleChange'    => 'changed global roles',
             'Banned'              => 'banned',
             'Edited'              => 'edited interface message',
             'Declined'            => 'declined',
@@ -221,6 +222,7 @@ class LogHelper
                 'Approved'            => 'approved',
                 'Suspended'           => 'suspended',
                 'RoleChange'          => 'changed roles',
+                'GlobalRoleChange'    => 'changed global roles',
                 'Declined'            => 'declined',
                 'Prefchange'          => 'changed user preferences',
                 'Renamed'             => 'renamed',
@@ -498,6 +500,7 @@ HTML;
                     $comment = 'Renamed \'' . $oldName . '\' to \'' . $newName . '\'.';
                     break;
                 case 'RoleChange':
+                case 'GlobalRoleChange':
                     $roleChangeData = unserialize($logEntry->getComment());
 
                     $removed = array();

--- a/includes/Helpers/Logger.php
+++ b/includes/Helpers/Logger.php
@@ -187,6 +187,17 @@ class Logger
         self::createLogEntry($database, $object, "RoleChange", $logData, null, $domain);
     }
 
+    public static function userGlobalRolesEdited(PdoDatabase $database, User $object, $reason, $added, $removed)
+    {
+        $logData = serialize(array(
+            'added'   => $added,
+            'removed' => $removed,
+            'reason'  => $reason,
+        ));
+
+        self::createLogEntry($database, $object, "GlobalRoleChange", $logData);
+    }
+
     #endregion
 
     /**

--- a/includes/Helpers/Logger.php
+++ b/includes/Helpers/Logger.php
@@ -91,8 +91,7 @@ class Logger
     #region Users
 
     /**
-     * @param PdoDatabase $database
-     * @param User        $user
+     * @throws Exception
      */
     public static function newUser(PdoDatabase $database, User $user)
     {
@@ -100,8 +99,7 @@ class Logger
     }
 
     /**
-     * @param PdoDatabase $database
-     * @param User        $object
+     * @throws Exception
      */
     public static function approvedUser(PdoDatabase $database, User $object)
     {
@@ -109,57 +107,31 @@ class Logger
     }
 
     /**
-     * @param PdoDatabase $database
-     * @param User        $object
-     * @param string      $comment
+     * @throws Exception
      */
-    public static function declinedUser(PdoDatabase $database, User $object, $comment)
+    public static function declinedUser(PdoDatabase $database, User $object, string $comment)
     {
         self::createLogEntry($database, $object, "Declined", $comment);
     }
 
     /**
-     * @param PdoDatabase $database
-     * @param User        $object
-     * @param string      $comment
+     * @throws Exception
      */
-    public static function suspendedUser(PdoDatabase $database, User $object, $comment)
+    public static function suspendedUser(PdoDatabase $database, User $object, string $comment)
     {
         self::createLogEntry($database, $object, "Suspended", $comment);
     }
 
     /**
-     * @param PdoDatabase $database
-     * @param User        $object
-     * @param string      $comment
+     * @throws Exception
      */
-    public static function demotedUser(PdoDatabase $database, User $object, $comment)
-    {
-        self::createLogEntry($database, $object, "Demoted", $comment);
-    }
-
-    /**
-     * @param PdoDatabase $database
-     * @param User        $object
-     */
-    public static function promotedUser(PdoDatabase $database, User $object)
-    {
-        self::createLogEntry($database, $object, "Promoted");
-    }
-
-    /**
-     * @param PdoDatabase $database
-     * @param User        $object
-     * @param string      $comment
-     */
-    public static function renamedUser(PdoDatabase $database, User $object, $comment)
+    public static function renamedUser(PdoDatabase $database, User $object, string $comment)
     {
         self::createLogEntry($database, $object, "Renamed", $comment);
     }
 
     /**
-     * @param PdoDatabase $database
-     * @param User        $object
+     * @throws Exception
      */
     public static function userPreferencesChange(PdoDatabase $database, User $object)
     {
@@ -167,17 +139,16 @@ class Logger
     }
 
     /**
-     * @param PdoDatabase $database
-     * @param User        $object
-     * @param string      $reason
-     * @param array       $added
-     * @param array       $removed
-     * @param int         $domain
-     *
      * @throws Exception
      */
-    public static function userRolesEdited(PdoDatabase $database, User $object, $reason, $added, $removed, int $domain)
-    {
+    public static function userRolesEdited(
+        PdoDatabase $database,
+        User $object,
+        string $reason,
+        array $added,
+        array $removed,
+        int $domain
+    ) {
         $logData = serialize(array(
             'added'   => $added,
             'removed' => $removed,
@@ -187,12 +158,20 @@ class Logger
         self::createLogEntry($database, $object, "RoleChange", $logData, null, $domain);
     }
 
-    public static function userGlobalRolesEdited(PdoDatabase $database, User $object, $reason, $added, $removed)
-    {
+    /**
+     * @throws Exception
+     */
+    public static function userGlobalRolesEdited(
+        PdoDatabase $database,
+        User $object,
+        string $reason,
+        array $added,
+        array $removed
+    ): void {
         $logData = serialize(array(
-            'added'   => $added,
+            'added' => $added,
             'removed' => $removed,
-            'reason'  => $reason,
+            'reason' => $reason,
         ));
 
         self::createLogEntry($database, $object, "GlobalRoleChange", $logData);

--- a/includes/Pages/PageUserManagement.php
+++ b/includes/Pages/PageUserManagement.php
@@ -8,10 +8,13 @@
 
 namespace Waca\Pages;
 
+use Exception;
+use SmartyException;
 use Waca\DataObjects\Domain;
 use Waca\DataObjects\User;
 use Waca\DataObjects\UserRole;
 use Waca\Exceptions\ApplicationLogicException;
+use Waca\Exceptions\OptimisticLockFailedException;
 use Waca\Helpers\Logger;
 use Waca\Helpers\OAuthUserHelper;
 use Waca\Helpers\PreferenceManager;
@@ -106,15 +109,20 @@ class PageUserManagement extends InternalPageBase
 
     /**
      * Action target for editing the roles assigned to a user
+     *
+     * @throws ApplicationLogicException
+     * @throws SmartyException
+     * @throws OptimisticLockFailedException
+     * @throws Exception
      */
-    protected function editRoles()
+    protected function editRoles(): void
     {
         $this->setHtmlTitle('User Management');
         $database = $this->getDatabase();
         $domain = Domain::getCurrent($database);
         $userId = WebRequest::getInt('user');
 
-        /** @var User $user */
+        /** @var User|false $user */
         $user = User::getById($userId, $database);
 
         if ($user === false || $user->isCommunityUser()) {
@@ -225,8 +233,6 @@ class PageUserManagement extends InternalPageBase
             SessionAlert::quick('Roles changed for user ' . htmlentities($user->getUsername(), ENT_COMPAT, 'UTF-8'));
 
             $this->redirect('statistics/users', 'detail', array('user' => $user->getId()));
-
-            return;
         }
         else {
             $this->assignCSRFToken();

--- a/includes/Pages/Statistics/StatsUsers.php
+++ b/includes/Pages/Statistics/StatsUsers.php
@@ -121,7 +121,7 @@ SQL
         $this->assign("notcreated", $usersNotCreated);
 
         /** @var Log[] $logs */
-        $logs = LogSearchHelper::get($database, null)
+        $logs = LogSearchHelper::get($database, Domain::getCurrent($database)->getId())
             ->byObjectType('User')
             ->byObjectId($user->getId())
             ->getRecordCount($logCount)

--- a/includes/Security/SecurityManager.php
+++ b/includes/Security/SecurityManager.php
@@ -8,6 +8,7 @@
 
 namespace Waca\Security;
 
+use Waca\DataObjects\Domain;
 use Waca\DataObjects\User;
 use Waca\DataObjects\UserRole;
 use Waca\IdentificationVerifier;
@@ -179,7 +180,8 @@ final class SecurityManager
             $userRoles[] = 'loggedIn';
 
             if ($user->isActive()) {
-                $ur = UserRole::getForUser($user->getId(), $user->getDatabase(), 1); // FIXME: domains
+                $domain = Domain::getCurrent($user->getDatabase());
+                $ur = UserRole::getForUser($user->getId(), $user->getDatabase(), $domain->getId());
 
                 // NOTE: public is still in this array.
                 foreach ($ur as $r) {

--- a/includes/Security/SecurityManager.php
+++ b/includes/Security/SecurityManager.php
@@ -18,14 +18,10 @@ final class SecurityManager
     const ALLOWED = 1;
     const ERROR_NOT_IDENTIFIED = 2;
     const ERROR_DENIED = 3;
-    /** @var IdentificationVerifier */
-    private $identificationVerifier;
-    /**
-     * @var RoleConfiguration
-     */
-    private $roleConfiguration;
+    private IdentificationVerifier $identificationVerifier;
+    private RoleConfiguration $roleConfiguration;
 
-    private $cache = [];
+    private array $cache = [];
 
     /**
      * SecurityManager constructor.
@@ -122,12 +118,8 @@ final class SecurityManager
 
     /**
      * Takes an array of roles and flattens the values to a single set.
-     *
-     * @param array $activeRoles
-     *
-     * @return array
      */
-    private function flattenRoles($activeRoles)
+    private function flattenRoles(array $activeRoles): array
     {
         $result = array();
 
@@ -162,12 +154,7 @@ final class SecurityManager
         return $result;
     }
 
-    /**
-     * @param User  $user
-     * @param array $activeRoles
-     * @param array $inactiveRoles
-     */
-    public function getActiveRoles(User $user, &$activeRoles, &$inactiveRoles)
+    public function getActiveRoles(User $user, ?array &$activeRoles, ?array &$inactiveRoles)
     {
         // Default to the community user here, because the main user is logged out
         $identified = false;
@@ -210,12 +197,7 @@ final class SecurityManager
         }
     }
 
-    /**
-     * @param User  $user
-     * @param array $activeRoles
-     * @param array $inactiveRoles
-     */
-    public function getCachedActiveRoles(User $user, &$activeRoles, &$inactiveRoles)
+    public function getCachedActiveRoles(User $user, ?array &$activeRoles, ?array &$inactiveRoles): void
     {
         if (!array_key_exists($user->getId(), $this->cache)) {
             $this->getActiveRoles($user, $retrievedActiveRoles, $retrievedInactiveRoles);

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -19,7 +19,7 @@ class SiteConfiguration
 {
     private $baseUrl;
     private $filePath;
-    private $schemaVersion = 48;
+    private $schemaVersion = 49;
     private $debuggingTraceEnabled;
     private $debuggingCssBreakpointsEnabled;
     private $dataClearIp = '127.0.0.1';

--- a/sql/patches/patch49-globalroles.sql
+++ b/sql/patches/patch49-globalroles.sql
@@ -1,0 +1,57 @@
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
+DELIMITER ';;'
+CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
+    -- -------------------------------------------------------------------------
+    -- Developers - set the number of the schema patch here!
+    -- -------------------------------------------------------------------------
+    DECLARE patchversion INT DEFAULT 49;
+    -- -------------------------------------------------------------------------
+    -- working variables
+    DECLARE currentschemaversion INT DEFAULT 0;
+    DECLARE lastversion INT;
+
+    -- check the schema has a version table
+    IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'schemaversion' AND table_schema = DATABASE()) THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'Please ensure patches are run in order! This database does not have a schemaversion table.';
+    END IF;
+    
+    -- get the current version
+    SELECT version INTO currentschemaversion FROM schemaversion;
+    
+    -- check schema is not ahead of this patch
+    IF currentschemaversion >= patchversion THEN
+        SIGNAL SQLSTATE '45000' SET message_text = 'This patch has already been applied!';
+    END IF;
+    
+    -- check schema is up-to-date
+    SET lastversion = patchversion - 1;
+    IF currentschemaversion != lastversion THEN
+        SET @message_text = CONCAT('Please ensure patches are run in order! This patch upgrades to version ', patchversion, ', but the database is not version ', lastversion);
+        SIGNAL SQLSTATE '45000' SET message_text = @message_text;
+    END IF;
+
+    -- -------------------------------------------------------------------------
+    -- Developers - put your upgrade statements here!
+    -- -------------------------------------------------------------------------
+
+    ALTER TABLE userrole
+        MODIFY COLUMN domain int(10) unsigned NULL,
+        ADD COLUMN `global` tinyint(3) unsigned GENERATED ALWAYS AS (CASE WHEN domain IS NULL THEN  1 END) VIRTUAL COMMENT 'Is this globally-defined?',
+        -- existing constraint userrole_uidx_user_role_domain
+        -- prevents the same role being granted multiple times in the same domain.
+        -- this one prevents the same role being granted multiple times globally.
+        ADD CONSTRAINT userrole_uidx_user_role_global UNIQUE (user, role, global);
+        -- the case to prevent a role being granted locally *and* globally can't be easily done
+        -- in the database, so we'll handle that in the application.
+
+    ALTER TABLE userrole
+        ALTER COLUMN domain DROP DEFAULT;
+
+    -- -------------------------------------------------------------------------
+    -- finally, update the schema version to indicate success
+    # noinspection SqlWithoutWhere
+    UPDATE schemaversion SET version = patchversion;
+END;;
+DELIMITER ';'
+CALL SCHEMA_UPGRADE_SCRIPT();
+DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;

--- a/sql/patches/patch49-globalroles.sql
+++ b/sql/patches/patch49-globalroles.sql
@@ -42,10 +42,8 @@ CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
         -- this one prevents the same role being granted multiple times globally.
         ADD CONSTRAINT userrole_uidx_user_role_global UNIQUE (user, role, global);
         -- the case to prevent a role being granted locally *and* globally can't be easily done
-        -- in the database, so we'll handle that in the application.
-
-    ALTER TABLE userrole
-        ALTER COLUMN domain DROP DEFAULT;
+        -- in the database, so we handle that in the application by forcing a role to either be
+        -- global OR local, not both.
 
     -- -------------------------------------------------------------------------
     -- finally, update the schema version to indicate success

--- a/sql/test_db.sh
+++ b/sql/test_db.sh
@@ -260,6 +260,7 @@ if [[ $CreateOnly -eq 0 ]]; then
 
     log "Comparing dumps..."
     if ! diff -q schema.sql schema2.sql; then
+        diff -bu schema.sql schema2.sql;
         log "Difference detected!"
         exit 1
     fi

--- a/templates/usermanagement/roleedit.tpl
+++ b/templates/usermanagement/roleedit.tpl
@@ -21,7 +21,7 @@
             <div class="d-none d-md-block col-md-3 col-lg-2">
                 <span class="col-form-label">Editable roles:</span>
             </div>
-            <div class="col-md-9 col-lg-10">
+            <div class="col-md-9 col-lg-10 border-bottom">
                 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3">
                     {foreach from=$roleData key='role' item='data'}
                         {if $data['allowEdit'] === 1}
@@ -30,6 +30,7 @@
                                 <input class="custom-control-input" type="checkbox" name="role-{$role|escape}" id="role-{$role|escape}" {if $data['allowEdit'] === 0}disabled="disabled"{/if} {if $data['active'] === 1}checked="checked"{/if} />
                                 <label class="custom-control-label" for="role-{$role|escape}">
                                     <code>{$role|escape}</code>
+                                    {if $data['globalOnly']}<span class="badge badge-dark">Global role</span>{/if}
                                     <span class="form-text text-muted">{$data['description']|escape}</span>
                                 </label>
                             </div>
@@ -52,6 +53,7 @@
                                 <input class="custom-control-input" type="checkbox" name="role-{$role|escape}" id="role-{$role|escape}" disabled="disabled" {if $data['active'] === 1}checked="checked"{/if} />
                                 <label class="custom-control-label" for="role-{$role|escape}">
                                     <code>{$role|escape}</code>
+                                    {if $data['globalOnly']}<span class="badge badge-dark">Global role</span>{/if}
                                     <span class="form-text text-muted">{$data['description']|escape}</span>
                                 </label>
                             </div>


### PR DESCRIPTION
Roles can now be either defined as a "local" role (like tool admin or checkuser), or a "global" role (like tool root or steward).

Global roles automatically apply across all domains. Local roles only apply in the domain in which they are granted.

There is no practical difference between how a global and a local role are treated - the only difference occurs when the role is granted. If it's defined as global in RoleConfiguration, the application will ensure it is saved as a global role instead of a local role. From a data storage point of view, a global role grant simply has the `userrole.domain` column set to null.

This means it is possible to live-hack local roles to apply as global roles or vice-versa by directly manipulating the database and it'd behave as you'd otherwise expect. Please don't actually do that though.

This change also introduces a "steward" global role. Stewards have the ability to grant +steward and +checkuser to others, and have the ability to set large IP range bans and global bans. Otherwise, their privset is the same as someone with the checkuser role.