### PR TITLE
Make queue help messages dismissable

### DIFF
--- a/includes/Helpers/PreferenceManager.php
+++ b/includes/Helpers/PreferenceManager.php
@@ -23,6 +23,7 @@ class PreferenceManager
     const PREF_CREATION_MODE = 'creationMode';
     const PREF_SKIN = 'skin';
     const PREF_DEFAULT_DOMAIN = 'defaultDomain';
+    const PREF_QUEUE_HELP = 'showQueueHelp';
     const CREATION_MANUAL = 0;
     const CREATION_OAUTH = 1;
     const CREATION_BOT = 2;

--- a/includes/Pages/PageMain.php
+++ b/includes/Pages/PageMain.php
@@ -12,6 +12,7 @@ use PDO;
 use Waca\DataObjects\Request;
 use Waca\DataObjects\RequestQueue;
 use Waca\DataObjects\User;
+use Waca\Helpers\PreferenceManager;
 use Waca\Fragments\RequestListData;
 use Waca\Helpers\SearchHelpers\RequestSearchHelper;
 use Waca\PdoDatabase;
@@ -34,6 +35,7 @@ class PageMain extends InternalPageBase
         $config = $this->getSiteConfiguration();
         $database = $this->getDatabase();
         $currentUser = User::getCurrent($database);
+        $preferencesManager = PreferenceManager::getForCurrent($database);
 
         // general template configuration
         // FIXME: domains!
@@ -46,6 +48,7 @@ class PageMain extends InternalPageBase
         list($defaultSort, $defaultSortDirection) = WebRequest::requestListDefaultSort();
         $this->assign('defaultSort', $defaultSort);
         $this->assign('defaultSortDirection', $defaultSortDirection);
+        $this->assign('showQueueHelp', $preferencesManager->getPreference(PreferenceManager::PREF_QUEUE_HELP) ?? true);
 
         // Fetch request data
         $requestSectionData = array();

--- a/includes/Pages/PageMain.php
+++ b/includes/Pages/PageMain.php
@@ -48,7 +48,8 @@ class PageMain extends InternalPageBase
         list($defaultSort, $defaultSortDirection) = WebRequest::requestListDefaultSort();
         $this->assign('defaultSort', $defaultSort);
         $this->assign('defaultSortDirection', $defaultSortDirection);
-        $this->assign('showQueueHelp', $preferencesManager->getPreference(PreferenceManager::PREF_QUEUE_HELP) ?? true);
+        $showQueueHelp = $preferencesManager->getPreference(PreferenceManager::PREF_QUEUE_HELP) ?? true;
+        $this->assign('showQueueHelp', $showQueueHelp);
 
         // Fetch request data
         $requestSectionData = array();

--- a/includes/Pages/UserAuth/PagePreferences.php
+++ b/includes/Pages/UserAuth/PagePreferences.php
@@ -103,7 +103,7 @@ class PagePreferences extends InternalPageBase
         string $preference,
         string $fieldName,
         bool $defaultGlobal,
-        mixed $defaultValue = null
+        $defaultValue = null
     ): void {
         $this->assign($fieldName, $preferencesManager->getPreference($preference) ?? $defaultValue);
         $this->assign($fieldName . 'Global', $preferencesManager->isGlobalPreference($preference) ?? $defaultGlobal);

--- a/includes/Pages/UserAuth/PagePreferences.php
+++ b/includes/Pages/UserAuth/PagePreferences.php
@@ -73,6 +73,7 @@ class PagePreferences extends InternalPageBase
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_CREATION_MODE, 'creationMode', false);
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_SKIN, 'skin', true);
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_SKIP_JS_ABORT, 'skipJsAbort', false);
+            $this->assignPreference($preferencesManager, PreferenceManager::PREF_QUEUE_HELP, 'showQueueHelp', false);
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_DEFAULT_DOMAIN, 'defaultDomain', true);
 
             $this->assign('canManualCreate',

--- a/includes/Pages/UserAuth/PagePreferences.php
+++ b/includes/Pages/UserAuth/PagePreferences.php
@@ -74,7 +74,7 @@ class PagePreferences extends InternalPageBase
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_CREATION_MODE, 'creationMode', false);
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_SKIN, 'skin', true);
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_SKIP_JS_ABORT, 'skipJsAbort', false);
-            $this->assignPreference($preferencesManager, PreferenceManager::PREF_QUEUE_HELP, 'showQueueHelp', false);
+            $this->assignPreference($preferencesManager, PreferenceManager::PREF_QUEUE_HELP, 'showQueueHelp', false, true);
             $this->assignPreference($preferencesManager, PreferenceManager::PREF_DEFAULT_DOMAIN, 'defaultDomain', true);
 
             $this->assign('canManualCreate',
@@ -102,9 +102,10 @@ class PagePreferences extends InternalPageBase
         PreferenceManager $preferencesManager,
         string $preference,
         string $fieldName,
-        bool $defaultGlobal
+        bool $defaultGlobal,
+        mixed $defaultValue = null
     ): void {
-        $this->assign($fieldName, $preferencesManager->getPreference($preference));
+        $this->assign($fieldName, $preferencesManager->getPreference($preference) ?? $defaultValue);
         $this->assign($fieldName . 'Global', $preferencesManager->isGlobalPreference($preference) ?? $defaultGlobal);
     }
 

--- a/includes/Pages/UserAuth/PagePreferences.php
+++ b/includes/Pages/UserAuth/PagePreferences.php
@@ -39,6 +39,7 @@ class PagePreferences extends InternalPageBase
 
             $this->setPreference($preferencesManager,PreferenceManager::PREF_EMAIL_SIGNATURE, 'emailSignature');
             $this->setPreferenceWithValue($preferencesManager,PreferenceManager::PREF_SKIP_JS_ABORT, 'skipJsAbort', WebRequest::postBoolean('skipJsAbort') ? 1 : 0);
+            $this->setPreferenceWithValue($preferencesManager,PreferenceManager::PREF_QUEUE_HELP, 'showQueueHelp', WebRequest::postBoolean('showQueueHelp') ? 1 : 0);
             $this->setCreationMode($user, $preferencesManager);
             $this->setSkin($preferencesManager);
             $preferencesManager->setGlobalPreference(PreferenceManager::PREF_DEFAULT_DOMAIN, WebRequest::postInt('defaultDomain'));

--- a/templates/mainpage/accordiongroup.tpl
+++ b/templates/mainpage/accordiongroup.tpl
@@ -16,7 +16,7 @@
     </div>
     <div id="collapse{$section.api|escape}" class="collapse" data-parent="#requestListAccordion">
         <div class="card-body">
-            {if $section.help !== null}
+            {if $section.help !== null && $showQueueHelp}
                 <div class="alert alert-info alert-accordion prewrap">{$section.help|escape}</div>
             {/if}
             {include file="mainpage/requestlist.tpl" showStatus={$section.special !== null}}

--- a/templates/preferences/prefs.tpl
+++ b/templates/preferences/prefs.tpl
@@ -61,7 +61,7 @@
                                 <label class="custom-control-label" for="showQueueHelp">Show help text on queues</label>
                             </div>
                         </div>
-                        {include file="preferences/globalcheck.tpl" settingName="showQueueHelp" settingState=$showQueueHelpGlobal settingAvailable=false}
+                        {include file="preferences/globalcheck.tpl" settingName="showQueueHelp" settingState=$showQueueHelpGlobal settingAvailable=true}
                     </div>
 
                     <div class="form-group row mb-5">

--- a/templates/preferences/prefs.tpl
+++ b/templates/preferences/prefs.tpl
@@ -53,6 +53,19 @@
 
                     <div class="form-group row mb-5">
                         <div class="col-md-2 col-lg-3">
+                            <span class="col-form-label">Queue Help Text</span>
+                        </div>
+                        <div class="col-md-8 col-lg-7 col-xl-6">
+                            <div class="custom-control custom-switch">
+                                <input class="custom-control-input" type="checkbox" id="showQueueHelp" name="showQueueHelp"{if $showQueueHelp} checked{/if}>
+                                <label class="custom-control-label" for="showQueueHelp">Show help text on queues</label>
+                            </div>
+                        </div>
+                        {include file="preferences/globalcheck.tpl" settingName="showQueueHelp" settingState=$showQueueHelpGlobal settingAvailable=false}
+                    </div>
+
+                    <div class="form-group row mb-5">
+                        <div class="col-md-2 col-lg-3">
                             <label class="col-form-label">Account Creation Mode</label>
                         </div>
                         <div class="col-md-8 col-lg-7 col-xl-6">


### PR DESCRIPTION
Resolve #566 .

Add a preferences option to show/hide queue help text. Defaulting to on/show