### PR TITLE
Security refactor

### DIFF
--- a/includes/DataObjects/CommunityUser.php
+++ b/includes/DataObjects/CommunityUser.php
@@ -110,11 +110,6 @@ class CommunityUser extends User
 
     #region user access checks
 
-    public function isIdentified(IIdentificationVerifier $iv): bool
-    {
-        return false;
-    }
-
     public function isSuspended()
     {
         return false;

--- a/includes/DataObjects/CommunityUser.php
+++ b/includes/DataObjects/CommunityUser.php
@@ -10,7 +10,7 @@
 namespace Waca\DataObjects;
 
 use DateTime;
-use Waca\IdentificationVerifier;
+use Waca\IIdentificationVerifier;
 
 /**
  * User data object
@@ -110,7 +110,7 @@ class CommunityUser extends User
 
     #region user access checks
 
-    public function isIdentified(IdentificationVerifier $iv)
+    public function isIdentified(IIdentificationVerifier $iv): bool
     {
         return false;
     }

--- a/includes/DataObjects/Domain.php
+++ b/includes/DataObjects/Domain.php
@@ -101,32 +101,6 @@ SQL
         return $resultObject;
     }
 
-    public static function getDomainByUser(PdoDatabase $database, User $user, ?bool $enabled = null)
-    {
-        $statement = $database->prepare(<<<'SQL'
-            SELECT d.* 
-            FROM domain d
-            INNER JOIN userdomain ud on d.id = ud.domain
-            WHERE ud.user = :user
-            AND (:filterEnabled = 0 OR d.enabled = :enabled)
-SQL
-);
-        $statement->execute([
-            ':user' => $user->getId(),
-            ':filterEnabled' => ($enabled === null) ? 0 : 1,
-            ':enabled' => ($enabled) ? 1 : 0
-        ]);
-
-        $resultObject = $statement->fetchAll(PDO::FETCH_CLASS, get_called_class());
-
-        /** @var Domain $t */
-        foreach ($resultObject as $t) {
-            $t->setDatabase($database);
-        }
-
-        return $resultObject;
-    }
-
     public function save()
     {
         if ($this->isNew()) {

--- a/includes/DataObjects/User.php
+++ b/includes/DataObjects/User.php
@@ -13,7 +13,7 @@ use DateTime;
 use Exception;
 use Waca\DataObject;
 use Waca\Exceptions\OptimisticLockFailedException;
-use Waca\IdentificationVerifier;
+use Waca\IIdentificationVerifier;
 use Waca\PdoDatabase;
 use Waca\WebRequest;
 
@@ -382,16 +382,12 @@ SQL
 
     /**
      * Tests if the user is identified
-     *
-     * @param IdentificationVerifier $iv
-     *
-     * @return bool
      * @todo     Figure out what on earth is going on with PDO's typecasting here.  Apparently, it returns string("0") for
      *       the force-unidentified case, and int(1) for the identified case?!  This is quite ugly, but probably needed
      *       to play it safe for now.
      * @category Security-Critical
      */
-    public function isIdentified(IdentificationVerifier $iv)
+    public function isIdentified(IIdentificationVerifier $iv): bool
     {
         if ($this->forceidentified === 0 || $this->forceidentified === "0") {
             // User forced to unidentified in the database.

--- a/includes/Exceptions/AccessDeniedException.php
+++ b/includes/Exceptions/AccessDeniedException.php
@@ -106,7 +106,11 @@ class AccessDeniedException extends ReadableException
             ->limit(1)
             ->fetch();
 
-        return $logs[0]->getComment();
+        if (count($logs) > 0) {
+            return $logs[0]->getComment();
+        }
+
+        return null;
     }
 
     protected function getSecurityManager(): SecurityManager

--- a/includes/Exceptions/AccessDeniedException.php
+++ b/includes/Exceptions/AccessDeniedException.php
@@ -16,8 +16,8 @@ use Waca\Fragments\NavigationMenuAccessControl;
 use Waca\Helpers\PreferenceManager;
 use Waca\Helpers\SearchHelpers\LogSearchHelper;
 use Waca\PdoDatabase;
-use Waca\Security\DomainAccessManager;
-use Waca\Security\SecurityManager;
+use Waca\Security\IDomainAccessManager;
+use Waca\Security\ISecurityManager;
 
 /**
  * Class AccessDeniedException
@@ -30,18 +30,16 @@ class AccessDeniedException extends ReadableException
 {
     use NavigationMenuAccessControl;
 
-    /** @var SecurityManager */
-    private $securityManager;
-    /** @var DomainAccessManager */
-    private $domainAccessManager;
+    private ISecurityManager $securityManager;
+    private IDomainAccessManager $domainAccessManager;
 
     /**
      * AccessDeniedException constructor.
      *
-     * @param SecurityManager     $securityManager
-     * @param DomainAccessManager $domainAccessManager
+     * @param ISecurityManager     $securityManager
+     * @param IDomainAccessManager $domainAccessManager
      */
-    public function __construct(SecurityManager $securityManager, DomainAccessManager $domainAccessManager)
+    public function __construct(ISecurityManager $securityManager, IDomainAccessManager $domainAccessManager)
     {
         $this->securityManager = $securityManager;
         $this->domainAccessManager = $domainAccessManager;
@@ -62,9 +60,7 @@ class AccessDeniedException extends ReadableException
         $this->assign('currentUser', $currentUser);
         $this->assign('currentDomain', Domain::getCurrent($database));
 
-        if ($this->securityManager !== null) {
-            $this->setupNavMenuAccess($currentUser);
-        }
+        $this->setupNavMenuAccess($currentUser);
 
         if ($currentUser->isDeclined()) {
             $this->assign('htmlTitle', 'Account Declined');
@@ -113,12 +109,12 @@ class AccessDeniedException extends ReadableException
         return null;
     }
 
-    protected function getSecurityManager(): SecurityManager
+    protected function getSecurityManager(): ISecurityManager
     {
         return $this->securityManager;
     }
 
-    public function getDomainAccessManager(): DomainAccessManager
+    public function getDomainAccessManager(): IDomainAccessManager
     {
         return $this->domainAccessManager;
     }

--- a/includes/Exceptions/DomainSwitchNotAllowedException.php
+++ b/includes/Exceptions/DomainSwitchNotAllowedException.php
@@ -1,0 +1,15 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\Exceptions;
+
+use Exception;
+
+class DomainSwitchNotAllowedException extends Exception
+{
+}

--- a/includes/Exceptions/NotIdentifiedException.php
+++ b/includes/Exceptions/NotIdentifiedException.php
@@ -14,25 +14,17 @@ use Waca\DataObjects\User;
 use Waca\Fragments\NavigationMenuAccessControl;
 use Waca\Helpers\PreferenceManager;
 use Waca\PdoDatabase;
-use Waca\Security\DomainAccessManager;
-use Waca\Security\SecurityManager;
+use Waca\Security\IDomainAccessManager;
+use Waca\Security\ISecurityManager;
 
 class NotIdentifiedException extends ReadableException
 {
     use NavigationMenuAccessControl;
 
-    /** @var SecurityManager */
-    private $securityManager;
-    /** @var DomainAccessManager */
-    private $domainAccessManager;
+    private ISecurityManager $securityManager;
+    private IDomainAccessManager $domainAccessManager;
 
-    /**
-     * NotIdentifiedException constructor.
-     *
-     * @param SecurityManager     $securityManager
-     * @param DomainAccessManager $domainAccessManager
-     */
-    public function __construct(SecurityManager $securityManager, DomainAccessManager $domainAccessManager)
+    public function __construct(ISecurityManager $securityManager, IDomainAccessManager $domainAccessManager)
     {
         $this->securityManager = $securityManager;
         $this->domainAccessManager = $domainAccessManager;
@@ -64,12 +56,12 @@ class NotIdentifiedException extends ReadableException
         return $this->fetchTemplate("exception/not-identified.tpl");
     }
 
-    protected function getSecurityManager(): SecurityManager
+    protected function getSecurityManager(): ISecurityManager
     {
         return $this->securityManager;
     }
 
-    public function getDomainAccessManager(): DomainAccessManager
+    public function getDomainAccessManager(): IDomainAccessManager
     {
         return $this->domainAccessManager;
     }

--- a/includes/Fragments/NavigationMenuAccessControl.php
+++ b/includes/Fragments/NavigationMenuAccessControl.php
@@ -31,20 +31,17 @@ use Waca\Pages\PageWelcomeTemplateManagement;
 use Waca\Pages\Statistics\StatsMain;
 use Waca\Pages\Statistics\StatsUsers;
 use Waca\PdoDatabase;
-use Waca\Security\DomainAccessManager;
+use Waca\Security\IDomainAccessManager;
+use Waca\Security\ISecurityManager;
 use Waca\Security\RoleConfiguration;
-use Waca\Security\SecurityManager;
 
 trait NavigationMenuAccessControl
 {
     protected abstract function assign($name, $value);
 
-    /**
-     * @return SecurityManager
-     */
-    protected abstract function getSecurityManager();
+    protected abstract function getSecurityManager(): ISecurityManager;
 
-    public abstract function getDomainAccessManager(): DomainAccessManager;
+    public abstract function getDomainAccessManager(): IDomainAccessManager;
 
     /**
      * @param $currentUser
@@ -52,50 +49,50 @@ trait NavigationMenuAccessControl
     protected function setupNavMenuAccess($currentUser)
     {
         $this->assign('nav__canRequests', $this->getSecurityManager()
-                ->allows(PageMain::class, RoleConfiguration::MAIN, $currentUser) === SecurityManager::ALLOWED);
+                ->allows(PageMain::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
 
         $this->assign('nav__canLogs', $this->getSecurityManager()
-                ->allows(PageLog::class, RoleConfiguration::MAIN, $currentUser) === SecurityManager::ALLOWED);
+                ->allows(PageLog::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canUsers', $this->getSecurityManager()
-                ->allows(StatsUsers::class, RoleConfiguration::MAIN, $currentUser) === SecurityManager::ALLOWED);
+                ->allows(StatsUsers::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canSearch', $this->getSecurityManager()
-                ->allows(PageSearch::class, RoleConfiguration::MAIN, $currentUser) === SecurityManager::ALLOWED);
+                ->allows(PageSearch::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canStats', $this->getSecurityManager()
-                ->allows(StatsMain::class, RoleConfiguration::MAIN, $currentUser) === SecurityManager::ALLOWED);
+                ->allows(StatsMain::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
 
         $this->assign('nav__canBan', $this->getSecurityManager()
-                ->allows(PageBan::class, RoleConfiguration::MAIN, $currentUser) === SecurityManager::ALLOWED);
+                ->allows(PageBan::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canEmailMgmt', $this->getSecurityManager()
                 ->allows(PageEmailManagement::class, RoleConfiguration::MAIN,
-                    $currentUser) === SecurityManager::ALLOWED);
+                    $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canWelcomeMgmt', $this->getSecurityManager()
                 ->allows(PageWelcomeTemplateManagement::class, RoleConfiguration::MAIN,
-                    $currentUser) === SecurityManager::ALLOWED);
+                    $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canSiteNoticeMgmt', $this->getSecurityManager()
-                ->allows(PageSiteNotice::class, RoleConfiguration::MAIN, $currentUser) === SecurityManager::ALLOWED);
+                ->allows(PageSiteNotice::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canUserMgmt', $this->getSecurityManager()
                 ->allows(PageUserManagement::class, RoleConfiguration::MAIN,
-                    $currentUser) === SecurityManager::ALLOWED);
+                    $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canJobQueue', $this->getSecurityManager()
                 ->allows(PageJobQueue::class, RoleConfiguration::MAIN,
-                    $currentUser) === SecurityManager::ALLOWED);
+                    $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canDomainMgmt', $this->getSecurityManager()
                 ->allows(PageDomainManagement::class, RoleConfiguration::MAIN,
-                    $currentUser) === SecurityManager::ALLOWED);
+                    $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canFlaggedComments', $this->getSecurityManager()
                 ->allows(PageListFlaggedComments::class, RoleConfiguration::MAIN,
-                    $currentUser) === SecurityManager::ALLOWED);
+                    $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canQueueMgmt', $this->getSecurityManager()
                 ->allows(PageQueueManagement::class, RoleConfiguration::MAIN,
-                    $currentUser) === SecurityManager::ALLOWED);
+                    $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canFormMgmt', $this->getSecurityManager()
                 ->allows(PageRequestFormManagement::class, RoleConfiguration::MAIN,
-                    $currentUser) === SecurityManager::ALLOWED);
+                    $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canErrorLog', $this->getSecurityManager()
-                ->allows(PageErrorLogViewer::class, RoleConfiguration::MAIN, $currentUser) === SecurityManager::ALLOWED);
+                ->allows(PageErrorLogViewer::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
 
         $this->assign('nav__canViewRequest', $this->getSecurityManager()
-                ->allows(PageViewRequest::class, RoleConfiguration::MAIN, $currentUser) === SecurityManager::ALLOWED);
+                ->allows(PageViewRequest::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
 
         $this->assign('nav__domainList', []);
         if ($this->getDomainAccessManager() !== null) {

--- a/includes/Fragments/NavigationMenuAccessControl.php
+++ b/includes/Fragments/NavigationMenuAccessControl.php
@@ -33,7 +33,7 @@ use Waca\Pages\Statistics\StatsUsers;
 use Waca\PdoDatabase;
 use Waca\Security\IDomainAccessManager;
 use Waca\Security\ISecurityManager;
-use Waca\Security\RoleConfiguration;
+use Waca\Security\RoleConfigurationBase;
 
 trait NavigationMenuAccessControl
 {
@@ -49,50 +49,50 @@ trait NavigationMenuAccessControl
     protected function setupNavMenuAccess($currentUser)
     {
         $this->assign('nav__canRequests', $this->getSecurityManager()
-                ->allows(PageMain::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
+                ->allows(PageMain::class, RoleConfigurationBase::MAIN, $currentUser) === ISecurityManager::ALLOWED);
 
         $this->assign('nav__canLogs', $this->getSecurityManager()
-                ->allows(PageLog::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
+                ->allows(PageLog::class, RoleConfigurationBase::MAIN, $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canUsers', $this->getSecurityManager()
-                ->allows(StatsUsers::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
+                ->allows(StatsUsers::class, RoleConfigurationBase::MAIN, $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canSearch', $this->getSecurityManager()
-                ->allows(PageSearch::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
+                ->allows(PageSearch::class, RoleConfigurationBase::MAIN, $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canStats', $this->getSecurityManager()
-                ->allows(StatsMain::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
+                ->allows(StatsMain::class, RoleConfigurationBase::MAIN, $currentUser) === ISecurityManager::ALLOWED);
 
         $this->assign('nav__canBan', $this->getSecurityManager()
-                ->allows(PageBan::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
+                ->allows(PageBan::class, RoleConfigurationBase::MAIN, $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canEmailMgmt', $this->getSecurityManager()
-                ->allows(PageEmailManagement::class, RoleConfiguration::MAIN,
+                ->allows(PageEmailManagement::class, RoleConfigurationBase::MAIN,
                     $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canWelcomeMgmt', $this->getSecurityManager()
-                ->allows(PageWelcomeTemplateManagement::class, RoleConfiguration::MAIN,
+                ->allows(PageWelcomeTemplateManagement::class, RoleConfigurationBase::MAIN,
                     $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canSiteNoticeMgmt', $this->getSecurityManager()
-                ->allows(PageSiteNotice::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
+                ->allows(PageSiteNotice::class, RoleConfigurationBase::MAIN, $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canUserMgmt', $this->getSecurityManager()
-                ->allows(PageUserManagement::class, RoleConfiguration::MAIN,
+                ->allows(PageUserManagement::class, RoleConfigurationBase::MAIN,
                     $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canJobQueue', $this->getSecurityManager()
-                ->allows(PageJobQueue::class, RoleConfiguration::MAIN,
+                ->allows(PageJobQueue::class, RoleConfigurationBase::MAIN,
                     $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canDomainMgmt', $this->getSecurityManager()
-                ->allows(PageDomainManagement::class, RoleConfiguration::MAIN,
+                ->allows(PageDomainManagement::class, RoleConfigurationBase::MAIN,
                     $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canFlaggedComments', $this->getSecurityManager()
-                ->allows(PageListFlaggedComments::class, RoleConfiguration::MAIN,
+                ->allows(PageListFlaggedComments::class, RoleConfigurationBase::MAIN,
                     $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canQueueMgmt', $this->getSecurityManager()
-                ->allows(PageQueueManagement::class, RoleConfiguration::MAIN,
+                ->allows(PageQueueManagement::class, RoleConfigurationBase::MAIN,
                     $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canFormMgmt', $this->getSecurityManager()
-                ->allows(PageRequestFormManagement::class, RoleConfiguration::MAIN,
+                ->allows(PageRequestFormManagement::class, RoleConfigurationBase::MAIN,
                     $currentUser) === ISecurityManager::ALLOWED);
         $this->assign('nav__canErrorLog', $this->getSecurityManager()
-                ->allows(PageErrorLogViewer::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
+                ->allows(PageErrorLogViewer::class, RoleConfigurationBase::MAIN, $currentUser) === ISecurityManager::ALLOWED);
 
         $this->assign('nav__canViewRequest', $this->getSecurityManager()
-                ->allows(PageViewRequest::class, RoleConfiguration::MAIN, $currentUser) === ISecurityManager::ALLOWED);
+                ->allows(PageViewRequest::class, RoleConfigurationBase::MAIN, $currentUser) === ISecurityManager::ALLOWED);
 
         $this->assign('nav__domainList', []);
         if ($this->getDomainAccessManager() !== null) {
@@ -118,13 +118,13 @@ trait NavigationMenuAccessControl
         $countOfJobQueue = 0;
 
         // Count of flagged comments:
-        if($this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageListFlaggedComments::class)) {
+        if($this->barrierTest(RoleConfigurationBase::MAIN, $currentUser, PageListFlaggedComments::class)) {
             // We want all flagged comments that haven't been acknowledged if we can visit the page.
             $countOfFlagged = sizeof(Comment::getFlaggedComments($database, 1)); // FIXME: domains
         }
 
         // Count of failed job queue changes:
-        if($this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageJobQueue::class)) {
+        if($this->barrierTest(RoleConfigurationBase::MAIN, $currentUser, PageJobQueue::class)) {
             // We want all failed jobs that haven't been acknowledged if we can visit the page.
             JobQueueSearchHelper::get($database, 1) // FIXME: domains
                 ->statusIn([JobQueue::STATUS_FAILED])

--- a/includes/Fragments/RequestData.php
+++ b/includes/Fragments/RequestData.php
@@ -21,7 +21,7 @@ use Waca\Providers\Interfaces\ILocationProvider;
 use Waca\Providers\Interfaces\IRDnsProvider;
 use Waca\Providers\Interfaces\IXffTrustProvider;
 use Waca\RequestStatus;
-use Waca\Security\SecurityManager;
+use Waca\Security\ISecurityManager;
 use Waca\SiteConfiguration;
 use Waca\WebRequest;
 
@@ -121,8 +121,7 @@ trait RequestData
      */
     abstract protected function getRouteName();
 
-    /** @return SecurityManager */
-    abstract protected function getSecurityManager();
+    abstract protected function getSecurityManager(): ISecurityManager;
 
     /**
      * Sets the name of the template this page should display.

--- a/includes/Helpers/BanHelper.php
+++ b/includes/Helpers/BanHelper.php
@@ -17,7 +17,7 @@ use Waca\DataObjects\User;
 use Waca\Helpers\Interfaces\IBanHelper;
 use Waca\PdoDatabase;
 use Waca\Providers\Interfaces\IXffTrustProvider;
-use Waca\Security\SecurityManager;
+use Waca\Security\ISecurityManager;
 
 class BanHelper implements IBanHelper
 {
@@ -27,15 +27,13 @@ class BanHelper implements IBanHelper
     private $xffTrustProvider;
     /** @var Ban[][] */
     private $banCache = [];
-    /**
-     * @var null|SecurityManager
-     */
-    private $securityManager;
+
+    private ?ISecurityManager $securityManager;
 
     public function __construct(
         PdoDatabase $database,
         IXffTrustProvider $xffTrustProvider,
-        ?SecurityManager $securityManager
+        ?ISecurityManager $securityManager
     ) {
         $this->database = $database;
         $this->xffTrustProvider = $xffTrustProvider;
@@ -145,20 +143,20 @@ SQL;
         $user = User::getCurrent($this->database);
 
         $allowed = true;
-        $allowed = $allowed && ($ban->getName() === null || $this->securityManager->allows('BanType', 'name', $user) === SecurityManager::ALLOWED);
-        $allowed = $allowed && ($ban->getEmail() === null || $this->securityManager->allows('BanType', 'email', $user) === SecurityManager::ALLOWED);
-        $allowed = $allowed && ($ban->getIp() === null || $this->securityManager->allows('BanType', 'ip', $user) === SecurityManager::ALLOWED);
-        $allowed = $allowed && ($ban->getUseragent() === null || $this->securityManager->allows('BanType', 'useragent', $user) === SecurityManager::ALLOWED);
+        $allowed = $allowed && ($ban->getName() === null || $this->securityManager->allows('BanType', 'name', $user) === ISecurityManager::ALLOWED);
+        $allowed = $allowed && ($ban->getEmail() === null || $this->securityManager->allows('BanType', 'email', $user) === ISecurityManager::ALLOWED);
+        $allowed = $allowed && ($ban->getIp() === null || $this->securityManager->allows('BanType', 'ip', $user) === ISecurityManager::ALLOWED);
+        $allowed = $allowed && ($ban->getUseragent() === null || $this->securityManager->allows('BanType', 'useragent', $user) === ISecurityManager::ALLOWED);
 
         if ($ban->getDomain() === null) {
-            $allowed &= $this->securityManager->allows('BanType', 'global', $user) === SecurityManager::ALLOWED;
+            $allowed &= $this->securityManager->allows('BanType', 'global', $user) === ISecurityManager::ALLOWED;
         }
         else {
             $currentDomain = Domain::getCurrent($this->database);
             $allowed &= $currentDomain->getId() === $ban->getDomain();
         }
 
-        $allowed = $allowed && $this->securityManager->allows('BanVisibility', $ban->getVisibility(), $user) === SecurityManager::ALLOWED;
+        $allowed = $allowed && $this->securityManager->allows('BanVisibility', $ban->getVisibility(), $user) === ISecurityManager::ALLOWED;
 
         return $allowed;
     }

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -26,7 +26,7 @@ use Waca\DataObjects\WelcomeTemplate;
 use Waca\Helpers\SearchHelpers\LogSearchHelper;
 use Waca\Helpers\SearchHelpers\UserSearchHelper;
 use Waca\PdoDatabase;
-use Waca\Security\SecurityManager;
+use Waca\Security\ISecurityManager;
 use Waca\SiteConfiguration;
 
 class LogHelper
@@ -39,14 +39,14 @@ class LogHelper
     public static function getRequestLogsWithComments(
         $requestId,
         PdoDatabase $db,
-        SecurityManager $securityManager
+        ISecurityManager $securityManager
     ): array {
         // FIXME: domains
         $logs = LogSearchHelper::get($db, 1)->byObjectType('Request')->byObjectId($requestId)->fetch();
 
         $currentUser = User::getCurrent($db);
-        $showRestrictedComments = $securityManager->allows('RequestData', 'seeRestrictedComments', $currentUser) === SecurityManager::ALLOWED;
-        $showCheckuserComments = $securityManager->allows('RequestData', 'seeCheckuserComments', $currentUser) === SecurityManager::ALLOWED;
+        $showRestrictedComments = $securityManager->allows('RequestData', 'seeRestrictedComments', $currentUser) === ISecurityManager::ALLOWED;
+        $showCheckuserComments = $securityManager->allows('RequestData', 'seeCheckuserComments', $currentUser) === ISecurityManager::ALLOWED;
 
         $comments = Comment::getForRequest($requestId, $db, $showRestrictedComments, $showCheckuserComments, $currentUser->getId());
 

--- a/includes/IIdentificationVerifier.php
+++ b/includes/IIdentificationVerifier.php
@@ -1,0 +1,31 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca;
+
+use Waca\Exceptions\EnvironmentException;
+
+/**
+ * Handles automatically verifying if users are identified with the Wikimedia Foundation or not.  Intended to be used
+ * as necessary by the User class when a user's "forceidentified" attribute is NULL.
+ *
+ * @category Security-Critical
+ */
+interface IIdentificationVerifier
+{
+    /**
+     * Checks if the given user is identified to the Wikimedia Foundation.
+     *
+     * @param string $onWikiName The Wikipedia username of the user
+     *
+     * @return bool
+     * @throws EnvironmentException
+     * @category Security-Critical
+     */
+    public function isUserIdentified(string $onWikiName): bool;
+}

--- a/includes/Pages/PageDomainSwitch.php
+++ b/includes/Pages/PageDomainSwitch.php
@@ -11,6 +11,8 @@ namespace Waca\Pages;
 
 use Waca\DataObjects\Domain;
 use Waca\DataObjects\User;
+use Waca\Exceptions\AccessDeniedException;
+use Waca\Exceptions\DomainSwitchNotAllowedException;
 use Waca\Router\RequestRouter;
 use Waca\Tasks\InternalPageBase;
 use Waca\WebRequest;
@@ -40,7 +42,12 @@ class PageDomainSwitch extends InternalPageBase
             return;
         }
 
-        $this->getDomainAccessManager()->switchDomain($currentUser, $newDomain);
+        try {
+            $this->getDomainAccessManager()->switchDomain($currentUser, $newDomain);
+        }
+        catch(DomainSwitchNotAllowedException $ex){
+            throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
+        }
 
         // try to stay on the same page if possible.
         // This only checks basic ACLs and not domain privileges, so this may still result in a 403.

--- a/includes/Pages/PageListFlaggedComments.php
+++ b/includes/Pages/PageListFlaggedComments.php
@@ -13,7 +13,7 @@ use Waca\DataObjects\Comment;
 use Waca\DataObjects\Request;
 use Waca\DataObjects\User;
 use Waca\PdoDatabase;
-use Waca\Security\RoleConfiguration;
+use Waca\Security\RoleConfigurationBase;
 use Waca\Tasks\InternalPageBase;
 
 class PageListFlaggedComments extends InternalPageBase
@@ -98,8 +98,8 @@ class PageListFlaggedComments extends InternalPageBase
         $this->assign('seeCheckuserComments', $seeCheckuserComments);
 
         $this->assign('editOthersComments', $this->barrierTest('editOthers', $currentUser, PageEditComment::class));
-        $this->assign('editComments', $this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageEditComment::class));
-        $this->assign('canUnflag', $this->barrierTest('unflag', $currentUser, PageFlagComment::class) && $this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageFlagComment::class));
+        $this->assign('editComments', $this->barrierTest(RoleConfigurationBase::MAIN, $currentUser, PageEditComment::class));
+        $this->assign('canUnflag', $this->barrierTest('unflag', $currentUser, PageFlagComment::class) && $this->barrierTest(RoleConfigurationBase::MAIN, $currentUser, PageFlagComment::class));
     }
 
     private function copyCommentData(Comment $object, array &$data, PdoDatabase $database): void

--- a/includes/Pages/PageUserManagement.php
+++ b/includes/Pages/PageUserManagement.php
@@ -636,7 +636,7 @@ class PageUserManagement extends InternalPageBase
      */
     private function getRoleData($activeRoles)
     {
-        $availableRoles = $this->getSecurityManager()->getRoleConfiguration()->getAvailableRoles();
+        $availableRoles = $this->getSecurityManager()->getAvailableRoles();
 
         $currentUser = User::getCurrent($this->getDatabase());
         $this->getSecurityManager()->getActiveRoles($currentUser, $userRoles, $inactiveRoles);

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -26,7 +26,7 @@ use Waca\Helpers\OAuthUserHelper;
 use Waca\Helpers\PreferenceManager;
 use Waca\Pages\RequestAction\PageManuallyConfirm;
 use Waca\PdoDatabase;
-use Waca\Security\RoleConfiguration;
+use Waca\Security\RoleConfigurationBase;
 use Waca\RequestStatus;
 use Waca\Tasks\InternalPageBase;
 use Waca\WebRequest;
@@ -62,7 +62,7 @@ class PageViewRequest extends InternalPageBase
         // Shows a page if the email is not confirmed.
         if ($request->getEmailConfirm() !== 'Confirmed') {
             // Show a banner if the user can manually confirm the request
-            $viewConfirm = $this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageManuallyConfirm::class);
+            $viewConfirm = $this->barrierTest(RoleConfigurationBase::MAIN, $currentUser, PageManuallyConfirm::class);
 
             // If the request is purged, there's nothing to confirm!
             if ($request->getEmail() === $this->getSiteConfiguration()->getDataClearEmail()) {
@@ -233,7 +233,7 @@ class PageViewRequest extends InternalPageBase
 
         $editableComments = $this->barrierTest('editOthers', $currentUser, PageEditComment::class);
 
-        $canFlag = $this->barrierTest(RoleConfiguration::MAIN, $currentUser, PageFlagComment::class);
+        $canFlag = $this->barrierTest(RoleConfigurationBase::MAIN, $currentUser, PageFlagComment::class);
         $canUnflag = $this->barrierTest('unflag', $currentUser, PageFlagComment::class);
 
         /** @var Log|Comment $entry */

--- a/includes/Pages/RequestAction/PageCreateRequest.php
+++ b/includes/Pages/RequestAction/PageCreateRequest.php
@@ -21,7 +21,7 @@ use Waca\Helpers\Logger;
 use Waca\Helpers\PreferenceManager;
 use Waca\PdoDatabase;
 use Waca\RequestStatus;
-use Waca\Security\SecurityManager;
+use Waca\Security\ISecurityManager;
 use Waca\SessionAlert;
 use Waca\WebRequest;
 
@@ -54,12 +54,12 @@ class PageCreateRequest extends RequestActionBase
         $preferencesManager = PreferenceManager::getForCurrent($database);
 
         $secMgr = $this->getSecurityManager();
-        if ($secMgr->allows('RequestCreation', PreferenceManager::CREATION_BOT, $user) !== SecurityManager::ALLOWED
+        if ($secMgr->allows('RequestCreation', PreferenceManager::CREATION_BOT, $user) !== ISecurityManager::ALLOWED
             && $creationMode === 'bot'
         ) {
             throw new AccessDeniedException($secMgr, $this->getDomainAccessManager());
         }
-        elseif ($secMgr->allows('RequestCreation', PreferenceManager::CREATION_OAUTH, $user) !== SecurityManager::ALLOWED
+        elseif ($secMgr->allows('RequestCreation', PreferenceManager::CREATION_OAUTH, $user) !== ISecurityManager::ALLOWED
             && $creationMode === 'oauth'
         ) {
             throw new AccessDeniedException($secMgr, $this->getDomainAccessManager());

--- a/includes/Pages/Statistics/StatsUsers.php
+++ b/includes/Pages/Statistics/StatsUsers.php
@@ -35,13 +35,11 @@ class StatsUsers extends InternalPageBase
 SELECT
     u.id
     , u.username
-    , CASE WHEN ru.role IS NOT NULL THEN 'Yes' ELSE 'No' END tooluser
     , CASE WHEN ra.role IS NOT NULL THEN 'Yes' ELSE 'No' END tooladmin
     , CASE WHEN rc.role IS NOT NULL THEN 'Yes' ELSE 'No' END checkuser
     , CASE WHEN rs.role IS NOT NULL THEN 'Yes' ELSE 'No' END steward
     , CASE WHEN rr.role IS NOT NULL THEN 'Yes' ELSE 'No' END toolroot
 FROM user u
-    LEFT JOIN userrole ru ON ru.user = u.id AND ru.role = 'user'
     LEFT JOIN userrole ra ON ra.user = u.id AND ra.role = 'admin'
     LEFT JOIN userrole rc ON rc.user = u.id AND rc.role = 'checkuser'
     LEFT JOIN userrole rs ON rs.user = u.id AND rs.role = 'steward'

--- a/includes/Pages/UserAuth/PagePreferences.php
+++ b/includes/Pages/UserAuth/PagePreferences.php
@@ -14,7 +14,7 @@ use Waca\DataObjects\User;
 use Waca\Helpers\OAuthUserHelper;
 use Waca\Helpers\PreferenceManager;
 use Waca\Pages\PageMain;
-use Waca\Security\RoleConfiguration;
+use Waca\Security\RoleConfigurationBase;
 use Waca\SessionAlert;
 use Waca\Tasks\InternalPageBase;
 use Waca\WebRequest;
@@ -53,7 +53,7 @@ class PagePreferences extends InternalPageBase
             $user->save();
             SessionAlert::success("Preferences updated!");
 
-            if ($this->barrierTest(RoleConfiguration::MAIN, $user, PageMain::class)) {
+            if ($this->barrierTest(RoleConfigurationBase::MAIN, $user, PageMain::class)) {
                 $this->redirect('');
             }
             else {

--- a/includes/Security/DomainAccessManager.php
+++ b/includes/Security/DomainAccessManager.php
@@ -13,21 +13,12 @@ use Waca\DataObject;
 use Waca\DataObjects\Domain;
 use Waca\DataObjects\User;
 use Waca\Exceptions\AccessDeniedException;
+use Waca\Exceptions\DomainSwitchNotAllowedException;
 use Waca\Helpers\PreferenceManager;
 use Waca\WebRequest;
 
-class DomainAccessManager
+class DomainAccessManager implements IDomainAccessManager
 {
-    /**
-     * @var SecurityManager
-     */
-    private $securityManager;
-
-    public function __construct(SecurityManager $securityManager)
-    {
-        $this->securityManager = $securityManager;
-    }
-
     /**
      * @param User $user
      *
@@ -54,7 +45,7 @@ class DomainAccessManager
             WebRequest::setActiveDomain($newDomain);
         }
         else {
-            throw new AccessDeniedException($this->securityManager, $this);
+            throw new DomainSwitchNotAllowedException();
         }
     }
 

--- a/includes/Security/DomainAccessManager.php
+++ b/includes/Security/DomainAccessManager.php
@@ -18,7 +18,19 @@ use Waca\WebRequest;
 
 class DomainAccessManager implements IDomainAccessManager
 {
+    private IUserAccessLoader $userAccessLoader;
+
+    public function __construct(IUserAccessLoader $userAccessLoader)
+    {
+        $this->userAccessLoader = $userAccessLoader;
+    }
+
     /**
+     * Returns the domains the user is a member of.
+     *
+     * Note - this *does not* determine the access rights that a user has in any
+     * specific domain. Permissions checks still need to be performed.
+     *
      * @param User $user
      *
      * @return Domain[]
@@ -29,7 +41,7 @@ class DomainAccessManager implements IDomainAccessManager
             return [];
         }
 
-        return Domain::getDomainByUser($user->getDatabase(), $user, true);
+        return $this->userAccessLoader->loadDomainsForUser($user);
     }
 
     public function switchDomain(User $user, Domain $newDomain): void

--- a/includes/Security/DomainAccessManager.php
+++ b/includes/Security/DomainAccessManager.php
@@ -12,7 +12,6 @@ namespace Waca\Security;
 use Waca\DataObject;
 use Waca\DataObjects\Domain;
 use Waca\DataObjects\User;
-use Waca\Exceptions\AccessDeniedException;
 use Waca\Exceptions\DomainSwitchNotAllowedException;
 use Waca\Helpers\PreferenceManager;
 use Waca\WebRequest;
@@ -39,7 +38,7 @@ class DomainAccessManager implements IDomainAccessManager
             return $object->getId();
         };
 
-        $allowed = in_array($newDomain->getId(), array_map($mapToId, self::getAllowedDomains($user)));
+        $allowed = in_array($newDomain->getId(), array_map($mapToId, $this->getAllowedDomains($user)));
 
         if ($allowed) {
             WebRequest::setActiveDomain($newDomain);

--- a/includes/Security/IDomainAccessManager.php
+++ b/includes/Security/IDomainAccessManager.php
@@ -1,0 +1,26 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\Security;
+
+use Waca\DataObjects\Domain;
+use Waca\DataObjects\User;
+
+interface IDomainAccessManager
+{
+    public function switchToDefaultDomain(User $user): void;
+
+    public function switchDomain(User $user, Domain $newDomain): void;
+
+    /**
+     * @param User $user
+     *
+     * @return Domain[]
+     */
+    public function getAllowedDomains(User $user): array;
+}

--- a/includes/Security/ISecurityManager.php
+++ b/includes/Security/ISecurityManager.php
@@ -1,0 +1,40 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\Security;
+
+use Waca\DataObjects\User;
+
+interface ISecurityManager
+{
+    public const ALLOWED = 1;
+    public const ERROR_NOT_IDENTIFIED = 2;
+    public const ERROR_DENIED = 3;
+
+    /**
+     * Tests if a user is allowed to perform an action.
+     *
+     * This method should form a hard, deterministic security barrier, and only return true if it is absolutely sure
+     * that a user should have access to something.
+     *
+     * @param string $page
+     * @param string $route
+     * @param User   $user
+     *
+     * @return int
+     *
+     * @category Security-Critical
+     */
+    public function allows(string $page, string $route, User $user): int;
+
+    public function getActiveRoles(User $user, ?array &$activeRoles, ?array &$inactiveRoles);
+
+    public function getCachedActiveRoles(User $user, ?array &$activeRoles, ?array &$inactiveRoles): void;
+
+    public function getRoleConfiguration(): RoleConfiguration;
+}

--- a/includes/Security/ISecurityManager.php
+++ b/includes/Security/ISecurityManager.php
@@ -36,5 +36,5 @@ interface ISecurityManager
 
     public function getCachedActiveRoles(User $user, ?array &$activeRoles, ?array &$inactiveRoles): void;
 
-    public function getRoleConfiguration(): RoleConfigurationBase;
+    public function getAvailableRoles(): array;
 }

--- a/includes/Security/ISecurityManager.php
+++ b/includes/Security/ISecurityManager.php
@@ -36,5 +36,5 @@ interface ISecurityManager
 
     public function getCachedActiveRoles(User $user, ?array &$activeRoles, ?array &$inactiveRoles): void;
 
-    public function getRoleConfiguration(): RoleConfiguration;
+    public function getRoleConfiguration(): RoleConfigurationBase;
 }

--- a/includes/Security/IUserAccessLoader.php
+++ b/includes/Security/IUserAccessLoader.php
@@ -10,7 +10,21 @@ namespace Waca\Security;
 
 use Waca\DataObjects\User;
 
-interface IUserRoleLoader
+interface IUserAccessLoader
 {
+    /**
+     * Loads the roles for the given user in the current domain from the database.
+     *
+     * This is mostly just a wrapper around the static method calls so this logic
+     * can be mocked out in unit tests.
+     */
     public function loadRolesForUser(User $user): array;
+
+    /**
+     * Loads the domains which are currently active for the given user
+     *
+     * This is mostly just a wrapper around the static method calls so this logic
+     * can be mocked out in unit tests.
+     */
+    public function loadDomainsForUser(User $user): array;
 }

--- a/includes/Security/IUserRoleLoader.php
+++ b/includes/Security/IUserRoleLoader.php
@@ -1,0 +1,16 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\Security;
+
+use Waca\DataObjects\User;
+
+interface IUserRoleLoader
+{
+    public function loadRolesForUser(User $user): array;
+}

--- a/includes/Security/RoleConfiguration.php
+++ b/includes/Security/RoleConfiguration.php
@@ -147,8 +147,9 @@ class RoleConfiguration
             )
         ),
         'user'              => array(
-            '_description'                       => 'A standard tool user.',
-            '_editableBy'                        => array('admin', 'toolRoot'),
+            /*
+             * THIS ROLE IS GRANTED TO APPROVED AND IDENTIFIED LOGGED-IN USERS IMPLICITLY.
+             */
             '_childRoles'                        => array(
                 'internalStats',
             ),
@@ -512,7 +513,8 @@ class RoleConfiguration
 
     public function getAvailableRoles(): array
     {
-        $possible = array_diff(array_keys($this->roleConfig), array('public', 'loggedIn'));
+        // remove the implicit roles
+        $possible = array_diff(array_keys($this->roleConfig), array('public', 'loggedIn', 'user'));
 
         $actual = array();
 

--- a/includes/Security/RoleConfiguration.php
+++ b/includes/Security/RoleConfiguration.php
@@ -55,14 +55,8 @@ use Waca\Pages\Statistics\StatsTemplateStats;
 use Waca\Pages\Statistics\StatsTopCreators;
 use Waca\Pages\Statistics\StatsUsers;
 
-class RoleConfiguration
+final class RoleConfiguration extends RoleConfigurationBase
 {
-    const ACCESS_ALLOW = 1;
-    const ACCESS_DENY = -1;
-    const ACCESS_DEFAULT = 0;
-    const MAIN = 'main';
-    const ALL = '*';
-
     /**
      * A map of roles to rights
      *
@@ -90,8 +84,9 @@ class RoleConfiguration
      * The public role is special, and is applied to all users automatically. Avoid using deny on this role.
      *
      * @var array
+     * @category Security-Critical
      */
-    private array $roleConfig = array(
+    private static array $productionRoleConfig = array(
         'public'            => array(
             /*
              * THIS ROLE IS GRANTED TO ALL LOGGED *OUT* USERS IMPLICITLY.
@@ -460,83 +455,10 @@ class RoleConfiguration
      *
      * @category Security-Critical
      */
-    private array $identificationExempt = array('public', 'loggedIn');
+    private static array $productionIdentificationExempt = array('public', 'loggedIn');
 
-    /**
-     * RoleConfiguration constructor.
-     *
-     * @param ?array $roleConfig           Set to non-null to override the default configuration.
-     * @param ?array $identificationExempt Set to non-null to override the default configuration.
-     */
-    public function __construct(array $roleConfig = null, array $identificationExempt = null)
+    public function __construct()
     {
-        if ($roleConfig !== null) {
-            $this->roleConfig = $roleConfig;
-        }
-
-        if ($identificationExempt !== null) {
-            $this->identificationExempt = $identificationExempt;
-        }
-    }
-
-    /**
-     * @param array $roles The roles to check
-     */
-    public function getApplicableRoles(array $roles): array
-    {
-        $available = array();
-
-        foreach ($roles as $role) {
-            if (!isset($this->roleConfig[$role])) {
-                // wat
-                continue;
-            }
-
-            $available[$role] = $this->roleConfig[$role];
-
-            if (isset($available[$role]['_childRoles'])) {
-                $childRoles = $this->getApplicableRoles($available[$role]['_childRoles']);
-                $available = array_merge($available, $childRoles);
-
-                unset($available[$role]['_childRoles']);
-            }
-
-            foreach (array('_hidden', '_editableBy', '_description') as $item) {
-                if (isset($available[$role][$item])) {
-                    unset($available[$role][$item]);
-                }
-            }
-        }
-
-        return $available;
-    }
-
-    public function getAvailableRoles(): array
-    {
-        // remove the implicit roles
-        $possible = array_diff(array_keys($this->roleConfig), array('public', 'loggedIn', 'user'));
-
-        $actual = array();
-
-        foreach ($possible as $role) {
-            if (!isset($this->roleConfig[$role]['_hidden'])) {
-                $actual[$role] = array(
-                    'description' => $this->roleConfig[$role]['_description'],
-                    'editableBy'  => $this->roleConfig[$role]['_editableBy'],
-                    'globalOnly'  => isset($this->roleConfig[$role]['_globalOnly']) && $this->roleConfig[$role]['_globalOnly'],
-                );
-            }
-        }
-
-        return $actual;
-    }
-
-    public function roleNeedsIdentification(string $role): bool
-    {
-        if (in_array($role, $this->identificationExempt)) {
-            return false;
-        }
-
-        return true;
+        parent::__construct(self::$productionRoleConfig, self::$productionIdentificationExempt);
     }
 }

--- a/includes/Security/RoleConfigurationBase.php
+++ b/includes/Security/RoleConfigurationBase.php
@@ -19,7 +19,7 @@ abstract class RoleConfigurationBase
     protected array $roleConfig;
     protected array $identificationExempt;
 
-    protected function __construct(array $roleConfig = null, array $identificationExempt = null)
+    protected function __construct(array $roleConfig, array $identificationExempt)
     {
         $this->roleConfig = $roleConfig;
         $this->identificationExempt = $identificationExempt;

--- a/includes/Security/RoleConfigurationBase.php
+++ b/includes/Security/RoleConfigurationBase.php
@@ -1,0 +1,144 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\Security;
+
+abstract class RoleConfigurationBase
+{
+    const ACCESS_ALLOW = 1;
+    const ACCESS_DENY = -1;
+    const ACCESS_DEFAULT = 0;
+    const MAIN = 'main';
+    const ALL = '*';
+
+    protected array $roleConfig;
+    protected array $identificationExempt;
+
+    protected function __construct(array $roleConfig = null, array $identificationExempt = null)
+    {
+        $this->roleConfig = $roleConfig;
+        $this->identificationExempt = $identificationExempt;
+    }
+
+    /**
+     * Takes an array of role names and flattens the values to a single
+     * resultant role configuration.
+     *
+     * @param string[] $activeRoles
+     * @category Security-Critical
+     */
+    public function getResultantRole(array $activeRoles): array
+    {
+        $result = array();
+
+        $roleConfig = $this->getApplicableRoles($activeRoles);
+
+        // Iterate over every page in every role
+        foreach ($roleConfig as $role) {
+            foreach ($role as $page => $pageRights) {
+                // Create holder in result for this page
+                if (!isset($result[$page])) {
+                    $result[$page] = array();
+                }
+
+                foreach ($pageRights as $action => $permission) {
+                    // Deny takes precedence, so if it's set, don't change it.
+                    if (isset($result[$page][$action])) {
+                        if ($result[$page][$action] === RoleConfigurationBase::ACCESS_DENY) {
+                            continue;
+                        }
+                    }
+
+                    if ($permission === RoleConfigurationBase::ACCESS_DEFAULT) {
+                        // Configured to do precisely nothing.
+                        continue;
+                    }
+
+                    $result[$page][$action] = $permission;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns a set of all roles which are available to be set.
+     *
+     * Hidden roles and implicit roles are excluded.
+     */
+    public function getAvailableRoles(): array
+    {
+        // remove the implicit roles
+        $possible = array_diff(array_keys($this->roleConfig), array('public', 'loggedIn', 'user'));
+
+        $actual = array();
+
+        foreach ($possible as $role) {
+            if (!isset($this->roleConfig[$role]['_hidden'])) {
+                $actual[$role] = array(
+                    'description' => $this->roleConfig[$role]['_description'],
+                    'editableBy'  => $this->roleConfig[$role]['_editableBy'],
+                    'globalOnly'  => isset($this->roleConfig[$role]['_globalOnly']) && $this->roleConfig[$role]['_globalOnly'],
+                );
+            }
+        }
+
+        return $actual;
+    }
+
+    /**
+     * Returns a boolean for whether the provided role requires identification
+     * before being used by a user.
+     *
+     * @category Security-Critical
+     */
+    public function roleNeedsIdentification(string $role): bool
+    {
+        if (in_array($role, $this->identificationExempt)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Takes an array of role names, and returns all the relevant roles for that
+     * set, including any child roles found recursively.
+     *
+     * @param array $roles The names of roles to start searching with
+     */
+    private function getApplicableRoles(array $roles): array
+    {
+        $available = array();
+
+        foreach ($roles as $role) {
+            if (!isset($this->roleConfig[$role])) {
+                // wat
+                continue;
+            }
+
+            $available[$role] = $this->roleConfig[$role];
+
+            if (isset($available[$role]['_childRoles'])) {
+                $childRoles = $this->getApplicableRoles($available[$role]['_childRoles']);
+                $available = array_merge($available, $childRoles);
+
+                unset($available[$role]['_childRoles']);
+            }
+
+            foreach (array('_hidden', '_editableBy', '_description') as $item) {
+                if (isset($available[$role][$item])) {
+                    unset($available[$role][$item]);
+                }
+            }
+        }
+
+        return $available;
+    }
+}

--- a/includes/Security/SecurityManager.php
+++ b/includes/Security/SecurityManager.php
@@ -14,22 +14,13 @@ use Waca\DataObjects\User;
 use Waca\DataObjects\UserRole;
 use Waca\IdentificationVerifier;
 
-final class SecurityManager
+final class SecurityManager implements ISecurityManager
 {
-    const ALLOWED = 1;
-    const ERROR_NOT_IDENTIFIED = 2;
-    const ERROR_DENIED = 3;
     private IdentificationVerifier $identificationVerifier;
     private RoleConfiguration $roleConfiguration;
 
     private array $cache = [];
 
-    /**
-     * SecurityManager constructor.
-     *
-     * @param IdentificationVerifier $identificationVerifier
-     * @param RoleConfiguration      $roleConfiguration
-     */
     public function __construct(
         IdentificationVerifier $identificationVerifier,
         RoleConfiguration $roleConfiguration
@@ -44,15 +35,9 @@ final class SecurityManager
      * This method should form a hard, deterministic security barrier, and only return true if it is absolutely sure
      * that a user should have access to something.
      *
-     * @param string $page
-     * @param string $route
-     * @param User   $user
-     *
-     * @return int
-     *
      * @category Security-Critical
      */
-    public function allows($page, $route, User $user)
+    public function allows(string $page, string $route, User $user): int
     {
         $this->getCachedActiveRoles($user, $activeRoles, $inactiveRoles);
 
@@ -78,6 +63,8 @@ final class SecurityManager
     }
 
     /**
+     * Tests a role for an ACL decision on a specific page/route
+     *
      * @param array  $pseudoRole The role (flattened) to check
      * @param string $page       The page class to check
      * @param string $route      The page route to check

--- a/includes/Security/SecurityManager.php
+++ b/includes/Security/SecurityManager.php
@@ -168,6 +168,9 @@ final class SecurityManager
             $userRoles[] = 'loggedIn';
 
             if ($user->isActive()) {
+                // All active users get +user
+                $userRoles[] = 'user';
+
                 $domain = Domain::getCurrent($user->getDatabase());
                 $ur = UserRole::getForUser($user->getId(), $user->getDatabase(), $domain->getId());
 

--- a/includes/Security/SecurityManager.php
+++ b/includes/Security/SecurityManager.php
@@ -20,16 +20,16 @@ final class SecurityManager implements ISecurityManager
     private RoleConfigurationBase $roleConfiguration;
 
     private array $cache = [];
-    private IUserRoleLoader $userRoleLoader;
+    private IUserAccessLoader $userAccessLoader;
 
     public function __construct(
         IIdentificationVerifier $identificationVerifier,
         RoleConfigurationBase $roleConfiguration,
-        IUserRoleLoader $userRoleLoader
+        IUserAccessLoader $userAccessLoader
     ) {
         $this->identificationVerifier = $identificationVerifier;
         $this->roleConfiguration = $roleConfiguration;
-        $this->userRoleLoader = $userRoleLoader;
+        $this->userAccessLoader = $userAccessLoader;
     }
 
     /**
@@ -81,7 +81,7 @@ final class SecurityManager implements ISecurityManager
                 // All active users get +user
                 $userRoles[] = 'user';
 
-                $loadedRoles = $this->userRoleLoader->loadRolesForUser($user);
+                $loadedRoles = $this->userAccessLoader->loadRolesForUser($user);
 
                 // NOTE: public is still in this array.
                 $userRoles = array_merge($userRoles, $loadedRoles);

--- a/includes/Security/SecurityManager.php
+++ b/includes/Security/SecurityManager.php
@@ -12,17 +12,17 @@ namespace Waca\Security;
 use Waca\DataObjects\Domain;
 use Waca\DataObjects\User;
 use Waca\DataObjects\UserRole;
-use Waca\IdentificationVerifier;
+use Waca\IIdentificationVerifier;
 
 final class SecurityManager implements ISecurityManager
 {
-    private IdentificationVerifier $identificationVerifier;
+    private IIdentificationVerifier $identificationVerifier;
     private RoleConfiguration $roleConfiguration;
 
     private array $cache = [];
 
     public function __construct(
-        IdentificationVerifier $identificationVerifier,
+        IIdentificationVerifier $identificationVerifier,
         RoleConfiguration $roleConfiguration
     ) {
         $this->identificationVerifier = $identificationVerifier;

--- a/includes/Security/SecurityManager.php
+++ b/includes/Security/SecurityManager.php
@@ -86,7 +86,7 @@ final class SecurityManager implements ISecurityManager
                 // NOTE: public is still in this array.
                 $userRoles = array_merge($userRoles, $loadedRoles);
 
-                $identified = $user->isIdentified($this->identificationVerifier);
+                $identified = $this->userIsIdentified($user);
             }
         }
 
@@ -164,5 +164,21 @@ final class SecurityManager implements ISecurityManager
 
         // return indeterminate result
         return null;
+    }
+
+    private function userIsIdentified(User $user): bool
+    {
+        if ($user->getForceIdentified() === false) {
+            // User forced to be unidentified in the database.
+            return false;
+        }
+
+        if ($user->getForceIdentified() === true) {
+            // User forced to be identified in the database.
+            return true;
+        }
+
+        // User not forced to any particular identified status; consult IdentificationVerifier
+        return $this->identificationVerifier->isUserIdentified($user->getOnWikiName());
     }
 }

--- a/includes/Security/UserAccessLoader.php
+++ b/includes/Security/UserAccessLoader.php
@@ -8,23 +8,44 @@
 
 namespace Waca\Security;
 
+use PDO;
 use Waca\DataObjects\Domain;
 use Waca\DataObjects\User;
 use Waca\DataObjects\UserRole;
 
-final class UserRoleLoader implements IUserRoleLoader
+final class UserAccessLoader implements IUserAccessLoader
 {
-    /**
-     * Loads the roles for the given user in the current domain from the database.
-     *
-     * This is mostly just a wrapper around the static method calls so this logic
-     * can be mocked out in unit tests.
-     */
     public function loadRolesForUser(User $user): array
     {
         $domain = Domain::getCurrent($user->getDatabase());
         $userRoles = UserRole::getForUser($user->getId(), $user->getDatabase(), $domain->getId());
 
         return array_map(fn(UserRole $r): string => $r->getRole(), $userRoles);
+    }
+
+    public function loadDomainsForUser(User $user): array
+    {
+        $database = $user->getDatabase();
+
+        $statement = $database->prepare(<<<'SQL'
+            SELECT d.* 
+            FROM domain d
+            INNER JOIN userdomain ud on d.id = ud.domain
+            WHERE ud.user = :user
+            AND d.enabled = 1
+SQL
+        );
+        $statement->execute([
+            ':user' => $user->getId()
+        ]);
+
+        $resultObjects = $statement->fetchAll(PDO::FETCH_CLASS, Domain::class);
+
+        /** @var Domain $t */
+        foreach ($resultObjects as $t) {
+            $t->setDatabase($database);
+        }
+
+        return $resultObjects;
     }
 }

--- a/includes/Security/UserRoleLoader.php
+++ b/includes/Security/UserRoleLoader.php
@@ -1,0 +1,30 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\Security;
+
+use Waca\DataObjects\Domain;
+use Waca\DataObjects\User;
+use Waca\DataObjects\UserRole;
+
+final class UserRoleLoader implements IUserRoleLoader
+{
+    /**
+     * Loads the roles for the given user in the current domain from the database.
+     *
+     * This is mostly just a wrapper around the static method calls so this logic
+     * can be mocked out in unit tests.
+     */
+    public function loadRolesForUser(User $user): array
+    {
+        $domain = Domain::getCurrent($user->getDatabase());
+        $userRoles = UserRole::getForUser($user->getId(), $user->getDatabase(), $domain->getId());
+
+        return array_map(fn(UserRole $r): string => $r->getRole(), $userRoles);
+    }
+}

--- a/includes/Tasks/InternalPageBase.php
+++ b/includes/Tasks/InternalPageBase.php
@@ -18,8 +18,8 @@ use Waca\Exceptions\NotIdentifiedException;
 use Waca\Fragments\NavigationMenuAccessControl;
 use Waca\Helpers\Interfaces\IBlacklistHelper;
 use Waca\Helpers\Interfaces\ITypeAheadHelper;
-use Waca\Security\DomainAccessManager;
-use Waca\Security\SecurityManager;
+use Waca\Security\IDomainAccessManager;
+use Waca\Security\ISecurityManager;
 use Waca\WebRequest;
 
 abstract class InternalPageBase extends PageBase
@@ -28,12 +28,11 @@ abstract class InternalPageBase extends PageBase
 
     /** @var ITypeAheadHelper */
     private $typeAheadHelper;
-    /** @var SecurityManager */
-    private $securityManager;
+    private ISecurityManager $securityManager;
     /** @var IBlacklistHelper */
     private $blacklistHelper;
-    /** @var DomainAccessManager */
-    private $domainAccessManager;
+
+    private IDomainAccessManager $domainAccessManager;
 
     /**
      * @return ITypeAheadHelper
@@ -86,7 +85,7 @@ abstract class InternalPageBase extends PageBase
         // This code essentially doesn't care if the user is logged in or not, as the security manager hides all that
         // away for us
         $securityResult = $this->getSecurityManager()->allows(get_called_class(), $this->getRouteName(), $currentUser);
-        if ($securityResult === SecurityManager::ALLOWED) {
+        if ($securityResult === ISecurityManager::ALLOWED) {
             // We're allowed to run the page, so let's run it.
             $this->runPage();
         }
@@ -168,11 +167,11 @@ abstract class InternalPageBase extends PageBase
         else {
             // Decide whether this was a rights failure, or an identification failure.
 
-            if ($denyReason === SecurityManager::ERROR_NOT_IDENTIFIED) {
+            if ($denyReason === ISecurityManager::ERROR_NOT_IDENTIFIED) {
                 // Not identified
                 throw new NotIdentifiedException($this->getSecurityManager(), $this->getDomainAccessManager());
             }
-            elseif ($denyReason === SecurityManager::ERROR_DENIED) {
+            elseif ($denyReason === ISecurityManager::ERROR_DENIED) {
                 // Nope, plain old access denied
                 throw new AccessDeniedException($this->getSecurityManager(), $this->getDomainAccessManager());
             }
@@ -204,7 +203,7 @@ abstract class InternalPageBase extends PageBase
 
         $securityResult = $this->getSecurityManager()->allows($page, $action, $user);
 
-        return $securityResult === SecurityManager::ALLOWED;
+        return $securityResult === ISecurityManager::ALLOWED;
     }
 
     /**
@@ -218,18 +217,12 @@ abstract class InternalPageBase extends PageBase
         }
     }
 
-    /**
-     * @return SecurityManager
-     */
-    public function getSecurityManager()
+    public function getSecurityManager(): ISecurityManager
     {
         return $this->securityManager;
     }
 
-    /**
-     * @param SecurityManager $securityManager
-     */
-    public function setSecurityManager(SecurityManager $securityManager)
+    public function setSecurityManager(ISecurityManager $securityManager)
     {
         $this->securityManager = $securityManager;
     }
@@ -250,18 +243,12 @@ abstract class InternalPageBase extends PageBase
         $this->blacklistHelper = $blacklistHelper;
     }
 
-    /**
-     * @return DomainAccessManager
-     */
-    public function getDomainAccessManager(): DomainAccessManager
+    public function getDomainAccessManager(): IDomainAccessManager
     {
         return $this->domainAccessManager;
     }
 
-    /**
-     * @param DomainAccessManager $domainAccessManager
-     */
-    public function setDomainAccessManager(DomainAccessManager $domainAccessManager): void
+    public function setDomainAccessManager(IDomainAccessManager $domainAccessManager): void
     {
         $this->domainAccessManager = $domainAccessManager;
     }

--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -88,7 +88,7 @@ class WebStart extends ApplicationBase
                     $page->setBlacklistHelper(new FakeBlacklistHelper());
                 }
 
-                $page->setDomainAccessManager(new DomainAccessManager($page->getSecurityManager()));
+                $page->setDomainAccessManager(new DomainAccessManager());
             }
         }
     }

--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -23,7 +23,7 @@ use Waca\Security\DomainAccessManager;
 use Waca\Security\RoleConfiguration;
 use Waca\Security\SecurityManager;
 use Waca\Security\TokenManager;
-use Waca\Security\UserRoleLoader;
+use Waca\Security\UserAccessLoader;
 use Waca\Tasks\ITask;
 use Waca\Tasks\InternalPageBase;
 use Waca\Tasks\PageBase;
@@ -79,18 +79,22 @@ class WebStart extends ApplicationBase
             if ($page instanceof InternalPageBase) {
                 $page->setTypeAheadHelper(new TypeAheadHelper());
 
-                $identificationVerifier = new IdentificationVerifier($page->getHttpHelper(), $siteConfiguration, $database);
-                $page->setSecurityManager(
-                    new SecurityManager($identificationVerifier, new RoleConfiguration(), new UserRoleLoader()));
+                $httpHelper = $page->getHttpHelper();
+
+                $userAccessLoader = new UserAccessLoader();
+                $domainAccessManager = new DomainAccessManager($userAccessLoader);
+
+                $identificationVerifier = new IdentificationVerifier($httpHelper, $siteConfiguration, $database);
+
+                $page->setSecurityManager(new SecurityManager($identificationVerifier, new RoleConfiguration(), $userAccessLoader));
+                $page->setDomainAccessManager($domainAccessManager);
 
                 if ($siteConfiguration->getTitleBlacklistEnabled()) {
-                    $page->setBlacklistHelper(new BlacklistHelper($page->getHttpHelper(), $database, $siteConfiguration));
+                    $page->setBlacklistHelper(new BlacklistHelper($httpHelper, $database, $siteConfiguration));
                 }
                 else {
                     $page->setBlacklistHelper(new FakeBlacklistHelper());
                 }
-
-                $page->setDomainAccessManager(new DomainAccessManager());
             }
         }
     }

--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -23,6 +23,7 @@ use Waca\Security\DomainAccessManager;
 use Waca\Security\RoleConfiguration;
 use Waca\Security\SecurityManager;
 use Waca\Security\TokenManager;
+use Waca\Security\UserRoleLoader;
 use Waca\Tasks\ITask;
 use Waca\Tasks\InternalPageBase;
 use Waca\Tasks\PageBase;
@@ -79,7 +80,8 @@ class WebStart extends ApplicationBase
                 $page->setTypeAheadHelper(new TypeAheadHelper());
 
                 $identificationVerifier = new IdentificationVerifier($page->getHttpHelper(), $siteConfiguration, $database);
-                $page->setSecurityManager(new SecurityManager($identificationVerifier, new RoleConfiguration()));
+                $page->setSecurityManager(
+                    new SecurityManager($identificationVerifier, new RoleConfiguration(), new UserRoleLoader()));
 
                 if ($siteConfiguration->getTitleBlacklistEnabled()) {
                     $page->setBlacklistHelper(new BlacklistHelper($page->getHttpHelper(), $database, $siteConfiguration));

--- a/templates/statistics/users.tpl
+++ b/templates/statistics/users.tpl
@@ -4,7 +4,6 @@
         <thead>
             <tr>
                 <th>Username</th>
-                <th>Tool user</th>
                 <th><abbr title="Handles day-to-day tool administration, user access, etc.">Tool admin</abbr></th>
                 <th><abbr title="Has checkuser access to data, only given to on-wiki checkusers">Checkuser</abbr></th>
                 <th><abbr title="Has checkuser access to data across all domains, only given to on-wiki stewards">Stewards</abbr></th>
@@ -17,7 +16,6 @@
                     <td>
                         <a href="{$baseurl}/internal.php/statistics/users/detail?user={$user.id}">{$user.username|escape}</a>
                     </td>
-                    <td {if $user.tooluser === 'Yes'}class="table-success"{else}class="table-danger"{/if}>{$user.tooluser}</td>
                     <td {if $user.tooladmin === 'Yes'}class="table-success"{else}class="table-danger"{/if}>{$user.tooladmin}</td>
                     <td {if $user.checkuser === 'Yes'}class="table-success"{else}class="table-danger"{/if}>{$user.checkuser}</td>
                     <td {if $user.steward === 'Yes'}class="table-success"{else}class="table-danger"{/if}>{$user.steward}</td>

--- a/templates/usermanagement/main.tpl
+++ b/templates/usermanagement/main.tpl
@@ -46,7 +46,7 @@
                 <div class="card">
                     <div class="card-header position-relative py-0">
                         <button class="btn btn-link stretched-link" data-toggle="collapse" data-parent="#userListAccordion" data-target="#collapseUsers">
-                            Users
+                            All users
                         </button>
                     </div>
                     <div id="collapseUsers" class="collapse" data-parent="#userListAccordion">

--- a/tests/includes/Security/DomainAccessManagerTest.php
+++ b/tests/includes/Security/DomainAccessManagerTest.php
@@ -1,0 +1,115 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ *                                                                            *
+ * All code in this file is released into the public domain by the ACC        *
+ * Development Team. Please see team.json for a list of contributors.         *
+ ******************************************************************************/
+
+namespace Waca\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use Waca\DataObjects\Domain;
+use Waca\DataObjects\User;
+use Waca\Exceptions\DomainSwitchNotAllowedException;
+use Waca\Providers\GlobalState\FakeGlobalStateProvider;
+use Waca\Providers\GlobalState\IGlobalStateProvider;
+use Waca\Security\DomainAccessManager;
+use Waca\Security\IUserAccessLoader;
+use Waca\WebRequest;
+
+class DomainAccessManagerTest extends TestCase
+{
+    private User $user;
+
+    private IUserAccessLoader $userAccessLoader;
+
+    private IGlobalStateProvider $stateProvider;
+
+    public function setUp() : void
+    {
+        $this->user = $this->getMockBuilder(User::class)->getMock();
+        $this->userAccessLoader = $this->getMockBuilder(IUserAccessLoader::class)->getMock();
+
+        $this->stateProvider = new FakeGlobalStateProvider();
+        WebRequest::setGlobalStateProvider($this->stateProvider);
+    }
+
+    public function testGetAllowedDomainsCommunity() {
+        // arrange
+        $dam = new DomainAccessManager($this->userAccessLoader);
+
+        // act
+        $domains = $dam->getAllowedDomains(User::getCommunity());
+
+        // assert
+        $this->assertCount(0, $domains);
+    }
+
+    public function testGetAllowedDomainsUser() {
+        // arrange
+        $dam = new DomainAccessManager($this->userAccessLoader);
+
+        $d = $this->getMockBuilder(Domain::class)->getMock();
+
+        $this->userAccessLoader->method('loadDomainsForUser')->willReturn([
+            $d
+        ]);
+
+        // act
+        $domains = $dam->getAllowedDomains($this->user);
+
+        // assert
+        $this->assertCount(1, $domains);
+        $this->assertEquals($d, $domains[0]);
+    }
+
+    public function testSwitchDomain() {
+        // arrange
+        $dam = new DomainAccessManager($this->userAccessLoader);
+
+        $d1 = $this->getMockBuilder(Domain::class)->getMock();
+        $d1->method('getId')->willReturn(1);
+
+        $d2 = $this->getMockBuilder(Domain::class)->getMock();
+        $d2->method('getId')->willReturn(2);
+
+        $this->stateProvider->session = ['domainID' => 1];
+
+        $this->userAccessLoader->method('loadDomainsForUser')->willReturn([$d1, $d2]);
+
+        // act
+        $dam->switchDomain($this->user, $d2);
+
+        // assert
+        $this->assertEquals(2, $this->stateProvider->session['domainID']);
+    }
+
+    public function testSwitchDomainNotAllowed() {
+        // arrange
+        $dam = new DomainAccessManager($this->userAccessLoader);
+
+        $d1 = $this->getMockBuilder(Domain::class)->getMock();
+        $d1->method('getId')->willReturn(1);
+
+        $d2 = $this->getMockBuilder(Domain::class)->getMock();
+        $d2->method('getId')->willReturn(2);
+
+        $this->stateProvider->session = ['domainID' => 1];
+
+        $this->userAccessLoader->method('loadDomainsForUser')->willReturn([$d1]);
+
+        $exceptionThrown = false;
+
+        // act
+        try {
+            $dam->switchDomain($this->user, $d2);
+        } catch (DomainSwitchNotAllowedException $e) {
+            $exceptionThrown = true;
+        }
+
+        // assert
+        $this->assertEquals(1, $this->stateProvider->session['domainID']);
+        $this->assertTrue($exceptionThrown);
+    }
+}

--- a/tests/includes/Security/SecurityManagerTest.php
+++ b/tests/includes/Security/SecurityManagerTest.php
@@ -9,13 +9,14 @@
 
 namespace Waca\Tests\Security;
 
-use PHPUnit_Framework_MockObject_MockObject;
+use Closure;
 use PHPUnit\Framework\TestCase;
 use Waca\DataObjects\User;
 use Waca\IIdentificationVerifier;
-use Waca\Security\RoleConfiguration;
-use Waca\Security\SecurityManager;
 use Waca\Security\ISecurityManager;
+use Waca\Security\IUserRoleLoader;
+use Waca\Security\RoleConfigurationBase;
+use Waca\Security\SecurityManager;
 
 /**
  * Class SecurityManagerTest
@@ -24,10 +25,12 @@ use Waca\Security\ISecurityManager;
  */
 class SecurityManagerTest extends TestCase
 {
-    /** @var User|PHPUnit_Framework_MockObject_MockObject */
     private $user;
-    /** @var IdentificationVerifier|PHPUnit_Framework_MockObject_MockObject */
-    private $identificationVerifier;
+
+    private IIdentificationVerifier $identificationVerifier;
+    private RoleConfigurationBase $roleConfig;
+    private IUserRoleLoader $userRoleLoader;
+    private Closure $needsIdCallback;
 
     public function setUp() : void
     {
@@ -36,55 +39,381 @@ class SecurityManagerTest extends TestCase
         $this->identificationVerifier = $this->getMockBuilder(IIdentificationVerifier::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->roleConfig = $this->getMockBuilder(RoleConfigurationBase::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->userRoleLoader = $this->getMockBuilder(IUserRoleLoader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->needsIdCallback = function($role) {
+            if ($role === 'loggedIn' || $role === 'public') {
+                return false;
+            }
+
+            return true;
+        };
     }
 
-    public function testPublicAccess()
-    {
+    public function testAvailableRoles() {
         // arrange
-        $page = 'Waca\\Page\\PageTest';
-        /** @var RoleConfiguration|PHPUnit_Framework_MockObject_MockObject */
-        $roleConfiguration = $this->getMockBuilder(RoleConfiguration::class)->getMock();
-        $roleConfiguration->method('getApplicableRoles')->willReturn(array(
-            'public' => array(
-                $page => array(
-                    RoleConfiguration::ALL => RoleConfiguration::ACCESS_ALLOW,
-                ),
-            ),
-        ));
-        $roleConfiguration->method('roleNeedsIdentification')->willReturn(false);
+        $availableRolesData = [
+            'admin'    => [],
+            'toolRoot' => [],
+        ];
 
-        $securityManager = new SecurityManager($this->identificationVerifier, $roleConfiguration);
-        $this->identificationVerifier->method('isUserIdentified')->willReturn(true);
+        $this->roleConfig->method('getAvailableRoles')->willReturn($availableRolesData);
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
 
         // act
-        $result = $securityManager->allows($page, 'main', User::getCommunity());
+        $availableRoles = $secMan->getAvailableRoles();
+
+        // assert
+        $this->assertEquals($availableRolesData, $availableRoles);
+    }
+
+    public function testGetActiveRoles() {
+        // arrange
+        $this->userRoleLoader->method('loadRolesForUser')->willReturn(['admin']);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $secMan->getActiveRoles($this->user, $retrievedActiveRoles, $retrievedInactiveRoles);
+
+        // assert
+
+        // implicit roles
+        $this->assertContains('public', $retrievedActiveRoles);
+        $this->assertContains('loggedIn', $retrievedActiveRoles);
+        $this->assertContains('user', $retrievedActiveRoles);
+
+        // explicit roles
+        $this->assertContains('admin', $retrievedActiveRoles);
+
+        // check there's nothing extra
+        $this->assertCount(4, $retrievedActiveRoles);
+        $this->assertCount(0, $retrievedInactiveRoles);
+    }
+
+    public function testGetActiveRolesInactiveUser() {
+        // arrange
+        $this->userRoleLoader->method('loadRolesForUser')->willReturn(['admin']);
+        $this->user->method('isActive')->willReturn(false);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $secMan->getActiveRoles($this->user, $retrievedActiveRoles, $retrievedInactiveRoles);
+
+        // assert
+
+        // implicit roles
+        $this->assertContains('public', $retrievedActiveRoles);
+        $this->assertContains('loggedIn', $retrievedActiveRoles);
+
+        // check there's nothing extra
+        $this->assertCount(2, $retrievedActiveRoles);
+
+        // inactive users don't have inactive roles
+        $this->assertCount(0, $retrievedInactiveRoles);
+    }
+
+    public function testGetActiveRolesNonIDUser() {
+        // arrange
+        $this->userRoleLoader->method('loadRolesForUser')->willReturn(['admin']);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(false);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $secMan->getActiveRoles($this->user, $retrievedActiveRoles, $retrievedInactiveRoles);
+
+        // assert
+
+        // implicit roles
+        $this->assertContains('public', $retrievedActiveRoles);
+        $this->assertContains('loggedIn', $retrievedActiveRoles);
+
+        // roles locked behind id flag
+        $this->assertContains('user', $retrievedInactiveRoles);
+        $this->assertContains('admin', $retrievedInactiveRoles);
+
+        // check there's nothing extra
+        $this->assertCount(2, $retrievedActiveRoles);
+        $this->assertCount(2, $retrievedInactiveRoles);
+    }
+
+    public function testGetActiveRolesImplicitOnly() {
+        // arrange
+        $this->userRoleLoader->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $secMan->getActiveRoles($this->user, $retrievedActiveRoles, $retrievedInactiveRoles);
+
+        // assert
+
+        // implicit roles
+        $this->assertContains('public', $retrievedActiveRoles);
+        $this->assertContains('loggedIn', $retrievedActiveRoles);
+        $this->assertContains('user', $retrievedActiveRoles);
+
+        // check there's nothing extra
+        $this->assertCount(3, $retrievedActiveRoles);
+        $this->assertCount(0, $retrievedInactiveRoles);
+    }
+
+    public function testGetActiveRolesCommunityUser() {
+        // arrange
+        $this->userRoleLoader->method('loadRolesForUser')->willReturn([]);
+
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $secMan->getActiveRoles(User::getCommunity(), $retrievedActiveRoles, $retrievedInactiveRoles);
+
+        // assert
+
+        // implicit roles
+        $this->assertContains('public', $retrievedActiveRoles);
+
+        // check there's nothing extra
+        $this->assertCount(1, $retrievedActiveRoles);
+        $this->assertCount(0, $retrievedInactiveRoles);
+    }
+
+    public function testCaching() {
+        // arrange
+        $this->userRoleLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $secMan->getCachedActiveRoles($this->user, $retrievedActiveRoles, $retrievedInactiveRoles);
+        $secMan->getCachedActiveRoles($this->user, $cachedActiveRoles, $cachedInactiveRoles);
+
+        // assert
+        $this->assertEquals($retrievedInactiveRoles, $cachedInactiveRoles);
+        $this->assertEquals($retrievedActiveRoles, $cachedActiveRoles);
+
+        $this->userRoleLoader->method('loadRolesForUser');
+    }
+
+    public function testAllowsAllowed()
+    {
+        // arrange
+        $this->userRoleLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+        $this->roleConfig->method('getResultantRole')->willReturn([
+            'PageA' => [
+                RoleConfigurationBase::MAIN => RoleConfigurationBase::ACCESS_ALLOW,
+                'private'                   => RoleConfigurationBase::ACCESS_DENY,
+            ],
+        ]);
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $result = $secMan->allows('PageA', RoleConfigurationBase::MAIN, $this->user);
 
         // assert
         $this->assertEquals(ISecurityManager::ALLOWED, $result);
     }
 
-    public function testPublicAccessDenied()
+    public function testAllowsDenied()
     {
         // arrange
-        $page = 'Waca\\Page\\PageTest';
-        /** @var RoleConfiguration|PHPUnit_Framework_MockObject_MockObject */
-        $roleConfiguration = $this->getMockBuilder(RoleConfiguration::class)->getMock();
-        $roleConfiguration->method('getApplicableRoles')->willReturn(array(
-            'public' => array(
-                $page => array(
-                    RoleConfiguration::ALL => RoleConfiguration::ACCESS_DENY,
-                ),
-            ),
-        ));
-        $roleConfiguration->method('roleNeedsIdentification')->willReturn(false);
+        $this->userRoleLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+        $this->roleConfig->method('getResultantRole')->willReturn([
+            'PageA' => [
+                RoleConfigurationBase::MAIN => RoleConfigurationBase::ACCESS_ALLOW,
+                'private'                   => RoleConfigurationBase::ACCESS_DENY,
+            ],
+        ]);
 
-        $securityManager = new SecurityManager($this->identificationVerifier, $roleConfiguration);
-        $this->identificationVerifier->method('isUserIdentified')->willReturn(true);
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
 
         // act
-        $result = $securityManager->allows($page, 'main', User::getCommunity());
+        $result = $secMan->allows('PageA', 'private', $this->user);
 
         // assert
         $this->assertEquals(ISecurityManager::ERROR_DENIED, $result);
+    }
+
+    public function testAllowsNotKnown()
+    {
+        // arrange
+        $this->userRoleLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+        $this->roleConfig->method('getResultantRole')->willReturn([
+            'PageA' => [
+                RoleConfigurationBase::MAIN => RoleConfigurationBase::ACCESS_ALLOW,
+                'private'                   => RoleConfigurationBase::ACCESS_DENY,
+            ],
+        ]);
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $result = $secMan->allows('PageNonExistent', RoleConfigurationBase::MAIN, $this->user);
+
+        // assert
+        $this->assertEquals(ISecurityManager::ERROR_DENIED, $result);
+    }
+
+    public function testAllowsDefault()
+    {
+        // arrange
+        $this->userRoleLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+        $this->roleConfig->method('getResultantRole')->willReturn([
+            'PageA' => [
+                RoleConfigurationBase::MAIN => RoleConfigurationBase::ACCESS_DEFAULT,
+            ],
+        ]);
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $result = $secMan->allows('PageA', RoleConfigurationBase::MAIN, $this->user);
+
+        // assert
+        $this->assertEquals(ISecurityManager::ERROR_DENIED, $result);
+    }
+
+    public function testAllowsNotID()
+    {
+        // arrange
+        $this->userRoleLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(false);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+        $this->roleConfig->method('getResultantRole')->willReturnOnConsecutiveCalls(
+            [
+                'PageA' => [
+                    RoleConfigurationBase::MAIN => RoleConfigurationBase::ACCESS_ALLOW,
+                ],
+            ],
+            [
+                'PageA' => [
+                    RoleConfigurationBase::MAIN => RoleConfigurationBase::ACCESS_ALLOW,
+                    'private'                   => RoleConfigurationBase::ACCESS_ALLOW,
+                ],
+            ]
+        );
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $result = $secMan->allows('PageA', 'private', $this->user);
+
+        // assert
+        $this->assertEquals(ISecurityManager::ERROR_NOT_IDENTIFIED, $result);
+    }
+
+    public function testAllowsWithAllDeny()
+    {
+        // arrange
+        $this->userRoleLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+        $this->roleConfig->method('getResultantRole')->willReturnOnConsecutiveCalls(
+            [
+                'PageA' => [
+                    RoleConfigurationBase::ALL => RoleConfigurationBase::ACCESS_DENY,
+                    RoleConfigurationBase::MAIN => RoleConfigurationBase::ACCESS_ALLOW,
+                ],
+            ]
+        );
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $result = $secMan->allows('PageA', RoleConfigurationBase::MAIN, $this->user);
+
+        // assert
+        // despite an 'allow' being granted, the 'deny' on all should override.
+        $this->assertEquals(ISecurityManager::ERROR_DENIED, $result);
+    }
+
+    public function testAllowsWithSpecificDeny()
+    {
+        // arrange
+        $this->userRoleLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+        $this->roleConfig->method('getResultantRole')->willReturnOnConsecutiveCalls(
+            [
+                'PageA' => [
+                    RoleConfigurationBase::ALL => RoleConfigurationBase::ACCESS_ALLOW,
+                    RoleConfigurationBase::MAIN => RoleConfigurationBase::ACCESS_DENY,
+                ],
+            ]
+        );
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $result = $secMan->allows('PageA', RoleConfigurationBase::MAIN, $this->user);
+
+        // assert
+        // despite an 'allow' being granted, the 'deny' on all should override.
+        $this->assertEquals(ISecurityManager::ERROR_DENIED, $result);
+    }
+
+    public function testAllowsWithAllAllow()
+    {
+        // arrange
+        $this->userRoleLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('isIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+        $this->roleConfig->method('getResultantRole')->willReturnOnConsecutiveCalls(
+            [
+                'PageA' => [
+                    RoleConfigurationBase::ALL => RoleConfigurationBase::ACCESS_ALLOW,
+                ],
+            ]
+        );
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userRoleLoader);
+
+        // act
+        $result = $secMan->allows('PageA', 'nonExistent', $this->user);
+
+        // assert
+        // even though this action is unknown, allow it anyway because it's an allow on all.
+        $this->assertEquals(ISecurityManager::ALLOWED, $result);
     }
 }

--- a/tests/includes/Security/SecurityManagerTest.php
+++ b/tests/includes/Security/SecurityManagerTest.php
@@ -12,7 +12,7 @@ namespace Waca\Tests\Security;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit\Framework\TestCase;
 use Waca\DataObjects\User;
-use Waca\IdentificationVerifier;
+use Waca\IIdentificationVerifier;
 use Waca\Security\RoleConfiguration;
 use Waca\Security\SecurityManager;
 use Waca\Security\ISecurityManager;
@@ -33,7 +33,7 @@ class SecurityManagerTest extends TestCase
     {
         $this->user = $this->getMockBuilder(User::class)->getMock();
 
-        $this->identificationVerifier = $this->getMockBuilder(IdentificationVerifier::class)
+        $this->identificationVerifier = $this->getMockBuilder(IIdentificationVerifier::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/includes/Security/SecurityManagerTest.php
+++ b/tests/includes/Security/SecurityManagerTest.php
@@ -15,6 +15,7 @@ use Waca\DataObjects\User;
 use Waca\IdentificationVerifier;
 use Waca\Security\RoleConfiguration;
 use Waca\Security\SecurityManager;
+use Waca\Security\ISecurityManager;
 
 /**
  * Class SecurityManagerTest
@@ -59,7 +60,7 @@ class SecurityManagerTest extends TestCase
         $result = $securityManager->allows($page, 'main', User::getCommunity());
 
         // assert
-        $this->assertEquals(SecurityManager::ALLOWED, $result);
+        $this->assertEquals(ISecurityManager::ALLOWED, $result);
     }
 
     public function testPublicAccessDenied()
@@ -84,6 +85,6 @@ class SecurityManagerTest extends TestCase
         $result = $securityManager->allows($page, 'main', User::getCommunity());
 
         // assert
-        $this->assertEquals(SecurityManager::ERROR_DENIED, $result);
+        $this->assertEquals(ISecurityManager::ERROR_DENIED, $result);
     }
 }

--- a/tests/includes/Security/SecurityManagerTest.php
+++ b/tests/includes/Security/SecurityManagerTest.php
@@ -79,7 +79,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->method('loadRolesForUser')->willReturn(['admin']);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
 
         $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userAccessLoader);
@@ -106,7 +106,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->method('loadRolesForUser')->willReturn(['admin']);
         $this->user->method('isActive')->willReturn(false);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
 
         $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userAccessLoader);
@@ -131,7 +131,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->method('loadRolesForUser')->willReturn(['admin']);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(false);
+        $this->user->method('getForceIdentified')->willReturn(false);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
 
         $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userAccessLoader);
@@ -158,7 +158,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->method('loadRolesForUser')->willReturn([]);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
 
         $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userAccessLoader);
@@ -203,7 +203,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
 
         $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userAccessLoader);
@@ -224,7 +224,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
         $this->roleConfig->method('getResultantRole')->willReturn([
             'PageA' => [
@@ -247,7 +247,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
         $this->roleConfig->method('getResultantRole')->willReturn([
             'PageA' => [
@@ -270,7 +270,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
         $this->roleConfig->method('getResultantRole')->willReturn([
             'PageA' => [
@@ -293,7 +293,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
         $this->roleConfig->method('getResultantRole')->willReturn([
             'PageA' => [
@@ -315,7 +315,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(false);
+        $this->user->method('getForceIdentified')->willReturn(false);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
         $this->roleConfig->method('getResultantRole')->willReturnOnConsecutiveCalls(
             [
@@ -345,7 +345,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
         $this->roleConfig->method('getResultantRole')->willReturnOnConsecutiveCalls(
             [
@@ -371,7 +371,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
         $this->roleConfig->method('getResultantRole')->willReturnOnConsecutiveCalls(
             [
@@ -397,7 +397,7 @@ class SecurityManagerTest extends TestCase
         // arrange
         $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
         $this->user->method('isActive')->willReturn(true);
-        $this->user->method('isIdentified')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
         $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
         $this->roleConfig->method('getResultantRole')->willReturnOnConsecutiveCalls(
             [
@@ -415,5 +415,84 @@ class SecurityManagerTest extends TestCase
         // assert
         // even though this action is unknown, allow it anyway because it's an allow on all.
         $this->assertEquals(ISecurityManager::ALLOWED, $result);
+    }
+
+    public function testForceIdentified() {
+        // arrange
+        $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(true);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+
+        $this->identificationVerifier->expects($this->never())->method('isUserIdentified');
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userAccessLoader);
+
+        // act
+        $secMan->getActiveRoles($this->user, $retrievedActiveRoles, $retrievedInactiveRoles);
+
+        // assert
+        $this->assertContains('user', $retrievedActiveRoles);
+        $this->assertNotContains('user', $retrievedInactiveRoles);
+    }
+
+    public function testForceNotIdentified() {
+        // arrange
+        $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('getForceIdentified')->willReturn(false);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+
+        $this->identificationVerifier->expects($this->never())->method('isUserIdentified');
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userAccessLoader);
+
+        // act
+        $secMan->getActiveRoles($this->user, $retrievedActiveRoles, $retrievedInactiveRoles);
+
+        // assert
+        $this->assertNotContains('user', $retrievedActiveRoles);
+        $this->assertContains('user', $retrievedInactiveRoles);
+    }
+
+
+    public function testLookupIdentified() {
+        // arrange
+        $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('getOnWikiName')->willReturn('Alice');
+        $this->user->method('getForceIdentified')->willReturn(null);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+
+        $this->identificationVerifier->expects($this->once())->method('isUserIdentified')->willReturn(true);
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userAccessLoader);
+
+        // act
+        $secMan->getActiveRoles($this->user, $retrievedActiveRoles, $retrievedInactiveRoles);
+
+        // assert
+        $this->assertContains('user', $retrievedActiveRoles);
+        $this->assertNotContains('user', $retrievedInactiveRoles);
+    }
+
+    public function testLookupNotIdentified() {
+        // arrange
+        $this->userAccessLoader->expects($this->once())->method('loadRolesForUser')->willReturn([]);
+        $this->user->method('isActive')->willReturn(true);
+        $this->user->method('getOnWikiName')->willReturn('Bob');
+        $this->user->method('getForceIdentified')->willReturn(null);
+        $this->roleConfig->method('roleNeedsIdentification')->will($this->returnCallback($this->needsIdCallback));
+
+        $this->identificationVerifier->expects($this->once())->method('isUserIdentified')->willReturn(false);
+
+        $secMan = new SecurityManager($this->identificationVerifier, $this->roleConfig, $this->userAccessLoader);
+
+        // act
+        $secMan->getActiveRoles($this->user, $retrievedActiveRoles, $retrievedInactiveRoles);
+
+        // assert
+        $this->assertNotContains('user', $retrievedActiveRoles);
+        $this->assertContains('user', $retrievedInactiveRoles);
     }
 }


### PR DESCRIPTION
This change does a general refactor of our security, roles and identification code.

The overall goal of this refactor is to make the security code more testable via unit tests, and as a result this change also introduces a bunch more unit tests on the security code. We also make the "user" role implicit in this change, as there's no (current) need for this to be toggle-able.

As this is a change to the security code, please treat this as a risky change.