### PR TITLE
Relicence project to the Unlicense

### DIFF
--- a/.github/scripts/lint.sh
+++ b/.github/scripts/lint.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+#*******************************************************************************
+# Wikipedia Account Creation Assistance tool                                   *
+# ACC Development Team. Please see team.json for a list of contributors.       *
+#                                                                              *
+# This is free and unencumbered software released into the public domain.      *
+# Please see LICENSE.md for the full licencing statement.                      *
+#*******************************************************************************
+
 echo -e "\033[32mRunning lint test on all PHP files...\033[0m"
 echo -e "\033[32mCurrent directory is \033[37;1m`pwd`\033[0m"
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ deploy/
 .project
 .idea/*
 !.idea/codeStyleSettings.xml
+!.idea/codeStyles/
+!.idea/copyright
+!.idea/sqldialects.xml
 templates_c/*
 *.phpproj.user
 temp/*

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,67 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="SOFT_MARGINS" value="80" />
+    <MarkdownNavigatorCodeStyleSettings>
+      <option name="RIGHT_MARGIN" value="72" />
+    </MarkdownNavigatorCodeStyleSettings>
+    <PHPCodeStyleSettings>
+      <option name="ALIGN_KEY_VALUE_PAIRS" value="true" />
+      <option name="ALIGN_PHPDOC_PARAM_NAMES" value="true" />
+      <option name="ALIGN_PHPDOC_COMMENTS" value="true" />
+      <option name="COMMA_AFTER_LAST_ARRAY_ELEMENT" value="true" />
+      <option name="PHPDOC_BLANK_LINES_AROUND_PARAMETERS" value="true" />
+      <option name="LOWER_CASE_BOOLEAN_CONST" value="true" />
+      <option name="LOWER_CASE_NULL_CONST" value="true" />
+      <option name="VARIABLE_NAMING_STYLE" value="CAMEL_CASE" />
+      <option name="BLANK_LINES_BEFORE_RETURN_STATEMENT" value="1" />
+      <option name="KEEP_RPAREN_AND_LBRACE_ON_ONE_LINE" value="true" />
+      <option name="SPACE_BEFORE_CLOSURE_LEFT_PARENTHESIS" value="false" />
+    </PHPCodeStyleSettings>
+    <SqlCodeStyleSettings version="7">
+      <option name="KEYWORD_CASE" value="2" />
+      <option name="TYPE_CASE" value="3" />
+    </SqlCodeStyleSettings>
+    <editorconfig>
+      <option name="ENABLED" value="false" />
+    </editorconfig>
+    <codeStyleSettings language="PHP">
+      <option name="RIGHT_MARGIN" value="120" />
+      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+      <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="0" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+      <option name="BLANK_LINES_AFTER_PACKAGE" value="1" />
+      <option name="ELSE_ON_NEW_LINE" value="true" />
+      <option name="WHILE_ON_NEW_LINE" value="true" />
+      <option name="CATCH_ON_NEW_LINE" value="true" />
+      <option name="FINALLY_ON_NEW_LINE" value="true" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_WRAP" value="5" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="5" />
+      <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
+      <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <indentOptions>
+        <option name="SMART_TABS" value="true" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Shell Script">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/copyright/PD.xml
+++ b/.idea/copyright/PD.xml
@@ -1,8 +1,0 @@
-<component name="CopyrightManager">
-  <copyright>
-    <option name="allowReplaceKeyword" value="" />
-    <option name="keyword" value="public domain" />
-    <option name="myName" value="PD" />
-    <option name="notice" value="Wikipedia Account Creation Assistance tool&#10;&#10;All code in this file is released into the public domain by the ACC&#10;Development Team. Please see team.json for a list of contributors." />
-  </copyright>
-</component>

--- a/.idea/copyright/Unlicense.xml
+++ b/.idea/copyright/Unlicense.xml
@@ -1,0 +1,8 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="allowReplaceRegexp" value="public domain" />
+    <option name="keyword" value="released into the public domain" />
+    <option name="notice" value="Wikipedia Account Creation Assistance tool&#10;ACC Development Team. Please see team.json for a list of contributors.&#10;&#10;This is free and unencumbered software released into the public domain.&#10;Please see LICENSE.md for the full licencing statement." />
+    <option name="myName" value="Unlicense" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,5 +1,5 @@
 <component name="CopyrightManager">
-  <settings default="PD">
+  <settings default="Unlicense">
     <LanguageOptions name="SCSS">
       <option name="fileTypeOverride" value="3" />
       <option name="block" value="false" />

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="PROJECT" dialect="MariaDB" />
+  </component>
+</project>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/api.php
+++ b/api.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/config.inc.php
+++ b/config.inc.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 /**************************************************************************

--- a/docker/config.local.inc.php
+++ b/docker/config.local.inc.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 // Sane defaults for Docker-based ACC development environments. When running `docker compose up`,

--- a/docker/database.sh
+++ b/docker/database.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -x
 
+#*******************************************************************************
+# Wikipedia Account Creation Assistance tool                                   *
+# ACC Development Team. Please see team.json for a list of contributors.       *
+#                                                                              *
+# This is free and unencumbered software released into the public domain.      *
+# Please see LICENSE.md for the full licencing statement.                      *
+#*******************************************************************************
+
 cd /wacadb || { echo "Failed to cd to /wacadb"; exit 1; }
 
 # Set env vars needed by the test_db.sh script. Note that the MYSQL_USER and MYSQL_PASSWORD env vars are set by the

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -ex
 
+#*******************************************************************************
+# Wikipedia Account Creation Assistance tool                                   *
+# ACC Development Team. Please see team.json for a list of contributors.       *
+#                                                                              *
+# This is free and unencumbered software released into the public domain.      *
+# Please see LICENSE.md for the full licencing statement.                      *
+#*******************************************************************************
+
 cd /var/www/html
 git config --global --replace-all safe.directory /var/www/html
 cp ~/.gitconfig /etc/gitconfig

--- a/docker/index.php
+++ b/docker/index.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 // Redirect user away from the current directory.

--- a/includes/API/Actions/CountAction.php
+++ b/includes/API/Actions/CountAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API\Actions;

--- a/includes/API/Actions/HelpAction.php
+++ b/includes/API/Actions/HelpAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API\Actions;

--- a/includes/API/Actions/JsTemplateConfirmsAction.php
+++ b/includes/API/Actions/JsTemplateConfirmsAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API\Actions;

--- a/includes/API/Actions/JsUsersAction.php
+++ b/includes/API/Actions/JsUsersAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API\Actions;

--- a/includes/API/Actions/MonitorAction.php
+++ b/includes/API/Actions/MonitorAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API\Actions;

--- a/includes/API/Actions/StatsAction.php
+++ b/includes/API/Actions/StatsAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API\Actions;

--- a/includes/API/Actions/StatusAction.php
+++ b/includes/API/Actions/StatusAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API\Actions;

--- a/includes/API/Actions/UnknownAction.php
+++ b/includes/API/Actions/UnknownAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API\Actions;

--- a/includes/API/ApiException.php
+++ b/includes/API/ApiException.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API;

--- a/includes/API/IApiAction.php
+++ b/includes/API/IApiAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API;

--- a/includes/API/IJsonApiAction.php
+++ b/includes/API/IJsonApiAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API;

--- a/includes/API/IXmlApiAction.php
+++ b/includes/API/IXmlApiAction.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\API;

--- a/includes/ApplicationBase.php
+++ b/includes/ApplicationBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/AutoLoader.php
+++ b/includes/AutoLoader.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/Background/BackgroundTaskBase.php
+++ b/includes/Background/BackgroundTaskBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Background;

--- a/includes/Background/CreationTaskBase.php
+++ b/includes/Background/CreationTaskBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Background;

--- a/includes/Background/Task/BotCreationTask.php
+++ b/includes/Background/Task/BotCreationTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Background\Task;

--- a/includes/Background/Task/UserCreationTask.php
+++ b/includes/Background/Task/UserCreationTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Background\Task;

--- a/includes/Background/Task/WelcomeUserTask.php
+++ b/includes/Background/Task/WelcomeUserTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Background\Task;

--- a/includes/ConsoleStart.php
+++ b/includes/ConsoleStart.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/ConsoleTasks/ClearExpiredIdentificationData.php
+++ b/includes/ConsoleTasks/ClearExpiredIdentificationData.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\ConsoleTasks;

--- a/includes/ConsoleTasks/ClearOAuthDataTask.php
+++ b/includes/ConsoleTasks/ClearOAuthDataTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\ConsoleTasks;

--- a/includes/ConsoleTasks/ClearOldDataTask.php
+++ b/includes/ConsoleTasks/ClearOldDataTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\ConsoleTasks;

--- a/includes/ConsoleTasks/MigrateToDomains.php
+++ b/includes/ConsoleTasks/MigrateToDomains.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\ConsoleTasks;

--- a/includes/ConsoleTasks/MigrateToRoles.php
+++ b/includes/ConsoleTasks/MigrateToRoles.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\ConsoleTasks;

--- a/includes/ConsoleTasks/OldRequestCleanupTask.php
+++ b/includes/ConsoleTasks/OldRequestCleanupTask.php
@@ -1,11 +1,12 @@
-<?php /** @noinspection SqlConstantCondition */
-
+<?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
+/** @noinspection SqlConstantCondition */
 
 namespace Waca\ConsoleTasks;
 

--- a/includes/ConsoleTasks/PrecacheGeolocationTask.php
+++ b/includes/ConsoleTasks/PrecacheGeolocationTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\ConsoleTasks;

--- a/includes/ConsoleTasks/RecreateTrustedIpTableTask.php
+++ b/includes/ConsoleTasks/RecreateTrustedIpTableTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\ConsoleTasks;

--- a/includes/ConsoleTasks/RefreshOAuthDataTask.php
+++ b/includes/ConsoleTasks/RefreshOAuthDataTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\ConsoleTasks;

--- a/includes/ConsoleTasks/RunJobQueueTask.php
+++ b/includes/ConsoleTasks/RunJobQueueTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\ConsoleTasks;

--- a/includes/ConsoleTasks/UpdateTorExitTask.php
+++ b/includes/ConsoleTasks/UpdateTorExitTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\ConsoleTasks;

--- a/includes/DataObject.php
+++ b/includes/DataObject.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/DataObjects/AntiSpoofCache.php
+++ b/includes/DataObjects/AntiSpoofCache.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/Ban.php
+++ b/includes/DataObjects/Ban.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/Comment.php
+++ b/includes/DataObjects/Comment.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/CommunityUser.php
+++ b/includes/DataObjects/CommunityUser.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/Credential.php
+++ b/includes/DataObjects/Credential.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/Domain.php
+++ b/includes/DataObjects/Domain.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/EmailTemplate.php
+++ b/includes/DataObjects/EmailTemplate.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/GeoLocation.php
+++ b/includes/DataObjects/GeoLocation.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/JobQueue.php
+++ b/includes/DataObjects/JobQueue.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/Log.php
+++ b/includes/DataObjects/Log.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/OAuthIdentity.php
+++ b/includes/DataObjects/OAuthIdentity.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/OAuthToken.php
+++ b/includes/DataObjects/OAuthToken.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/RDnsCache.php
+++ b/includes/DataObjects/RDnsCache.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/Request.php
+++ b/includes/DataObjects/Request.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/RequestData.php
+++ b/includes/DataObjects/RequestData.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/RequestForm.php
+++ b/includes/DataObjects/RequestForm.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/RequestQueue.php
+++ b/includes/DataObjects/RequestQueue.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/SiteNotice.php
+++ b/includes/DataObjects/SiteNotice.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/User.php
+++ b/includes/DataObjects/User.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/UserDomain.php
+++ b/includes/DataObjects/UserDomain.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/UserPreference.php
+++ b/includes/DataObjects/UserPreference.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/UserRole.php
+++ b/includes/DataObjects/UserRole.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/DataObjects/WelcomeTemplate.php
+++ b/includes/DataObjects/WelcomeTemplate.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\DataObjects;

--- a/includes/Environment.php
+++ b/includes/Environment.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/ExceptionHandler.php
+++ b/includes/ExceptionHandler.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/Exceptions/AccessDeniedException.php
+++ b/includes/Exceptions/AccessDeniedException.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Exceptions;

--- a/includes/Exceptions/ApplicationLogicException.php
+++ b/includes/Exceptions/ApplicationLogicException.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Exceptions;

--- a/includes/Exceptions/CurlException.php
+++ b/includes/Exceptions/CurlException.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Exceptions;

--- a/includes/Exceptions/EnvironmentException.php
+++ b/includes/Exceptions/EnvironmentException.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Exceptions;

--- a/includes/Exceptions/MediaWikiApiException.php
+++ b/includes/Exceptions/MediaWikiApiException.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Exceptions;

--- a/includes/Exceptions/NotIdentifiedException.php
+++ b/includes/Exceptions/NotIdentifiedException.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Exceptions;

--- a/includes/Exceptions/OAuthException.php
+++ b/includes/Exceptions/OAuthException.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Exceptions;

--- a/includes/Exceptions/OptimisticLockFailedException.php
+++ b/includes/Exceptions/OptimisticLockFailedException.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Exceptions;

--- a/includes/Exceptions/ReadableException.php
+++ b/includes/Exceptions/ReadableException.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Exceptions;

--- a/includes/Fragments/NavigationMenuAccessControl.php
+++ b/includes/Fragments/NavigationMenuAccessControl.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Fragments;

--- a/includes/Fragments/RequestData.php
+++ b/includes/Fragments/RequestData.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Fragments;

--- a/includes/Fragments/RequestListData.php
+++ b/includes/Fragments/RequestListData.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Fragments;

--- a/includes/Fragments/TemplateOutput.php
+++ b/includes/Fragments/TemplateOutput.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Fragments;

--- a/includes/Helpers/BanHelper.php
+++ b/includes/Helpers/BanHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/BlacklistHelper.php
+++ b/includes/Helpers/BlacklistHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/BotMediaWikiClient.php
+++ b/includes/Helpers/BotMediaWikiClient.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/DebugHelper.php
+++ b/includes/Helpers/DebugHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/EmailHelper.php
+++ b/includes/Helpers/EmailHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/FakeBlacklistHelper.php
+++ b/includes/Helpers/FakeBlacklistHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/HttpHelper.php
+++ b/includes/Helpers/HttpHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/Interfaces/IBanHelper.php
+++ b/includes/Helpers/Interfaces/IBanHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\Interfaces;

--- a/includes/Helpers/Interfaces/IBlacklistHelper.php
+++ b/includes/Helpers/Interfaces/IBlacklistHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\Interfaces;

--- a/includes/Helpers/Interfaces/IEmailHelper.php
+++ b/includes/Helpers/Interfaces/IEmailHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\Interfaces;

--- a/includes/Helpers/Interfaces/IMediaWikiClient.php
+++ b/includes/Helpers/Interfaces/IMediaWikiClient.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\Interfaces;

--- a/includes/Helpers/Interfaces/IOAuthProtocolHelper.php
+++ b/includes/Helpers/Interfaces/IOAuthProtocolHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\Interfaces;

--- a/includes/Helpers/Interfaces/ITypeAheadHelper.php
+++ b/includes/Helpers/Interfaces/ITypeAheadHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\Interfaces;

--- a/includes/Helpers/IrcNotificationHelper.php
+++ b/includes/Helpers/IrcNotificationHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/LogHelper.php
+++ b/includes/Helpers/LogHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/Logger.php
+++ b/includes/Helpers/Logger.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/MarkdownRenderingHelper.php
+++ b/includes/Helpers/MarkdownRenderingHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/MediaWikiHelper.php
+++ b/includes/Helpers/MediaWikiHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/OAuthProtocolHelper.php
+++ b/includes/Helpers/OAuthProtocolHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/OAuthUserHelper.php
+++ b/includes/Helpers/OAuthUserHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/PreferenceManager.php
+++ b/includes/Helpers/PreferenceManager.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/RequestEmailHelper.php
+++ b/includes/Helpers/RequestEmailHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/RequestQueueHelper.php
+++ b/includes/Helpers/RequestQueueHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/Helpers/SearchHelpers/JobQueueSearchHelper.php
+++ b/includes/Helpers/SearchHelpers/JobQueueSearchHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\SearchHelpers;

--- a/includes/Helpers/SearchHelpers/LogSearchHelper.php
+++ b/includes/Helpers/SearchHelpers/LogSearchHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\SearchHelpers;

--- a/includes/Helpers/SearchHelpers/RequestSearchHelper.php
+++ b/includes/Helpers/SearchHelpers/RequestSearchHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\SearchHelpers;

--- a/includes/Helpers/SearchHelpers/SearchHelperBase.php
+++ b/includes/Helpers/SearchHelpers/SearchHelperBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\SearchHelpers;

--- a/includes/Helpers/SearchHelpers/UserSearchHelper.php
+++ b/includes/Helpers/SearchHelpers/UserSearchHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers\SearchHelpers;

--- a/includes/Helpers/TypeAheadHelper.php
+++ b/includes/Helpers/TypeAheadHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Helpers;

--- a/includes/IdentificationVerifier.php
+++ b/includes/IdentificationVerifier.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/IrcColourCode.php
+++ b/includes/IrcColourCode.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/Offline.php
+++ b/includes/Offline.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/Pages/Page404.php
+++ b/includes/Pages/Page404.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageBan.php
+++ b/includes/Pages/PageBan.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageDomainManagement.php
+++ b/includes/Pages/PageDomainManagement.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageDomainSwitch.php
+++ b/includes/Pages/PageDomainSwitch.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageEditComment.php
+++ b/includes/Pages/PageEditComment.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageEmailManagement.php
+++ b/includes/Pages/PageEmailManagement.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageErrorLogViewer.php
+++ b/includes/Pages/PageErrorLogViewer.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageExpandedRequestList.php
+++ b/includes/Pages/PageExpandedRequestList.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageFlagComment.php
+++ b/includes/Pages/PageFlagComment.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageJobQueue.php
+++ b/includes/Pages/PageJobQueue.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageListFlaggedComments.php
+++ b/includes/Pages/PageListFlaggedComments.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageLog.php
+++ b/includes/Pages/PageLog.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageMain.php
+++ b/includes/Pages/PageMain.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageQueueManagement.php
+++ b/includes/Pages/PageQueueManagement.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageRequestFormManagement.php
+++ b/includes/Pages/PageRequestFormManagement.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageSearch.php
+++ b/includes/Pages/PageSearch.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageSiteNotice.php
+++ b/includes/Pages/PageSiteNotice.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageTeam.php
+++ b/includes/Pages/PageTeam.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageUserManagement.php
+++ b/includes/Pages/PageUserManagement.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageWelcomeTemplateManagement.php
+++ b/includes/Pages/PageWelcomeTemplateManagement.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/PageXffDemo.php
+++ b/includes/Pages/PageXffDemo.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages;

--- a/includes/Pages/Registration/PageRegisterBase.php
+++ b/includes/Pages/Registration/PageRegisterBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Registration;

--- a/includes/Pages/Registration/PageRegisterOption.php
+++ b/includes/Pages/Registration/PageRegisterOption.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Registration;

--- a/includes/Pages/Registration/PageRegisterStandard.php
+++ b/includes/Pages/Registration/PageRegisterStandard.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Registration;

--- a/includes/Pages/Request/PageConfirmEmail.php
+++ b/includes/Pages/Request/PageConfirmEmail.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Request;

--- a/includes/Pages/Request/PageEmailConfirmationRequired.php
+++ b/includes/Pages/Request/PageEmailConfirmationRequired.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Request;

--- a/includes/Pages/Request/PageRequestAccount.php
+++ b/includes/Pages/Request/PageRequestAccount.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Request;

--- a/includes/Pages/Request/PageRequestSubmitted.php
+++ b/includes/Pages/Request/PageRequestSubmitted.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Request;

--- a/includes/Pages/RequestAction/PageBreakReservation.php
+++ b/includes/Pages/RequestAction/PageBreakReservation.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/RequestAction/PageCloseRequest.php
+++ b/includes/Pages/RequestAction/PageCloseRequest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/RequestAction/PageComment.php
+++ b/includes/Pages/RequestAction/PageComment.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/RequestAction/PageCreateRequest.php
+++ b/includes/Pages/RequestAction/PageCreateRequest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/RequestAction/PageCustomClose.php
+++ b/includes/Pages/RequestAction/PageCustomClose.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/RequestAction/PageDeferRequest.php
+++ b/includes/Pages/RequestAction/PageDeferRequest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/RequestAction/PageDropRequest.php
+++ b/includes/Pages/RequestAction/PageDropRequest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/RequestAction/PageManuallyConfirm.php
+++ b/includes/Pages/RequestAction/PageManuallyConfirm.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/RequestAction/PageReservation.php
+++ b/includes/Pages/RequestAction/PageReservation.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/RequestAction/PageSendToUser.php
+++ b/includes/Pages/RequestAction/PageSendToUser.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/RequestAction/RequestActionBase.php
+++ b/includes/Pages/RequestAction/RequestActionBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\RequestAction;

--- a/includes/Pages/Statistics/StatsFastCloses.php
+++ b/includes/Pages/Statistics/StatsFastCloses.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Statistics;

--- a/includes/Pages/Statistics/StatsInactiveUsers.php
+++ b/includes/Pages/Statistics/StatsInactiveUsers.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Statistics;

--- a/includes/Pages/Statistics/StatsMain.php
+++ b/includes/Pages/Statistics/StatsMain.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Statistics;

--- a/includes/Pages/Statistics/StatsMonthlyStats.php
+++ b/includes/Pages/Statistics/StatsMonthlyStats.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Statistics;

--- a/includes/Pages/Statistics/StatsReservedRequests.php
+++ b/includes/Pages/Statistics/StatsReservedRequests.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Statistics;

--- a/includes/Pages/Statistics/StatsTemplateStats.php
+++ b/includes/Pages/Statistics/StatsTemplateStats.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Statistics;

--- a/includes/Pages/Statistics/StatsTopCreators.php
+++ b/includes/Pages/Statistics/StatsTopCreators.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Statistics;

--- a/includes/Pages/Statistics/StatsUsers.php
+++ b/includes/Pages/Statistics/StatsUsers.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\Statistics;

--- a/includes/Pages/UserAuth/Login/LoginCredentialPageBase.php
+++ b/includes/Pages/UserAuth/Login/LoginCredentialPageBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\UserAuth\Login;

--- a/includes/Pages/UserAuth/Login/PageOtpLogin.php
+++ b/includes/Pages/UserAuth/Login/PageOtpLogin.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\UserAuth\Login;

--- a/includes/Pages/UserAuth/Login/PagePasswordLogin.php
+++ b/includes/Pages/UserAuth/Login/PagePasswordLogin.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\UserAuth\Login;

--- a/includes/Pages/UserAuth/MultiFactor/PageMultiFactor.php
+++ b/includes/Pages/UserAuth/MultiFactor/PageMultiFactor.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\UserAuth\MultiFactor;

--- a/includes/Pages/UserAuth/PageChangePassword.php
+++ b/includes/Pages/UserAuth/PageChangePassword.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\UserAuth;

--- a/includes/Pages/UserAuth/PageForgotPassword.php
+++ b/includes/Pages/UserAuth/PageForgotPassword.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\UserAuth;

--- a/includes/Pages/UserAuth/PageLogout.php
+++ b/includes/Pages/UserAuth/PageLogout.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\UserAuth;

--- a/includes/Pages/UserAuth/PageOAuth.php
+++ b/includes/Pages/UserAuth/PageOAuth.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\UserAuth;

--- a/includes/Pages/UserAuth/PageOAuthCallback.php
+++ b/includes/Pages/UserAuth/PageOAuthCallback.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\UserAuth;

--- a/includes/Pages/UserAuth/PagePreferences.php
+++ b/includes/Pages/UserAuth/PagePreferences.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Pages\UserAuth;

--- a/includes/PdoDatabase.php
+++ b/includes/PdoDatabase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/Providers/CachedApiAntispoofProvider.php
+++ b/includes/Providers/CachedApiAntispoofProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers;

--- a/includes/Providers/CachedRDnsLookupProvider.php
+++ b/includes/Providers/CachedRDnsLookupProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers;

--- a/includes/Providers/FakeLocationProvider.php
+++ b/includes/Providers/FakeLocationProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers;

--- a/includes/Providers/GlobalState/FakeGlobalStateProvider.php
+++ b/includes/Providers/GlobalState/FakeGlobalStateProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers\GlobalState;

--- a/includes/Providers/GlobalState/GlobalStateProvider.php
+++ b/includes/Providers/GlobalState/GlobalStateProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers\GlobalState;

--- a/includes/Providers/GlobalState/IGlobalStateProvider.php
+++ b/includes/Providers/GlobalState/IGlobalStateProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers\GlobalState;

--- a/includes/Providers/Interfaces/IAntiSpoofProvider.php
+++ b/includes/Providers/Interfaces/IAntiSpoofProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers\Interfaces;

--- a/includes/Providers/Interfaces/ILocationProvider.php
+++ b/includes/Providers/Interfaces/ILocationProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers\Interfaces;

--- a/includes/Providers/Interfaces/IRDnsProvider.php
+++ b/includes/Providers/Interfaces/IRDnsProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers\Interfaces;

--- a/includes/Providers/Interfaces/IXffTrustProvider.php
+++ b/includes/Providers/Interfaces/IXffTrustProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers\Interfaces;

--- a/includes/Providers/IpLocationProvider.php
+++ b/includes/Providers/IpLocationProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers;

--- a/includes/Providers/TorExitProvider.php
+++ b/includes/Providers/TorExitProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers;

--- a/includes/Providers/XffTrustProvider.php
+++ b/includes/Providers/XffTrustProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Providers;

--- a/includes/RegexConstants.php
+++ b/includes/RegexConstants.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/RequestList.php
+++ b/includes/RequestList.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/RequestStatus.php
+++ b/includes/RequestStatus.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/Router/ApiRequestRouter.php
+++ b/includes/Router/ApiRequestRouter.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Router;

--- a/includes/Router/IRequestRouter.php
+++ b/includes/Router/IRequestRouter.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Router;

--- a/includes/Router/OAuthRequestRouter.php
+++ b/includes/Router/OAuthRequestRouter.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Router;

--- a/includes/Router/PublicRequestRouter.php
+++ b/includes/Router/PublicRequestRouter.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Router;

--- a/includes/Router/RequestRouter.php
+++ b/includes/Router/RequestRouter.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Router;

--- a/includes/Security/AuthenticationManager.php
+++ b/includes/Security/AuthenticationManager.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security;

--- a/includes/Security/ContentSecurityPolicyManager.php
+++ b/includes/Security/ContentSecurityPolicyManager.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security;

--- a/includes/Security/CredentialProviders/CredentialProviderBase.php
+++ b/includes/Security/CredentialProviders/CredentialProviderBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security\CredentialProviders;

--- a/includes/Security/CredentialProviders/ICredentialProvider.php
+++ b/includes/Security/CredentialProviders/ICredentialProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security\CredentialProviders;

--- a/includes/Security/CredentialProviders/PasswordCredentialProvider.php
+++ b/includes/Security/CredentialProviders/PasswordCredentialProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security\CredentialProviders;

--- a/includes/Security/CredentialProviders/ScratchTokenCredentialProvider.php
+++ b/includes/Security/CredentialProviders/ScratchTokenCredentialProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security\CredentialProviders;

--- a/includes/Security/CredentialProviders/TotpCredentialProvider.php
+++ b/includes/Security/CredentialProviders/TotpCredentialProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security\CredentialProviders;

--- a/includes/Security/CredentialProviders/YubikeyOtpCredentialProvider.php
+++ b/includes/Security/CredentialProviders/YubikeyOtpCredentialProvider.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security\CredentialProviders;

--- a/includes/Security/DomainAccessManager.php
+++ b/includes/Security/DomainAccessManager.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security;

--- a/includes/Security/EncryptionHelper.php
+++ b/includes/Security/EncryptionHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security;

--- a/includes/Security/RoleConfiguration.php
+++ b/includes/Security/RoleConfiguration.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security;

--- a/includes/Security/SecurityManager.php
+++ b/includes/Security/SecurityManager.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security;

--- a/includes/Security/Token.php
+++ b/includes/Security/Token.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security;

--- a/includes/Security/TokenManager.php
+++ b/includes/Security/TokenManager.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Security;

--- a/includes/Session.php
+++ b/includes/Session.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/SessionAlert.php
+++ b/includes/SessionAlert.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/Startup.php
+++ b/includes/Startup.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/StringFunctions.php
+++ b/includes/StringFunctions.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/Tasks/ApiPageBase.php
+++ b/includes/Tasks/ApiPageBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Tasks/ConsoleTaskBase.php
+++ b/includes/Tasks/ConsoleTaskBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Tasks/IRoutedTask.php
+++ b/includes/Tasks/IRoutedTask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Tasks/ITask.php
+++ b/includes/Tasks/ITask.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Tasks/InternalPageBase.php
+++ b/includes/Tasks/InternalPageBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Tasks/JsonApiPageBase.php
+++ b/includes/Tasks/JsonApiPageBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Tasks/PageBase.php
+++ b/includes/Tasks/PageBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Tasks/PagedInternalPageBase.php
+++ b/includes/Tasks/PagedInternalPageBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Tasks/PublicInterfacePageBase.php
+++ b/includes/Tasks/PublicInterfacePageBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Tasks/TaskBase.php
+++ b/includes/Tasks/TaskBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Tasks/XmlApiPageBase.php
+++ b/includes/Tasks/XmlApiPageBase.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tasks;

--- a/includes/Validation/RequestValidationHelper.php
+++ b/includes/Validation/RequestValidationHelper.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Validation;

--- a/includes/Validation/ValidationError.php
+++ b/includes/Validation/ValidationError.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Validation;

--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 /** @noinspection PhpPassByRefInspection - disable seemingly broken check in PhpStorm */

--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 // Redirect user away from the current directory.

--- a/index.php
+++ b/index.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/internal.php
+++ b/internal.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/ClearExpiredIdentificationData.php
+++ b/maintenance/ClearExpiredIdentificationData.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/ClearOAuthData.php
+++ b/maintenance/ClearOAuthData.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/ClearOldData.php
+++ b/maintenance/ClearOldData.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/MigrateToDomains.php
+++ b/maintenance/MigrateToDomains.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/MigrateToRoles.php
+++ b/maintenance/MigrateToRoles.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/OldRequestCleanup.php
+++ b/maintenance/OldRequestCleanup.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/PrecacheGeolocation.php
+++ b/maintenance/PrecacheGeolocation.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/RecreateTrustedIPs.php
+++ b/maintenance/RecreateTrustedIPs.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/RefreshOAuthData.php
+++ b/maintenance/RefreshOAuthData.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/RunJobQueue.php
+++ b/maintenance/RunJobQueue.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/maintenance/UpdateTorExitData.php
+++ b/maintenance/UpdateTorExitData.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/oauth/callback.php
+++ b/oauth/callback.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca;

--- a/redir.php
+++ b/redir.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 $toolList = array(

--- a/resources/global.js
+++ b/resources/global.js
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 $(function () {

--- a/resources/public.css
+++ b/resources/public.css
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 body {

--- a/resources/scss/_common.scss
+++ b/resources/scss/_common.scss
@@ -1,8 +1,9 @@
 //******************************************************************************
 // Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
 //                                                                             *
-// All code in this file is released into the public domain by the ACC         *
-// Development Team. Please see team.json for a list of contributors.          *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
 //******************************************************************************
 
 // this matches $indigo, but due to ordering constraints we have to redefine it here.

--- a/resources/scss/_login.scss
+++ b/resources/scss/_login.scss
@@ -1,8 +1,9 @@
 //******************************************************************************
 // Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
 //                                                                             *
-// All code in this file is released into the public domain by the ACC         *
-// Development Team. Please see team.json for a list of contributors.          *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
 //******************************************************************************
 
 #loginCredentialForm {

--- a/resources/scss/_mainPage.scss
+++ b/resources/scss/_mainPage.scss
@@ -1,8 +1,9 @@
 //******************************************************************************
 // Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
 //                                                                             *
-// All code in this file is released into the public domain by the ACC         *
-// Development Team. Please see team.json for a list of contributors.          *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
 //******************************************************************************
 
 #mainPage {

--- a/resources/scss/_password.scss
+++ b/resources/scss/_password.scss
@@ -1,8 +1,9 @@
 //******************************************************************************
 // Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
 //                                                                             *
-// All code in this file is released into the public domain by the ACC         *
-// Development Team. Please see team.json for a list of contributors.          *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
 //******************************************************************************
 
 div.password-strength-progress {

--- a/resources/scss/_sitenotice.scss
+++ b/resources/scss/_sitenotice.scss
@@ -1,8 +1,9 @@
 //******************************************************************************
 // Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
 //                                                                             *
-// All code in this file is released into the public domain by the ACC         *
-// Development Team. Please see team.json for a list of contributors.          *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
 //******************************************************************************
 
 .sitenotice-container {

--- a/resources/scss/_spacing.scss
+++ b/resources/scss/_spacing.scss
@@ -1,8 +1,9 @@
 //******************************************************************************
 // Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
 //                                                                             *
-// All code in this file is released into the public domain by the ACC         *
-// Development Team. Please see team.json for a list of contributors.          *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
 //******************************************************************************
 
 body {

--- a/resources/scss/_stats.scss
+++ b/resources/scss/_stats.scss
@@ -1,8 +1,9 @@
 //******************************************************************************
 // Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
 //                                                                             *
-// All code in this file is released into the public domain by the ACC         *
-// Development Team. Please see team.json for a list of contributors.          *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
 //******************************************************************************
 
 td.numeric, td.numeric-delta, td.timespan-delta {

--- a/resources/scss/_viewRequest.scss
+++ b/resources/scss/_viewRequest.scss
@@ -1,9 +1,11 @@
 //******************************************************************************
 // Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
 //                                                                             *
-// All code in this file is released into the public domain by the ACC         *
-// Development Team. Please see team.json for a list of contributors.          *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
 //******************************************************************************
+
 $zoom-section-spacer: 1.45rem;
 
 #pageRequestLog {

--- a/resources/scss/bootstrap-alt.scss
+++ b/resources/scss/bootstrap-alt.scss
@@ -1,9 +1,10 @@
-//*****************************************************************************
-// Wikipedia Account Creation Assistance tool                                 *
-//                                                                            *
-// All code in this file is released into the public domain by the ACC        *
-// Development Team. Please see team.json for a list of contributors.         *
-//*****************************************************************************
+//******************************************************************************
+// Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
+//                                                                             *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
+//******************************************************************************
 /*!
  * Wikipedia Account Creation Assistance tool
  * Styles based on Bootstrap

--- a/resources/scss/bootstrap-auto.scss
+++ b/resources/scss/bootstrap-auto.scss
@@ -1,9 +1,10 @@
-//*****************************************************************************
-// Wikipedia Account Creation Assistance tool                                 *
-//                                                                            *
-// All code in this file is released into the public domain by the ACC        *
-// Development Team. Please see team.json for a list of contributors.         *
-//*****************************************************************************
+//******************************************************************************
+// Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
+//                                                                             *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
+//******************************************************************************
 /*!
  * Wikipedia Account Creation Assistance tool
  * Styles based on Bootstrap

--- a/resources/scss/bootstrap-main.scss
+++ b/resources/scss/bootstrap-main.scss
@@ -1,8 +1,9 @@
 //******************************************************************************
 // Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
 //                                                                             *
-// All code in this file is released into the public domain by the ACC         *
-// Development Team. Please see team.json for a list of contributors.          *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
 //******************************************************************************
 /*!
  * Wikipedia Account Creation Assistance tool

--- a/smarty-plugins/function.defaultsort.php
+++ b/smarty-plugins/function.defaultsort.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 /**

--- a/smarty-plugins/modifier.date.php
+++ b/smarty-plugins/modifier.date.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 /**

--- a/smarty-plugins/modifier.demodhex.php
+++ b/smarty-plugins/modifier.demodhex.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 /**

--- a/smarty-plugins/modifier.iphex.php
+++ b/smarty-plugins/modifier.iphex.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 /**

--- a/smarty-plugins/modifier.nlimplode.php
+++ b/smarty-plugins/modifier.nlimplode.php
@@ -1,17 +1,18 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
- *****************************************************************************
- *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
+
+/*
  * @param array  $list
  * @param string $conjunction
  *
  * @return string
  */
-
 function smarty_modifier_nlimplode($list, $conjunction = 'or')
 {
     $last = array_pop($list);

--- a/smarty-plugins/modifier.relativedate.php
+++ b/smarty-plugins/modifier.relativedate.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 /**

--- a/smarty-plugins/modifier.timespan.php
+++ b/smarty-plugins/modifier.timespan.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 /**

--- a/sql/db-structure.sql
+++ b/sql/db-structure.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 -- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
 --
 -- Host: localhost    Database: production

--- a/sql/index.php
+++ b/sql/index.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 // Redirect user away from the current directory.

--- a/sql/patches/index.php
+++ b/sql/patches/index.php
@@ -1,13 +1,12 @@
 <?php
-/**************************************************************************
-**********      English Wikipedia Account Request Interface      **********
-***************************************************************************
-**                                                                       **
-** Code is released under the Public Domain                   			 **
-** by the ACC Development Team.                                          **
-**                                                                       **
-** See CREDITS for the list of developers.                               **
-***************************************************************************/
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
+
 // Redirect user away from the current directory.
 require_once('../../config.inc.php');
 global $baseurl;

--- a/sql/patches/patch00-example.sql
+++ b/sql/patches/patch00-example.sql
@@ -15,7 +15,13 @@
 -- If you are writing patches, you need to copy this template to a numbered 
 -- patch file, update the patchversion variable, and add the SQL code to upgrade
 -- the database where indicated below.
-
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch01-deprecatemessages.sql
+++ b/sql/patches/patch01-deprecatemessages.sql
@@ -1,1 +1,8 @@
-﻿UPDATE interfacemessage SET description = CONCAT(description, ' [deprecated]') WHERE id IN (10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 27, 28);
+﻿/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
+UPDATE interfacemessage SET description = CONCAT(description, ' [deprecated]') WHERE id IN (10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 27, 28);

--- a/sql/patches/patch02-drop-accuser-view.sql
+++ b/sql/patches/patch02-drop-accuser-view.sql
@@ -1,4 +1,11 @@
-﻿DROP VIEW IF EXISTS acc_user;
+﻿/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
+DROP VIEW IF EXISTS acc_user;
 DROP VIEW IF EXISTS acc_template;
 
 DROP VIEW IF EXISTS `request`;

--- a/sql/patches/patch03-drop-accwelcome.sql
+++ b/sql/patches/patch03-drop-accwelcome.sql
@@ -1,1 +1,8 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP TABLE IF EXISTS acc_welcome;

--- a/sql/patches/patch04-logtable.sql
+++ b/sql/patches/patch04-logtable.sql
@@ -1,4 +1,11 @@
-ALTER TABLE `acc_log` 
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
+ALTER TABLE `acc_log`
 CHANGE COLUMN `log_id` `id` INT(11) NOT NULL AUTO_INCREMENT ,
 CHANGE COLUMN `log_action` `action` VARCHAR(255) NOT NULL ,
 CHANGE COLUMN `log_time` `timestamp` DATETIME NOT NULL ,

--- a/sql/patches/patch05-applog.sql
+++ b/sql/patches/patch05-applog.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 CREATE TABLE `applicationlog` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `source` varchar(255) COLLATE utf8_unicode_ci NOT NULL,

--- a/sql/patches/patch06-log-indexes.sql
+++ b/sql/patches/patch06-log-indexes.sql
@@ -1,4 +1,11 @@
-ALTER TABLE `log` 
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
+ALTER TABLE `log`
 ADD INDEX `log_idx_action` (`action` ASC),
 ADD INDEX `log_idx_objectid` (`objectid` ASC),
 ADD INDEX `log_idx_user` (`user` ASC),

--- a/sql/patches/patch07-drop-createdusers.sql
+++ b/sql/patches/patch07-drop-createdusers.sql
@@ -1,1 +1,8 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP VIEW `createdusers`;

--- a/sql/patches/patch08-rename-checkuser.sql
+++ b/sql/patches/patch08-rename-checkuser.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 -- ALTER TABLE user
 --	CHANGE COLUMN checkuser checkuser INT(1) NOT NULL DEFAULT '0' COMMENT 'Deprecated - OAuth is now used.' ,
 --	ADD COLUMN root INT(1) NOT NULL DEFAULT 0;

--- a/sql/patches/patch09-applog-request.sql
+++ b/sql/patches/patch09-applog-request.sql
@@ -1,3 +1,10 @@
-﻿ALTER TABLE `applicationlog` 
+﻿/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
+ALTER TABLE `applicationlog`
 ADD COLUMN `request` VARCHAR(1024) NULL AFTER `timestamp`,
 ADD COLUMN `request_ts` DECIMAL(38,12) NULL AFTER `request`;

--- a/sql/patches/patch10-revert08-schemaversion.sql
+++ b/sql/patches/patch10-revert08-schemaversion.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS schema_change;
 
 DELIMITER ';;'

--- a/sql/patches/patch11-emailtemplate-defaultaction.sql
+++ b/sql/patches/patch11-emailtemplate-defaultaction.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
@@ -27,20 +17,20 @@ CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
     -- working variables
 	DECLARE currentschemaversion INT DEFAULT 0;
     DECLARE lastversion INT;
-	
+
     -- check the schema has a version table
     IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'schemaversion' AND table_schema = DATABASE()) THEN
         SIGNAL SQLSTATE '45000' SET message_text = 'Please ensure patches are run in order! This database does not have a schemaversion table.';
     END IF;
-    
+
     -- get the current version
     SELECT version INTO currentschemaversion FROM schemaversion;
-    
+
     -- check schema is not ahead of this patch
     IF currentschemaversion >= patchversion THEN
         SIGNAL SQLSTATE '45000' SET message_text = 'This patch has already been applied!';
     END IF;
-    
+
     -- check schema is up-to-date
     SET lastversion = patchversion - 1;
     IF currentschemaversion != lastversion THEN
@@ -51,22 +41,22 @@ CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN
     -- -------------------------------------------------------------------------
     -- Developers - put your upgrade statements here!
     -- -------------------------------------------------------------------------
-    
-    ALTER TABLE `emailtemplate` 
+
+    ALTER TABLE `emailtemplate`
     ADD COLUMN `defaultaction` VARCHAR(45) NULL DEFAULT NULL AFTER `preloadonly`;
-   
+
     UPDATE `emailtemplate`
     SET `defaultaction` = 'created'
     WHERE oncreated = 1;
-   
+
     UPDATE `emailtemplate`
     SET `defaultaction` = 'not created'
     WHERE oncreated = 0;
-   
-    ALTER TABLE `emailtemplate` 
+
+    ALTER TABLE `emailtemplate`
     CHANGE COLUMN `oncreated` `oncreated` TINYINT(1) NOT NULL DEFAULT '0' COMMENT 'Deprecated - see defaultaction' ,
     CHANGE COLUMN `defaultaction` `defaultaction` VARCHAR(45) NULL COMMENT 'The default action to take when this template is used for custom closes' ;
-    
+
     -- -------------------------------------------------------------------------
     UPDATE schemaversion SET version = patchversion;
 END;;

--- a/sql/patches/patch12-requestcomment.sql
+++ b/sql/patches/patch12-requestcomment.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch13-extra-indexes.sql
+++ b/sql/patches/patch13-extra-indexes.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch14-drop-acc_log.sql
+++ b/sql/patches/patch14-drop-acc_log.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch15-rename-admin-state.sql
+++ b/sql/patches/patch15-rename-admin-state.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch16-idx-banactive.sql
+++ b/sql/patches/patch16-idx-banactive.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch17-idx-pend-reserved.sql
+++ b/sql/patches/patch17-idx-pend-reserved.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch18-encoding.sql
+++ b/sql/patches/patch18-encoding.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch19-newinternal.sql
+++ b/sql/patches/patch19-newinternal.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch20-sitenotice.sql
+++ b/sql/patches/patch20-sitenotice.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch21-torcache.sql
+++ b/sql/patches/patch21-torcache.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch22-wtdelete-reserve-checksum.sql
+++ b/sql/patches/patch22-wtdelete-reserve-checksum.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch23-requestcomment.sql
+++ b/sql/patches/patch23-requestcomment.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch24-user-roles.sql
+++ b/sql/patches/patch24-user-roles.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch25-migrationscript-placeholder.sql
+++ b/sql/patches/patch25-migrationscript-placeholder.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 -- Hey!
 -- This patch script exists as a placeholder for a PHP-based migration maintenance job.
 -- If you are a database build job, this job should succeed without issues

--- a/sql/patches/patch26-drop-checkuser.sql
+++ b/sql/patches/patch26-drop-checkuser.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch27-user-refactor-oauth.sql
+++ b/sql/patches/patch27-user-refactor-oauth.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch28-oauth-creation.sql
+++ b/sql/patches/patch28-oauth-creation.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch29-otp-timeout.sql
+++ b/sql/patches/patch29-otp-timeout.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch30-force-identification.sql
+++ b/sql/patches/patch30-force-identification.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch31-darkmode.sql
+++ b/sql/patches/patch31-darkmode.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch32-ban-table.sql
+++ b/sql/patches/patch32-ban-table.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch33-requestercomment.sql
+++ b/sql/patches/patch33-requestercomment.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch34-cutools.sql
+++ b/sql/patches/patch34-cutools.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch35-user-welcometemplate-datafix.sql
+++ b/sql/patches/patch35-user-welcometemplate-datafix.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch36-multisite-base.sql
+++ b/sql/patches/patch36-multisite-base.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch37-domainmigration.sql
+++ b/sql/patches/patch37-domainmigration.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch38-requestqueuemigration.sql
+++ b/sql/patches/patch38-requestqueuemigration.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch39-comment-flagging.sql
+++ b/sql/patches/patch39-comment-flagging.sql
@@ -1,20 +1,10 @@
--- -----------------------------------------------------------------------------
--- Hey!
--- 
--- This is a new patch-creation script which SHOULD stop double-patching and
--- running patches out-of-order.
---
--- If you're running patches, please close this file, and run this from the 
--- command line:
---   $ mysql -u USERNAME -p SCHEMA < patchXX-this-file.sql
--- where:
---      USERNAME = a user with CREATE/ALTER access to the schema
---      SCHEMA = the schema to run the changes against
---      patch-XX-this-file.sql = this file
---
--- If you are writing patches, you need to copy this template to a numbered 
--- patch file, update the patchversion variable, and add the SQL code to upgrade
--- the database where indicated below.
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'

--- a/sql/patches/patch40-userdomains.sql
+++ b/sql/patches/patch40-userdomains.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 # noinspection SqlResolveForFile
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;

--- a/sql/patches/patch41-requestform-usage.sql
+++ b/sql/patches/patch41-requestform-usage.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 # noinspection SqlResolveForFile
 
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;

--- a/sql/patches/patch42-renamefield.sql
+++ b/sql/patches/patch42-renamefield.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch43-preferencesrefactor.sql
+++ b/sql/patches/patch43-preferencesrefactor.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch44-client-hints.sql
+++ b/sql/patches/patch44-client-hints.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch45-domain-columns.sql
+++ b/sql/patches/patch45-domain-columns.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch46-antispoof-cache.sql
+++ b/sql/patches/patch46-antispoof-cache.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch47-db-cleanup.sql
+++ b/sql/patches/patch47-db-cleanup.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch48-globalbans.sql
+++ b/sql/patches/patch48-globalbans.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/patches/patch49-globalroles.sql
+++ b/sql/patches/patch49-globalroles.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 DROP PROCEDURE IF EXISTS SCHEMA_UPGRADE_SCRIPT;
 DELIMITER ';;'
 CREATE PROCEDURE SCHEMA_UPGRADE_SCRIPT() BEGIN

--- a/sql/seed/emailtemplate_data.sql
+++ b/sql/seed/emailtemplate_data.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 -- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
 --
 -- Host: localhost    Database: production

--- a/sql/seed/interfacemessage_data.sql
+++ b/sql/seed/interfacemessage_data.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 -- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
 --
 -- Host: localhost    Database: production

--- a/sql/seed/user_data.sql
+++ b/sql/seed/user_data.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 -- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
 --
 -- Host: localhost    Database: production

--- a/sql/seed/welcometemplate_data.sql
+++ b/sql/seed/welcometemplate_data.sql
@@ -1,3 +1,10 @@
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 -- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
 --
 -- Host: localhost    Database: production

--- a/sql/test_db.sh
+++ b/sql/test_db.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+#*******************************************************************************
+# Wikipedia Account Creation Assistance tool                                   *
+# ACC Development Team. Please see team.json for a list of contributors.       *
+#                                                                              *
+# This is free and unencumbered software released into the public domain.      *
+# Please see LICENSE.md for the full licencing statement.                      *
+#*******************************************************************************
+
 cd "$(dirname "$0")"
 
 function usage {

--- a/sql/tests/check_name.sql
+++ b/sql/tests/check_name.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking check constraint naming";

--- a/sql/tests/fk_name.sql
+++ b/sql/tests/fk_name.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking foreign key naming";

--- a/sql/tests/fk_on_pk.sql
+++ b/sql/tests/fk_on_pk.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking foreign keys are based on table primary keys";

--- a/sql/tests/index_name.sql
+++ b/sql/tests/index_name.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking index names";

--- a/sql/tests/invalid_column_collation.sql
+++ b/sql/tests/invalid_column_collation.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking text-based column collations";

--- a/sql/tests/invalid_table_collation.sql
+++ b/sql/tests/invalid_table_collation.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking table default collations";

--- a/sql/tests/nontransactional_engines.sql
+++ b/sql/tests/nontransactional_engines.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking non-transactional engines used for non-transactional tables";

--- a/sql/tests/pk_attributes.sql
+++ b/sql/tests/pk_attributes.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking primary key attributes";

--- a/sql/tests/pk_name.sql
+++ b/sql/tests/pk_name.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking primary key naming";

--- a/sql/tests/pk_on_id.sql
+++ b/sql/tests/pk_on_id.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking primary keys based on id columns";

--- a/sql/tests/transactional_engines.sql
+++ b/sql/tests/transactional_engines.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking transactional engines used for transactional tables";

--- a/sql/tests/uniq_name.sql
+++ b/sql/tests/uniq_name.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking unique constraint naming";

--- a/sql/tests/updateversion.sql
+++ b/sql/tests/updateversion.sql
@@ -1,8 +1,9 @@
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 SELECT "Checking presence of updateversion column";

--- a/templates/index.php
+++ b/templates/index.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 header("Location: ../internal.php");

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 //This file is used by phpunit

--- a/tests/includes/API/ApiExceptionTest.php
+++ b/tests/includes/API/ApiExceptionTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Api;

--- a/tests/includes/ApplicationBaseTest.php
+++ b/tests/includes/ApplicationBaseTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/DataObjectTest.php
+++ b/tests/includes/DataObjectTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/EnvironmentTest.php
+++ b/tests/includes/EnvironmentTest.php
@@ -2,9 +2,10 @@
 
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 use PHPUnit\Framework\TestCase;

--- a/tests/includes/ExceptionHandlerTest.php
+++ b/tests/includes/ExceptionHandlerTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/Fragments/RequestDataForwardedIpDataTest.php
+++ b/tests/includes/Fragments/RequestDataForwardedIpDataTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Fragments;

--- a/tests/includes/Fragments/RequestDataPrivateDataTest.php
+++ b/tests/includes/Fragments/RequestDataPrivateDataTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Fragments;

--- a/tests/includes/Helpers/BlacklistHelperTest.php
+++ b/tests/includes/Helpers/BlacklistHelperTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Helpers;

--- a/tests/includes/Helpers/DebugHelperTest.php
+++ b/tests/includes/Helpers/DebugHelperTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Helpers;

--- a/tests/includes/Helpers/EmailHelperTest.php
+++ b/tests/includes/Helpers/EmailHelperTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Helpers;

--- a/tests/includes/Helpers/FakeBlacklistHelperTest.php
+++ b/tests/includes/Helpers/FakeBlacklistHelperTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Helpers;

--- a/tests/includes/Helpers/HttpHelperTest.php
+++ b/tests/includes/Helpers/HttpHelperTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Helpers;

--- a/tests/includes/Helpers/RequestQueueHelperTest.php
+++ b/tests/includes/Helpers/RequestQueueHelperTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace includes\Helpers;

--- a/tests/includes/IdentificationVerifierTest.php
+++ b/tests/includes/IdentificationVerifierTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/IrcColourCodeTest.php
+++ b/tests/includes/IrcColourCodeTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/OfflineTest.php
+++ b/tests/includes/OfflineTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/PdoDatabaseTest.php
+++ b/tests/includes/PdoDatabaseTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/RequestRouterTest.php
+++ b/tests/includes/RequestRouterTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/Security/RoleConfigurationTest.php
+++ b/tests/includes/Security/RoleConfigurationTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Security;

--- a/tests/includes/Security/SecurityManagerTest.php
+++ b/tests/includes/Security/SecurityManagerTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Security;

--- a/tests/includes/Security/TokenManagerTests.php
+++ b/tests/includes/Security/TokenManagerTests.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Security;

--- a/tests/includes/SessionAlertTests.php
+++ b/tests/includes/SessionAlertTests.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/SessionTests.php
+++ b/tests/includes/SessionTests.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/SiteConfigurationTest.php
+++ b/tests/includes/SiteConfigurationTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/StringFunctionsTest.php
+++ b/tests/includes/StringFunctionsTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/Validation/RequestValidationHelperTest.php
+++ b/tests/includes/Validation/RequestValidationHelperTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\Validation;

--- a/tests/includes/WebRequestTest.php
+++ b/tests/includes/WebRequestTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/includes/WebStartTest.php
+++ b/tests/includes/WebStartTest.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests;

--- a/tests/smarty-plugins/TimeSpanTests.php
+++ b/tests/smarty-plugins/TimeSpanTests.php
@@ -1,9 +1,10 @@
 <?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
  *                                                                            *
- * All code in this file is released into the public domain by the ACC        *
- * Development Team. Please see team.json for a list of contributors.         *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
 namespace Waca\Tests\SmartyPlugins;

--- a/tests/utility/MockFunction.php
+++ b/tests/utility/MockFunction.php
@@ -1,4 +1,11 @@
 <?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 /**
  * Extension for PHPUnit that makes MockObject-style expectations possible for global functions (even PECL functions).

--- a/tests/utility/MockStaticMethod.php
+++ b/tests/utility/MockStaticMethod.php
@@ -1,4 +1,11 @@
 <?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
 
 require_once(dirname(__FILE__) . '/MockFunction.php');
 


### PR DESCRIPTION
This project previously used a public domain declaration, which is known to cause [difficulties][osi-pd] legally. By moving to the Unlicense, we stick with the public domain intentions as closely as possible, while still using an OSI-approved licence.

[osi-pd]: https://opensource.org/faq#public-domain