### PR TITLE
Add privacy statement to relevant places

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,11 @@ jobs:
 
       - name: Run SCSS build
         run: npm run build-scss
+
+      - name: Check generated files
+        run: |
+          if [[ $(find resources/generated -type f -name *.css | wc -l) -ne 4 ]]; then
+            echo "Wrong number of generated files found!"
+            ls -l resources/generated/*.css
+            exit 1
+          fi

--- a/includes/Fragments/PrivacyStatement.php
+++ b/includes/Fragments/PrivacyStatement.php
@@ -1,0 +1,43 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
+
+namespace Waca\Fragments;
+
+use Waca\Helpers\MarkdownRenderingHelper;
+
+trait PrivacyStatement
+{
+    protected abstract function assign($name, $value);
+    protected abstract function templatePath();
+    protected abstract function setTemplate($name);
+    protected abstract function skipAlerts();
+    protected abstract function getSiteConfiguration();
+
+    protected function main()
+    {
+        $path = $this->getSiteConfiguration()->getPrivacyStatementPath();
+
+        if ($path == null || !file_exists($path)) {
+            if (!headers_sent()) {
+                header('HTTP/1.1 404 Not Found');
+            }
+
+            $this->skipAlerts();
+            $this->setTemplate('404.tpl');
+            return;
+        }
+
+        $markdown = file_get_contents($path);
+
+        $renderer = new MarkdownRenderingHelper();
+        $this->assign('content', $renderer->doRender($markdown));
+
+        $this->setTemplate($this->templatePath());
+    }
+}

--- a/includes/Helpers/MarkdownRenderingHelper.php
+++ b/includes/Helpers/MarkdownRenderingHelper.php
@@ -13,6 +13,7 @@ use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\Attributes\AttributesExtension;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
+use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\MarkdownConverter;
 
 class MarkdownRenderingHelper
@@ -20,7 +21,19 @@ class MarkdownRenderingHelper
     private $config = [
         'html_input'         => 'escape',
         'allow_unsafe_links' => false,
-        'max_nesting_level'  => 10
+        'max_nesting_level'  => 10,
+        'table'              => [
+            'wrap'                 => [
+                'enabled'    => true,
+                'tag'        => 'div',
+                'attributes' => ['class' => 'markdown-table'],
+            ],
+            'alignment_attributes' => [
+                'left'   => ['class' => 'text-left'],
+                'center' => ['class' => 'text-center'],
+                'right'  => ['class' => 'text-right'],
+            ],
+        ],
     ];
 
     private $blockRenderer;
@@ -31,6 +44,7 @@ class MarkdownRenderingHelper
         $blockEnvironment = new Environment($this->config);
         $blockEnvironment->addExtension(new CommonMarkCoreExtension());
         $blockEnvironment->addExtension(new AttributesExtension());
+        $blockEnvironment->addExtension(new TableExtension());
         $this->blockRenderer = new MarkdownConverter($blockEnvironment);
 
         $inlineEnvironment = new Environment($this->config);

--- a/includes/Pages/PagePrivacy.php
+++ b/includes/Pages/PagePrivacy.php
@@ -1,0 +1,23 @@
+<?php
+/******************************************************************************
+ * Wikipedia Account Creation Assistance tool                                 *
+ * ACC Development Team. Please see team.json for a list of contributors.     *
+ *                                                                            *
+ * This is free and unencumbered software released into the public domain.    *
+ * Please see LICENSE.md for the full licencing statement.                    *
+ ******************************************************************************/
+
+namespace Waca\Pages;
+
+use Waca\Fragments\PrivacyStatement;
+use Waca\Tasks\InternalPageBase;
+
+class PagePrivacy extends InternalPageBase
+{
+    use PrivacyStatement;
+
+    protected function templatePath()
+    {
+        return 'markdown/private.tpl';
+    }
+}

--- a/includes/Pages/PagePublicPrivacy.php
+++ b/includes/Pages/PagePublicPrivacy.php
@@ -1,3 +1,4 @@
+<?php
 /******************************************************************************
  * Wikipedia Account Creation Assistance tool                                 *
  * ACC Development Team. Please see team.json for a list of contributors.     *
@@ -6,6 +7,17 @@
  * Please see LICENSE.md for the full licencing statement.                    *
  ******************************************************************************/
 
-body {
-    padding-top: 2rem;
+namespace Waca\Pages;
+
+use Waca\Fragments\PrivacyStatement;
+use Waca\Tasks\PublicInterfacePageBase;
+
+class PagePublicPrivacy extends PublicInterfacePageBase
+{
+    use PrivacyStatement;
+
+    protected function templatePath()
+    {
+        return 'markdown/public.tpl';
+    }
 }

--- a/includes/Router/PublicRequestRouter.php
+++ b/includes/Router/PublicRequestRouter.php
@@ -9,6 +9,7 @@
 
 namespace Waca\Router;
 
+use Waca\Pages\PagePublicPrivacy;
 use Waca\Pages\Request\PageConfirmEmail;
 use Waca\Pages\Request\PageEmailConfirmationRequired;
 use Waca\Pages\Request\PageRequestAccount;
@@ -40,6 +41,12 @@ class PublicRequestRouter extends RequestRouter
             'confirmEmail'              =>
                 array(
                     'class'   => PageConfirmEmail::class,
+                    'actions' => array(),
+                ),
+            // Page showing the privacy statement
+            'privacy'                   =>
+                array(
+                    'class'   => PagePublicPrivacy::class,
                     'actions' => array(),
                 ),
         );

--- a/includes/Router/RequestRouter.php
+++ b/includes/Router/RequestRouter.php
@@ -21,6 +21,7 @@ use Waca\Pages\PageExpandedRequestList;
 use Waca\Pages\PageFlagComment;
 use Waca\Pages\PageJobQueue;
 use Waca\Pages\PageListFlaggedComments;
+use Waca\Pages\PagePrivacy;
 use Waca\Pages\PageQueueManagement;
 use Waca\Pages\PageRequestFormManagement;
 use Waca\Pages\PageXffDemo;
@@ -400,6 +401,11 @@ class RequestRouter implements IRequestRouter
             array(
                 'class'   => PageErrorLogViewer::class,
                 'actions' => array('remove', 'view'),
+            ),
+        'privacy'                     =>
+            array(
+                'class'   => PagePrivacy::class,
+                'actions' => array(),
             ),
     );
 

--- a/includes/Security/RoleConfiguration.php
+++ b/includes/Security/RoleConfiguration.php
@@ -22,6 +22,7 @@ use Waca\Pages\PageJobQueue;
 use Waca\Pages\PageListFlaggedComments;
 use Waca\Pages\PageLog;
 use Waca\Pages\PageMain;
+use Waca\Pages\PagePrivacy;
 use Waca\Pages\PageQueueManagement;
 use Waca\Pages\PageRequestFormManagement;
 use Waca\Pages\PageXffDemo;
@@ -106,6 +107,9 @@ class RoleConfiguration
             ),
             PageXffDemo::class        => array(
                 self::MAIN  => self::ACCESS_ALLOW,
+            ),
+            PagePrivacy::class => array(
+                self::MAIN => self::ACCESS_ALLOW,
             )
         ),
         'loggedIn'          => array(

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -82,6 +82,7 @@ class SiteConfiguration
         'username' => 'waca',
         'password' => 'waca'
     ];
+    private string $privacyStatementPath = '';
 
     /**
      * Gets the base URL of the tool
@@ -1114,5 +1115,17 @@ class SiteConfiguration
     public function getDatabaseConfig(): array
     {
         return $this->databaseConfig;
+    }
+
+    public function getPrivacyStatementPath(): string
+    {
+        return $this->privacyStatementPath;
+    }
+
+    public function setPrivacyStatementPath(string $privacyStatementPath): SiteConfiguration
+    {
+        $this->privacyStatementPath = $privacyStatementPath;
+
+        return $this;
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "sass": "^1.77.2"
   },
   "scripts": {
-    "build-scss": "./node_modules/.bin/sass --style=compressed resources/scss/bootstrap-alt.scss:resources/generated/bootstrap-alt.css resources/scss/bootstrap-main.scss:resources/generated/bootstrap-main.css resources/scss/bootstrap-auto.scss:resources/generated/bootstrap-auto.css"
+    "build-scss": "./node_modules/.bin/sass --style=compressed resources/scss/bootstrap-alt.scss:resources/generated/bootstrap-alt.css resources/scss/bootstrap-main.scss:resources/generated/bootstrap-main.css resources/scss/bootstrap-auto.scss:resources/generated/bootstrap-auto.css resources/scss/public.scss:resources/generated/public.css"
   },
   "author": "",
   "license": "UNLICENCED"

--- a/resources/scss/_common.scss
+++ b/resources/scss/_common.scss
@@ -34,6 +34,7 @@ $sortabletable-hover: $gray-200 !default;
 @import "_sortableTables.scss";
 @import "_stats.scss";
 @import "_footer.scss";
+@import "_markdown.scss";
 
 
 span.twitter-typeahead {

--- a/resources/scss/_common.scss
+++ b/resources/scss/_common.scss
@@ -33,6 +33,7 @@ $sortabletable-hover: $gray-200 !default;
 @import "_sitenotice.scss";
 @import "_sortableTables.scss";
 @import "_stats.scss";
+@import "_footer.scss";
 
 
 span.twitter-typeahead {

--- a/resources/scss/_footer.scss
+++ b/resources/scss/_footer.scss
@@ -1,0 +1,31 @@
+//******************************************************************************
+// Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
+//                                                                             *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
+//******************************************************************************
+
+footer {
+  margin-bottom: 1rem;
+
+  p {
+    margin-bottom: 0;
+    @extend .small;
+  }
+
+  ul {
+    list-style: none;
+    margin-bottom: 0;
+    padding: 0;
+
+    li {
+      display: inline-block;
+      @extend .small;
+
+      & + li::before {
+        content: " | ";
+      }
+    }
+  }
+}

--- a/resources/scss/_markdown.scss
+++ b/resources/scss/_markdown.scss
@@ -5,17 +5,9 @@
 // This is free and unencumbered software released into the public domain.     *
 // Please see LICENSE.md for the full licencing statement.                     *
 //******************************************************************************
-/*!
- * Wikipedia Account Creation Assistance tool
- * Styles based on Bootstrap
- */
 
-@import "../../node_modules/bootstrap/scss/bootstrap.scss";
-
-@import "_footer.scss";
-@import "_markdown.scss";
-
-body {
-  padding-top: 2rem;
+div.markdown-table {
+  table {
+    @extend .table, .table-bordered, .table-striped;
+  }
 }
-

--- a/resources/scss/public.scss
+++ b/resources/scss/public.scss
@@ -1,0 +1,20 @@
+//******************************************************************************
+// Wikipedia Account Creation Assistance tool                                  *
+// ACC Development Team. Please see team.json for a list of contributors.      *
+//                                                                             *
+// This is free and unencumbered software released into the public domain.     *
+// Please see LICENSE.md for the full licencing statement.                     *
+//******************************************************************************
+/*!
+ * Wikipedia Account Creation Assistance tool
+ * Styles based on Bootstrap
+ */
+
+@import "../../node_modules/bootstrap/scss/bootstrap.scss";
+
+@import "_footer.scss";
+
+body {
+  padding-top: 2rem;
+}
+

--- a/templates/base.tpl
+++ b/templates/base.tpl
@@ -53,16 +53,20 @@
     <hr/>
 
     <footer class="row">
-        <p class="col-md-6">
-            <small>
+        <div class="col-md-6">
+            <p>
                 Account Creation Assistance Manager
                 (<a href="https://github.com/enwikipedia-acc/waca/tree/{$toolversion}">version {$toolversion}</a>)
                 by <a href="{$baseurl}/internal.php/team">The ACC development team</a>
                 (<a href="https://github.com/enwikipedia-acc/waca/issues">Bug reports</a>)
-            </small>
-        </p>
-        <p class="col-md-6 text-right">
-            <small>
+            </p>
+            <ul>
+                <li><a href="{$baseurl}/internal.php/privacy">Privacy Statement</a></li>
+                <li><a href="https://wikitech.wikimedia.org/wiki/Wikitech:Cloud_Services_End_User_Terms_of_use">Wikimedia Cloud Services End User Terms of Use</a></li>
+            </ul>
+        </div>
+        <div class="col-md-6">
+            <p class="text-right">
                 {if count($onlineusers) > 0}
                     {count($onlineusers)} Account Creator{if count($onlineusers) !== 1}s{/if} currently online (past 5 minutes):
                     {foreach from=$onlineusers item=userObject name=onlineUserLoop}
@@ -70,8 +74,8 @@
                         {$userObject->getUsername()|escape}</a>{if !$smarty.foreach.onlineUserLoop.last}, {/if}
                     {/foreach}
                 {/if}
-            </small>
-        </p>
+            </p>
+        </div>
     </footer>
 </div><!--/.fluid-container-->
 

--- a/templates/form-management/preview.tpl
+++ b/templates/form-management/preview.tpl
@@ -27,6 +27,7 @@
                     <textarea class="form-control col-md-8" id="inputComments" rows="4" name="comments" disabled></textarea>
                     <small class="form-text text-muted offset-md-4 col-md-8">{$comment}</small>
                 </div>
+                {include file="request/legal-info.tpl"}
                 <div class="row">
                     <div class="offset-md-4 col-md-8 btn btn-primary btn-block disabled">Send request</div>
                 </div>

--- a/templates/markdown/private.tpl
+++ b/templates/markdown/private.tpl
@@ -1,0 +1,8 @@
+{extends file="base.tpl"}
+{block name="content"}
+<div class="row">
+  <div class="col-md-12">
+    {$content}
+  </div>
+</div>
+{/block}

--- a/templates/markdown/public.tpl
+++ b/templates/markdown/public.tpl
@@ -1,0 +1,8 @@
+{extends file="publicbase.tpl"}
+{block name="content"}
+<div class="row">
+  <div class="col-md-12">
+    {$content}
+  </div>
+</div>
+{/block}

--- a/templates/publicbase.tpl
+++ b/templates/publicbase.tpl
@@ -6,9 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- Le styles -->
-    <link href="{$baseurl}/node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="{$baseurl}/resources/public.css" rel="stylesheet"/>
-
+    <link href="{$baseurl}/resources/generated/public.css" rel="stylesheet"/>
 </head>
 
 <body>
@@ -41,14 +39,18 @@
     <hr/>
 
     <footer class="row">
-        <p class="col-md-12">
-            <small>
+        <div class="col-md-12">
+            <p>
                 Account Creation Assistance Manager
                 (<a href="https://github.com/enwikipedia-acc/waca/tree/{$toolversion}">version {$toolversion}</a>)
                 by <a href="{$baseurl}/internal.php/team">The ACC development team</a>
                 (<a href="https://github.com/enwikipedia-acc/waca/issues">Bug reports</a>)
-            </small>
-        </p>
+            </p>
+            <ul>
+                <li><a href="{$baseurl}/index.php/privacy">Privacy Statement</a></li>
+                <li><a href="https://wikitech.wikimedia.org/wiki/Wikitech:Cloud_Services_End_User_Terms_of_use">Wikimedia Cloud Services End User Terms of Use</a></li>
+            </ul>
+        </div>
     </footer>
     {/block}
 

--- a/templates/registration/register.tpl
+++ b/templates/registration/register.tpl
@@ -138,6 +138,16 @@
 
                 <div class="form-group row">
                     <div class="offset-sm-4 offset-md-5 col-sm-8 col-md-5 col-xl-4">
+                        <p class="legal-info">
+                            By submitting this form, you agree to your information being held by this tool to facilitate
+                            your use of this tool in accordance with our <a href="{$baseurl}/internal.php/privacy">Privacy Statement</a>
+                            and the <a href="https://wikitech.wikimedia.org/wiki/Wikitech:Cloud_Services_End_User_Terms_of_use">Wikimedia Cloud Services Terms of Use</a>
+                        </p>
+                    </div>
+                </div>
+
+                <div class="form-group row">
+                    <div class="offset-sm-4 offset-md-5 col-sm-8 col-md-5 col-xl-4">
                         <button type="submit" class="btn btn-primary btn-block">Signup</button>
                     </div>
                 </div>

--- a/templates/request/legal-info.tpl
+++ b/templates/request/legal-info.tpl
@@ -1,0 +1,7 @@
+<div class="row">
+    <p class="legal-info">
+        By submitting this form, you agree to your information being processed to fulfil your request in
+        accordance with our <a href="{$baseurl}/index.php/privacy">Privacy Statement</a> and the
+        <a href="https://wikitech.wikimedia.org/wiki/Wikitech:Cloud_Services_End_User_Terms_of_use">Wikimedia Cloud Services Terms of Use</a>
+    </p>
+</div>

--- a/templates/request/request-form-dynamic.tpl
+++ b/templates/request/request-form-dynamic.tpl
@@ -34,6 +34,7 @@
                         {$formCommentsHelp}
                     </small>
                 </div>
+                {include file="request/legal-info.tpl"}
                 <div class="row">
                     <button type="submit" class="offset-md-4 col-md-8 btn btn-primary btn-block">Send request</button>
                 </div>

--- a/templates/request/request-form.tpl
+++ b/templates/request/request-form.tpl
@@ -11,7 +11,8 @@
                 (please don't use temporary inboxes, or email aliasing, as this may cause your request to be rejected).
                 If you want to leave any comments, feel free to do so in the comments field below. Note that if you use
                 this form, your IP address will be recorded, and displayed to
-                <a href="{$baseurl}/internal.php/statistics/users">those who review account requests</a>.
+                <a href="{$baseurl}/internal.php/statistics/users">those who review account requests</a> in accordance
+                with our <a href="{$baseurl}/index.php/privacy">Privacy Statement</a>.
                 When you are done, click the "Submit" button.
             </p>
 
@@ -64,6 +65,7 @@
                             for a specific password. One will be randomly created for you.</strong>
                     </small>
                 </div>
+                {include file="request/legal-info.tpl"}
                 <div class="row">
                     <button type="submit" class="offset-md-4 col-md-8 btn btn-primary btn-block">Send request</button>
                 </div>


### PR DESCRIPTION
This adds links to the WMCS TOS and our brand new {entry}.php/privacy pages, which render the privacy statement in the correct context from a markdown file. Links have been added to both public and private footers, and to relevant data submission forms (request and register) for when users start using the service.

I've also taken the opportunity to sassify the public stylesheet.