### PR TITLE
Amqp deprecation fix

### DIFF
--- a/includes/Helpers/IrcNotificationHelper.php
+++ b/includes/Helpers/IrcNotificationHelper.php
@@ -115,14 +115,15 @@ class IrcNotificationHelper
             else {
                 $amqpConnectionConfig->setIsSecure(false);
             }
-            $connection = AMQPConnectionFactory::create($amqpConnectionConfig);
 
+            $connection = AMQPConnectionFactory::create($amqpConnectionConfig);
             $channel = $connection->channel();
 
             $msg = new AMQPMessage(substr($msg, 0, 512));
             $msg->set('user_id', $amqpSiteConfig['user']);
             $msg->set('app_id', $this->siteConfiguration->getUserAgent());
             $msg->set('content_type', 'text/plain');
+            
             $channel->basic_publish($msg, $amqpSiteConfig['exchange'], $domain->getNotificationTarget());
             $channel->close();
         }

--- a/includes/Helpers/IrcNotificationHelper.php
+++ b/includes/Helpers/IrcNotificationHelper.php
@@ -99,7 +99,7 @@ class IrcNotificationHelper
         $domain = Domain::getById(1, $this->primaryDatabase);
 
         try {
-            $amqpSiteConfig = $this->siteConfiguration->getamqpSiteConfiguration();
+            $amqpSiteConfig = $this->siteConfiguration->getAmqpConfiguration();
 
             $amqpConnectionConfig = new AMQPConnectionConfig();
             $amqpConnectionConfig->setHost($amqpSiteConfig['host']);


### PR DESCRIPTION
Resolves #957.

Notes:
* I tested this with the Docker config's default RabbitMQ settings (which do not include SSL/TLS), and RabbitMQ received the messages correctly. I could not test with SSL/TLS because I'm running the tool on my local machine.
* I got multiple exceptions/errors when setting up, logging in, creating a request, and reserving that request:
    * `WARN[0000] /home/m/waca/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion`
    * `( ! ) Warning: Undefined array key "hidden" in /var/www/html/templates_c/d5b8cd18de789ef98bed0c224d77de2b5c511f8b_0.file.request-log.tpl.php on line 48` in the comments section after reserving the request.
    * `( ! ) Deprecated: Using unregistered function "count" in a template is deprecated and will be removed in a future release. Use Smarty::registerPlugin to explicitly register a custom modifier. in /var/www/html/vendor/smarty/smarty/libs/sysplugins/smarty_internal_templatecompilerbase.php on line 663` at multiple points.

Are any of those known, or should I create (and maybe work on) separate issues for them?