### PR TITLE
Fix XSS in log comments

### DIFF
--- a/templates/exception/account-declined.tpl
+++ b/templates/exception/account-declined.tpl
@@ -7,7 +7,7 @@
                 You've requested an account for this tool successfully, but your account request has been declined by a
                 tool administrator. The reason given is shown below:
             </p>
-            <p class="card card-body prewrap">{$declineReason}</p>
+            <p class="card card-body prewrap">{$declineReason|escape}</p>
             <p>
                 If you wish to appeal this, please contact the tool admins.
             </p>

--- a/templates/exception/account-suspended.tpl
+++ b/templates/exception/account-suspended.tpl
@@ -7,7 +7,7 @@
                 I'm sorry, but your tool account has been suspended by a tool administrator. The reason given is shown
                 below:
             </p>
-            <p class="card card-body prewrap">{$suspendReason}</p>
+            <p class="card card-body prewrap">{$suspendReason|escape}</p>
             <p>
                 If you wish to appeal this, please contact the tool admins.
             </p>

--- a/templates/logs/datatable.tpl
+++ b/templates/logs/datatable.tpl
@@ -34,7 +34,7 @@
                 <td>{$entry.objectdescription}</td>
             {/if}
             {if $showComments}
-                <td>{$entry.comment}</td>
+                <td>{$entry.comment|escape}</td>
             {/if}
         </tr>
     {foreachelse}


### PR DESCRIPTION
This appears to only be triggerable from user input by tool admins, so the risk factor is low and it's trivially auditable if anyone takes advantage.