### PR TITLE
IPv6 Fixes

### DIFF
--- a/includes/Fragments/RequestData.php
+++ b/includes/Fragments/RequestData.php
@@ -42,6 +42,15 @@ trait RequestData
     );
 
     /**
+     * @var array Array of IPv6 address ranges classed as 'private' or reserved.
+     */
+    protected static $rfc4193ips = array(
+        "fc00::" => "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "fe80::" => "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "::1"    => "::1",
+    );
+
+    /**
      * Gets a request object
      *
      * @param PdoDatabase $database  The database connection
@@ -321,8 +330,8 @@ trait RequestData
                 // get data on this IP.
                 $thisProxyIsTrusted = $this->getXffTrustProvider()->isTrusted($proxyAddress);
 
-                $proxyIsInPrivateRange = $this->getXffTrustProvider()
-                    ->ipInRange(self::$rfc1918ips, $proxyAddress);
+                $proxyIsInPrivateRange = $this->getXffTrustProvider()->ipInRange(self::$rfc1918ips, $proxyAddress) 
+                || $this->getXffTrustProvider()->ipInRange(self::$rfc4193ips, $proxyAddress);
 
                 if (!$proxyIsInPrivateRange) {
                     $proxyReverseDns = $this->getRdnsProvider()->getReverseDNS($proxyAddress);

--- a/includes/Helpers/BanHelper.php
+++ b/includes/Helpers/BanHelper.php
@@ -194,14 +194,18 @@ SQL;
         $trustedIp = $this->xffTrustProvider->getTrustedClientIp($request->getIp(), $request->getForwardedIp());
         $isIPv6 = filter_var($trustedIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
 
-        $statement->execute([
-            ':name'      => $request->getName(),
-            ':email'     => $request->getEmail(),
-            ':useragent' => $request->getUserAgent(),
-            ':domain'    => $request->getDomain(),
-            ':ip4'       => $isIPv6 ? null : $trustedIp,
-            ':ip6'       => $isIPv6 ? $trustedIp : null,
-        ]);
+        $params = [
+        ':name'      => $request->getName(),
+        ':email'     => $request->getEmail(),
+        ':useragent' => $request->getUserAgent(),
+        ':domain'    => $request->getDomain(),
+        ':ip4'       => $isIPv6 ? null : $trustedIp,
+        ':ip6'       => $isIPv6 ? $trustedIp : null,
+        ];
+        
+        die(print_r($params, true));
+        
+        $statement->execute($params);
 
         /** @var Ban[] $result */
         $result = [];

--- a/includes/Helpers/BanHelper.php
+++ b/includes/Helpers/BanHelper.php
@@ -192,14 +192,15 @@ SQL;
 
         $statement = $this->database->prepare($query);
         $trustedIp = $this->xffTrustProvider->getTrustedClientIp($request->getIp(), $request->getForwardedIp());
+        $isIPv6 = filter_var($trustedIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
 
         $statement->execute([
             ':name'      => $request->getName(),
             ':email'     => $request->getEmail(),
             ':useragent' => $request->getUserAgent(),
             ':domain'    => $request->getDomain(),
-            ':ip4'       => $trustedIp,
-            ':ip6'       => $trustedIp,
+            ':ip4'       => $isIPv6 ? null : $trustedIp,
+            ':ip6'       => $isIPv6 ? $trustedIp : null,
         ]);
 
         /** @var Ban[] $result */

--- a/includes/Providers/IpLocationProvider.php
+++ b/includes/Providers/IpLocationProvider.php
@@ -90,7 +90,7 @@ class IpLocationProvider implements ILocationProvider
     private function getResult($ip)
     {
         try {
-            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            if (filter_var($ip, FILTER_VALIDATE_IP)) {
                 $xml = $this->httpHelper->get($this->getApiBase(), array(
                     'key'    => $this->apiKey,
                     'ip'     => $ip,

--- a/includes/Providers/XffTrustProvider.php
+++ b/includes/Providers/XffTrustProvider.php
@@ -125,6 +125,28 @@ class XffTrustProvider implements IXffTrustProvider
     }
 
     /**
+     * Checks if an IP address is in a range, supporting both IPv4 and IPv6.
+     *
+     * @param string $low  The lower bound of the range.
+     * @param string $high The upper bound of the range.
+     * @param string $ip   The IP address to check.
+     *
+     * @return bool True if the IP is in the range, false otherwise.
+     */
+    private function isIpInRange($low, $high, $ip)
+    {
+        $lowBinary = inet_pton($low);
+        $highBinary = inet_pton($high);
+        $ipBinary = inet_pton($ip);
+
+        if ($lowBinary === false || $highBinary === false || $ipBinary === false) {
+            return false; // Invalid IP address
+        }
+
+        return strcmp($lowBinary, $ipBinary) <= 0 && strcmp($highBinary, $ipBinary) >= 0;
+    }
+
+    /**
      * Takes an array( "low" => "high" ) values, and returns true if $needle is in at least one of them.
      *
      * @param array  $haystack
@@ -134,10 +156,8 @@ class XffTrustProvider implements IXffTrustProvider
      */
     public function ipInRange($haystack, $ip)
     {
-        $needle = ip2long($ip);
-
         foreach ($haystack as $low => $high) {
-            if (ip2long($low) <= $needle && ip2long($high) >= $needle) {
+            if ($this->isIpInRange($low, $high, $ip)) {
                 return true;
             }
         }


### PR DESCRIPTION
Fix #1027 
Updated bans lookup to support IPV6
Change how rDNS is retrieved
Add the v6 private ranges and remove the filter flag so it can make API calls to iplocation.io on a v6 address
Refactor how IP ranges are worked out