### PR TITLE
Add configurable global deny role

### DIFF
--- a/includes/Security/RoleConfiguration.php
+++ b/includes/Security/RoleConfiguration.php
@@ -473,8 +473,8 @@ final class RoleConfiguration extends RoleConfigurationBase
      */
     private static array $productionIdentificationExempt = array('public', 'loggedIn');
 
-    public function __construct()
+    public function __construct(array $globalDenyRole = [])
     {
-        parent::__construct(self::$productionRoleConfig, self::$productionIdentificationExempt);
+        parent::__construct(self::$productionRoleConfig, self::$productionIdentificationExempt, $globalDenyRole);
     }
 }

--- a/includes/Security/RoleConfigurationBase.php
+++ b/includes/Security/RoleConfigurationBase.php
@@ -18,11 +18,14 @@ abstract class RoleConfigurationBase
 
     protected array $roleConfig;
     protected array $identificationExempt;
+    private array $globallyDenied;
 
-    protected function __construct(array $roleConfig, array $identificationExempt)
+    protected function __construct(array $roleConfig, array $identificationExempt, array $globallyDenied)
     {
         $this->roleConfig = $roleConfig;
         $this->identificationExempt = $identificationExempt;
+
+        $this->globallyDenied = self::constructDenyOnlyRole($globallyDenied);;
     }
 
     /**
@@ -115,7 +118,9 @@ abstract class RoleConfigurationBase
      */
     private function getApplicableRoles(array $roles): array
     {
-        $available = array();
+        $available = [];
+
+        $available['_GLOBAL_DENY'] = $this->globallyDenied;
 
         foreach ($roles as $role) {
             if (!isset($this->roleConfig[$role])) {
@@ -140,5 +145,34 @@ abstract class RoleConfigurationBase
         }
 
         return $available;
+    }
+
+    /**
+     * Takes a role definition and filters it to just the deny actions.
+     *
+     * @param array $globallyDenied
+     * @return array
+     */
+    public static function constructDenyOnlyRole(array $globallyDenied): array
+    {
+        $result = [];
+
+        foreach ($globallyDenied as $page => $pageRights) {
+            if (in_array($page, ['_hidden', '_editableBy', '_description', '_globalOnly', '_childRoles'])) {
+                continue;
+            }
+
+            foreach ($pageRights as $action => $permission) {
+                if ($permission === RoleConfigurationBase::ACCESS_DENY) {
+                    if (!array_key_exists($page, $result)) {
+                        $result[$page] = [];
+                    }
+
+                    $result[$page][$action] = RoleConfigurationBase::ACCESS_DENY;;
+                }
+            }
+        }
+
+        return $result;
     }
 }

--- a/includes/SiteConfiguration.php
+++ b/includes/SiteConfiguration.php
@@ -84,6 +84,8 @@ class SiteConfiguration
     ];
     private string $privacyStatementPath = '';
 
+    private array $globalDenyRole = [];
+
     /**
      * Gets the base URL of the tool
      *
@@ -1125,6 +1127,18 @@ class SiteConfiguration
     public function setPrivacyStatementPath(string $privacyStatementPath): SiteConfiguration
     {
         $this->privacyStatementPath = $privacyStatementPath;
+
+        return $this;
+    }
+
+    public function getGlobalDenyRole(): array
+    {
+        return $this->globalDenyRole;
+    }
+
+    public function setGlobalDenyRole(array $globalDenyRole): SiteConfiguration
+    {
+        $this->globalDenyRole = $globalDenyRole;
 
         return $this;
     }

--- a/includes/WebStart.php
+++ b/includes/WebStart.php
@@ -86,7 +86,8 @@ class WebStart extends ApplicationBase
 
                 $identificationVerifier = new IdentificationVerifier($httpHelper, $siteConfiguration, $database);
 
-                $page->setSecurityManager(new SecurityManager($identificationVerifier, new RoleConfiguration(), $userAccessLoader));
+                $roleConfiguration = new RoleConfiguration($siteConfiguration->getGlobalDenyRole());
+                $page->setSecurityManager(new SecurityManager($identificationVerifier, $roleConfiguration, $userAccessLoader));
                 $page->setDomainAccessManager($domainAccessManager);
 
                 if ($siteConfiguration->getTitleBlacklistEnabled()) {


### PR DESCRIPTION
This adds a configurable role definition which is applied to every ACL check by everyone, logged in or not. This role definition is filtered to only permit `deny` actions so additional access cannot be granted via the configuration file.

The intent of this is to act as an emergency switch-off for any functionality in the tool by denying everyone access to it.