### PR TITLE
Remove reviewers/assignees from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,25 +7,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    reviewers:
-      - "@enwikipedia-acc/dependency-reviewers"
-    assignees:
-      - "@enwikipedia-acc/dependency-reviewers"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "@enwikipedia-acc/dependency-reviewers"
-    assignees:
-      - "@enwikipedia-acc/dependency-reviewers"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "@enwikipedia-acc/dependency-reviewers"
-    assignees:
-      - "@enwikipedia-acc/dependency-reviewers"


### PR DESCRIPTION
Assignees are broken, and reviewers are going away soon per the GitHub changelog.