### PR TITLE
Handle nulls in isUserIdentified

### DIFF
--- a/includes/IIdentificationVerifier.php
+++ b/includes/IIdentificationVerifier.php
@@ -21,11 +21,11 @@ interface IIdentificationVerifier
     /**
      * Checks if the given user is identified to the Wikimedia Foundation.
      *
-     * @param string $onWikiName The Wikipedia username of the user
+     * @param ?string $onWikiName The Wikipedia username of the user
      *
      * @return bool
      * @throws EnvironmentException
      * @category Security-Critical
      */
-    public function isUserIdentified(string $onWikiName): bool;
+    public function isUserIdentified(?string $onWikiName): bool;
 }

--- a/includes/IdentificationVerifier.php
+++ b/includes/IdentificationVerifier.php
@@ -66,13 +66,17 @@ class IdentificationVerifier implements IIdentificationVerifier
     /**
      * Checks if the given user is identified to the Wikimedia Foundation.
      *
-     * @param string $onWikiName The Wikipedia username of the user
+     * @param ?string $onWikiName The Wikipedia username of the user
      *
      * @category Security-Critical
      * @throws EnvironmentException
      */
-    public function isUserIdentified(string $onWikiName): bool
+    public function isUserIdentified(?string $onWikiName): bool
     {
+        if ($onWikiName === null || $onWikiName === '') {
+            return false;
+        }
+
         if ($this->checkIdentificationCache($onWikiName)) {
             return true;
         }


### PR DESCRIPTION
Currently, if a user's on-wiki username is not set, because they haven't completed the required OAuth verification as part of the registration process, for example, it's not possible to view the user's information/statistics page because `isUserIdentified()` can't handle `null`s. This addresses the issue; if passing in `null` or an empty string, it now always returns `false`, and `null`s are allowed by the type check.

Tested locally to resolve the issue as expected.