### PR TITLE
Update request-form.tpl to link to m:USURP instead of WP:CHU/U

### DIFF
--- a/templates/request/request-form.tpl
+++ b/templates/request/request-form.tpl
@@ -21,7 +21,7 @@
                 We do not have access to existing account data. If you have lost your password, please reset it using
                 <a href="https://en.wikipedia.org/wiki/Special:PasswordReset">this form</a> at wikipedia.org. If you are
                 trying to 'take over' an account that already exists, please use
-                <a href="https://meta.wikimedia.org/wiki/USURP">"Changing usernames/Usurpation"</a> at meta.wikimedia.org. We
+                <a href="https://meta.wikimedia.org/wiki/SRUC">"Changing usernames/Usurpation"</a> at meta.wikimedia.org. We
                 cannot do either of these things for you.
             </div>
             <p>


### PR DESCRIPTION
[[WP:CHU/U]] has been closed down as a result of this RFC: https://en.wikipedia.org/wiki/Special:PermanentLink/1275463643#RfC:_Should_all_future_username_usurpation_requests_be_directed_to_Meta-Wiki?

The modification points the user to the correct location to make username usurpation requests (the Stewards request page on meta).