### PR TITLE
Handle TBL API being dead

### DIFF
--- a/includes/Helpers/BlacklistHelper.php
+++ b/includes/Helpers/BlacklistHelper.php
@@ -103,7 +103,7 @@ class BlacklistHelper implements IBlacklistHelper
 
         $parameters = array(
             'action'       => 'titleblacklist',
-            'format'       => 'php',
+            'format'       => 'json',
             'tbtitle'      => $username,
             'tbaction'     => 'new-account',
             'tbnooverride' => true,
@@ -111,7 +111,7 @@ class BlacklistHelper implements IBlacklistHelper
 
         $apiResult = $this->httpHelper->get($endpoint, $parameters);
 
-        $data = unserialize($apiResult);
+        $data = json_decode($apiResult, true);
 
         return $data['titleblacklist'];
     }

--- a/includes/Helpers/BlacklistHelper.php
+++ b/includes/Helpers/BlacklistHelper.php
@@ -63,14 +63,6 @@ class BlacklistHelper implements IBlacklistHelper
             ExceptionHandler::logExceptionToDisk($ex, $this->siteConfiguration);
             return false;
         }
-        
-        if (!isset($result['result'])) {
-            if (isset($result['error']['info'])) {
-                throw new Exception("Unrecognised API response to blacklist query: " . $result['error']['info']);
-            }
-            
-            throw new Exception("Unrecognised API response to blacklist query.");
-        }
 
         if ($result['result'] === 'ok') {
             // not blacklisted

--- a/includes/Helpers/BlacklistHelper.php
+++ b/includes/Helpers/BlacklistHelper.php
@@ -63,6 +63,14 @@ class BlacklistHelper implements IBlacklistHelper
             ExceptionHandler::logExceptionToDisk($ex, $this->siteConfiguration);
             return false;
         }
+        
+        if (!isset($result['result'])) {
+            if (isset($result['error']['info'])) {
+                throw new Exception("Unrecognised API response to blacklist query: " . $result['error']['info']);
+            }
+            
+            throw new Exception("Unrecognised API response to blacklist query.");
+        }
 
         if ($result['result'] === 'ok') {
             // not blacklisted

--- a/includes/Helpers/MediaWikiHelper.php
+++ b/includes/Helpers/MediaWikiHelper.php
@@ -247,11 +247,11 @@ class MediaWikiHelper
         $parameters = array(
             'action'  => 'query',
             'list'    => 'users',
-            'format'  => 'php',
+            'format'  => 'json',
             'ususers' => $username,
         );
 
-        $apiResult = $this->mediaWikiClient->doApiCall($parameters, 'GET');
+        $apiResult = json_decode($this->mediaWikiClient->doApiCall($parameters, 'GET'));
 
         $entry = $apiResult->query->users[0];
         $exists = !isset($entry->missing);

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -379,7 +379,7 @@ class PageViewRequest extends InternalPageBase
         $creationHasChoice = count(array_filter([$canManualCreate, $canOauthCreate, $canBotCreate])) > 1;
 
         $creationModePreference = $preferenceManager->getPreference(PreferenceManager::PREF_CREATION_MODE);
-        if (!$this->barrierTest($creationModePreference, $user, 'RequestCreation')) {
+        if (($creationModePreference === null) || (!$this->barrierTest($creationModePreference, $user, 'RequestCreation')) {
             // user is not allowed to use their default. Force a choice.
             $creationHasChoice = true;
         }

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -380,7 +380,7 @@ class PageViewRequest extends InternalPageBase
 
         $creationModePreference = $preferenceManager->getPreference(PreferenceManager::PREF_CREATION_MODE);
         if (($creationModePreference === null) || (!$this->barrierTest($creationModePreference, $user, 'RequestCreation')) {
-            // user is not allowed to use their default. Force a choice.
+            // user is not allowed to use their default, or does not have one. Force a choice.
             $creationHasChoice = true;
         }
 

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -333,8 +333,10 @@ class PageViewRequest extends InternalPageBase
     {
         $blacklistData = $this->getBlacklistHelper()->isBlacklisted($request->getName());
 
-        $this->assign('requestIsBlacklisted', $blacklistData !== false);
-        $this->assign('requestBlacklist', $blacklistData);
+        if (($blacklistData !== false && $blacklistData !== '') {
+            $this->assign('requestIsBlacklisted', $blacklistData !== false);
+            $this->assign('requestBlacklist', $blacklistData);
+        }
 
         try {
             $spoofs = $this->getAntiSpoofProvider()->getSpoofs($request->getName());

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -334,8 +334,10 @@ class PageViewRequest extends InternalPageBase
         $blacklistData = $this->getBlacklistHelper()->isBlacklisted($request->getName());
 
         if (($blacklistData !== false && $blacklistData !== '') {
-            $this->assign('requestIsBlacklisted', $blacklistData !== false);
+            $this->assign('requestIsBlacklisted', true);
             $this->assign('requestBlacklist', $blacklistData);
+        } else {
+            $this->assign('requestIsBlacklisted', false);
         }
 
         try {

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -333,7 +333,7 @@ class PageViewRequest extends InternalPageBase
     {
         $blacklistData = $this->getBlacklistHelper()->isBlacklisted($request->getName());
 
-        if (($blacklistData !== false && $blacklistData !== '') {
+        if (($blacklistData !== false) && ($blacklistData !== '')) {
             $this->assign('requestIsBlacklisted', true);
             $this->assign('requestBlacklist', $blacklistData);
         } else {

--- a/includes/Pages/PageViewRequest.php
+++ b/includes/Pages/PageViewRequest.php
@@ -379,7 +379,7 @@ class PageViewRequest extends InternalPageBase
         $creationHasChoice = count(array_filter([$canManualCreate, $canOauthCreate, $canBotCreate])) > 1;
 
         $creationModePreference = $preferenceManager->getPreference(PreferenceManager::PREF_CREATION_MODE);
-        if (($creationModePreference === null) || (!$this->barrierTest($creationModePreference, $user, 'RequestCreation')) {
+        if (($creationModePreference === null) || (!$this->barrierTest($creationModePreference, $user, 'RequestCreation'))) {
             // user is not allowed to use their default, or does not have one. Force a choice.
             $creationHasChoice = true;
         }

--- a/includes/Pages/RequestAction/PageCloseRequest.php
+++ b/includes/Pages/RequestAction/PageCloseRequest.php
@@ -171,7 +171,7 @@ class PageCloseRequest extends RequestActionBase
             $parameters = array(
                 'action'  => 'query',
                 'list'    => 'users',
-                'format'  => 'php',
+                'format'  => 'json',
                 'ususers' => $request->getName(),
             );
 
@@ -181,7 +181,7 @@ class PageCloseRequest extends RequestActionBase
 
             $content = $this->getHttpHelper()->get($domain->getWikiApiPath(), $parameters);
 
-            $apiResult = unserialize($content);
+            $apiResult = json_decode($content, true);
             $exists = !isset($apiResult['query']['users']['0']['missing']);
 
             if (!$exists) {

--- a/includes/Providers/CachedApiAntispoofProvider.php
+++ b/includes/Providers/CachedApiAntispoofProvider.php
@@ -52,7 +52,7 @@ class CachedApiAntispoofProvider implements IAntiSpoofProvider
             // get the data from the API
             $data = $this->httpHelper->get($domain->getWikiApiPath(), array(
                 'action'   => 'antispoof',
-                'format'   => 'php',
+                'format'   => 'json',
                 'username' => $username,
             ));
 
@@ -68,7 +68,7 @@ class CachedApiAntispoofProvider implements IAntiSpoofProvider
             $data = $cacheResult->getData();
         }
 
-        $result = unserialize($data);
+        $result = json_decode($data, true);
 
         if (!isset($result['antispoof']) || !isset($result['antispoof']['result'])) {
             $cacheResult->delete();

--- a/includes/Providers/IpLocationProvider.php
+++ b/includes/Providers/IpLocationProvider.php
@@ -10,7 +10,6 @@
 namespace Waca\Providers;
 
 use Exception;
-use SimpleXMLElement;
 use Waca\DataObjects\GeoLocation;
 use Waca\Exceptions\OptimisticLockFailedException;
 use Waca\Helpers\HttpHelper;
@@ -91,13 +90,17 @@ class IpLocationProvider implements ILocationProvider
     {
         try {
             if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
-                $xml = $this->httpHelper->get($this->getApiBase(), array(
+                $json = $this->httpHelper->get($this->getApiBase(), array(
                     'key'    => $this->apiKey,
                     'ip'     => $ip,
-                    'format' => 'xml',
+                    'format' => 'json',
                 ));
 
-                $response = @new SimpleXMLElement($xml);
+                $response = json_decode($json, true);
+
+                if (!is_array($response)) {
+                    return null;
+                }
 
                 $result = array();
 

--- a/includes/Providers/IpLocationProvider.php
+++ b/includes/Providers/IpLocationProvider.php
@@ -10,6 +10,7 @@
 namespace Waca\Providers;
 
 use Exception;
+use SimpleXMLElement;
 use Waca\DataObjects\GeoLocation;
 use Waca\Exceptions\OptimisticLockFailedException;
 use Waca\Helpers\HttpHelper;
@@ -90,17 +91,13 @@ class IpLocationProvider implements ILocationProvider
     {
         try {
             if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
-                $json = $this->httpHelper->get($this->getApiBase(), array(
+                $xml = $this->httpHelper->get($this->getApiBase(), array(
                     'key'    => $this->apiKey,
                     'ip'     => $ip,
-                    'format' => 'json',
+                    'format' => 'xml',
                 ));
 
-                $response = json_decode($json, true);
-
-                if (!is_array($response)) {
-                    return null;
-                }
+                $response = @new SimpleXMLElement($xml);
 
                 $result = array();
 

--- a/includes/Validation/RequestValidationHelper.php
+++ b/includes/Validation/RequestValidationHelper.php
@@ -338,13 +338,13 @@ class RequestValidationHelper
                         'tbtitle'      => $request->getName(),
                         'tbaction'     => 'new-account',
                         'tbnooverride' => true,
-                        'format'       => 'php',
+                        'format'       => 'json',
                     ),
                     [],
                     $this->validationRemoteTimeout
                 );
 
-                $data = unserialize($apiResult);
+                $data = json_decode($apiResult, true);
 
                 $requestIsOk = $data['titleblacklist']['result'] == "ok";
             }
@@ -374,13 +374,13 @@ class RequestValidationHelper
                     'action'  => 'query',
                     'list'    => 'users',
                     'ususers' => $request->getName(),
-                    'format'  => 'php',
+                    'format'  => 'json',
                 ),
                 [],
                 $this->validationRemoteTimeout
             );
 
-            $ue = unserialize($userExists);
+            $ue = json_decode($userExists, true);
             if (!isset ($ue['query']['users']['0']['missing']) && isset ($ue['query']['users']['0']['userid'])) {
                 return true;
             }
@@ -406,13 +406,13 @@ class RequestValidationHelper
                     'action'  => 'query',
                     'meta'    => 'globaluserinfo',
                     'guiuser' => $requestName,
-                    'format'  => 'php',
+                    'format'  => 'json',
                 ),
                 [],
                 $this->validationRemoteTimeout
             );
 
-            $ue = unserialize($userExists);
+            $ue = json_decode($userExists, true);
             if (isset ($ue['query']['globaluserinfo']['id'])) {
                 return true;
             }


### PR DESCRIPTION
Turns out that if the API fails for the TBL check, everything ends up in Flagged Users.

Added check to BlacklistHelper to throw an Exception if there is no result

Added check to PageViewRequest to check the data isn't an empty string (in addition to the check for false) before as it seems that's the issue why requests are ending up in Flagged Users.

Also, add a check to the if statement just in case a default creation mode has not been set
Fixes #1081  (hopefully) (Yes, Rich does not know how to Git properly...)